### PR TITLE
Add missing deps and pin package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ geopandas==0.10.2
 geoviews==1.9.2
 holoviews==1.14.6
 hvplot==0.7.3
+intake-xarray==0.5.0
 lmoments3
 matplotlib==3.4.3
 numpy==1.21.2
@@ -12,5 +13,6 @@ pandas==1.3.4
 panel==0.12.4
 param==1.11.1
 regionmask
+s3fs==2021.10.1
 scipy==1.7.1
 shapely==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,16 @@
 xarray==0.19.0
 -e git+https://github.com/OpenHydrology/lmoments3.git@7e19f97c23019ca68cbd526b8bd417c412438f1c#egg=lmoments3
+cartopy==0.20.1
+geopandas==0.10.2
+geoviews==1.9.2
+holoviews==1.14.6
+hvplot==0.7.3
+lmoments3
+matplotlib==3.4.3
+numpy==1.21.2
+pandas==1.3.4
+panel==0.12.4
+param==1.11.1
+regionmask
+scipy==1.7.1
+shapely==1.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     geoviews
     holoviews
     hvplot
-    intake
+    intake-xarray
     lmoments3
     matplotlib
     numpy
@@ -29,6 +29,7 @@ install_requires =
     panel
     param
     regionmask
+    s3fs
     scipy
     shapely
     xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
 packages = find:
 install_requires =
     cartopy
-    datetime
     geopandas
     geoviews
     holoviews


### PR DESCRIPTION
This adds dependencies on intake-xarray and s3fs which are required for reading the Zarr stores from the intake catalog. It also pins the packages to the versions tested against on the container image.