### PR TITLE
confidence intervals for threshold_tools

### DIFF
--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -258,7 +258,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
 #####################################################################
 
-def calculate_return(fitted_distr, data_variable, arg_value)
+def calculate_return(fitted_distr, data_variable, arg_value):
     """
     Returns corresponding extreme value calculation for selected data variable.
     """

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -4,9 +4,6 @@
 #                                      #
 ########################################
 
-#####################################################################
-# import packages
-
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -30,12 +27,11 @@ import hvplot.xarray
 from .visualize import get_geospatial_plot
 
 #####################################################################
-# GET AMS
-# input: data array
-# export: data array of maximums
-
 
 def get_ams(da, extremes_type="max"):
+    """
+    Returns a data array of annual maximums.
+    """
 
     extremes_types = ["max"]
     if extremes_type not in extremes_types:
@@ -59,14 +55,12 @@ def get_ams(da, extremes_type="max"):
 
     return ams
 
-
-#####################################################################
-# GET L-MOMENTS DISTR
-# input: distribution name
-# export: corresponding l-moments distribution function
-
+#####################################################################a
 
 def get_lmom_distr(distr):
+    """
+    Returns corresponding l-moments distribution function from selected distribution name.
+    """
 
     distrs = ["gev", "gumbel", "weibull", "pearson3", "genpareto"]
     if distr not in distrs:
@@ -93,12 +87,11 @@ def get_lmom_distr(distr):
 
 
 #####################################################################
-# GET L-MOMENTS
-# input: annual maximum series
-# export: xarray dataset of l-moment ratios
-
 
 def get_lmoments(ams, distr="gev", multiple_points=True):
+    """
+    Returns dataset of l-moments ratios from an inputed maximum series.
+    """
 
     lmom_distr = get_lmom_distr(distr)
     ams_attributes = ams.attrs
@@ -127,12 +120,11 @@ def get_lmoments(ams, distr="gev", multiple_points=True):
 
 
 #####################################################################
-# GET KS STAT
-# input: annual maximum series
-# export: xarray dataset of ks test d-statistics and p-values
-
 
 def get_ks_stat(ams, distr="gev", multiple_points=True):
+    """
+    Returns a dataset of ks test d-statistics and p-values from an inputed maximum series.
+    """
 
     lmom_distr = get_lmom_distr(distr)
     ams_attributes = ams.attrs
@@ -241,12 +233,11 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
 
 #####################################################################
-# BOOTSTRAP
-# input: annual maximum series and relevant parameters
-# export: boostrap-calculated value for relevant parameters
-
 
 def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
+    """
+    Returns a bootstrap-calculated value for relevant parameters from a inputed maximum series.
+    """
 
     data_variables = ["return_value", "return_prob", "return_period"]
     if data_variable not in data_variables:
@@ -434,10 +425,6 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
 
 
 #####################################################################
-# GET RETURN VALUE
-# input: annual maximum series and relevant parameters
-# export: xarray dataset with return values and confidence intervals
-
 
 def get_return_value(
     ams,
@@ -448,6 +435,9 @@ def get_return_value(
     conf_int_upper_bound=97.5,
     multiple_points=True,
 ):
+    """
+    Returns dataset with return values and confidence intervals from maximum series.
+    """
 
     data_variable = "return_value"
     lmom_distr = get_lmom_distr(distr)
@@ -623,10 +613,6 @@ def get_return_value(
 
 
 #####################################################################
-# GET RETURN PROBABILITY
-# input: annual maximum series and relevant parameters
-# export: xarray dataset with return probabilities and confidence intervals
-
 
 def get_return_prob(
     ams,
@@ -637,6 +623,9 @@ def get_return_prob(
     conf_int_upper_bound=97.5,
     multiple_points=True,
 ):
+    """
+    Returns dataset with return probabilities and confidence intervals from maximum series.
+    """
 
     data_variable = "return_prob"
     lmom_distr = get_lmom_distr(distr)
@@ -787,10 +776,6 @@ def get_return_prob(
 
 
 #####################################################################
-# GET RETURN PERIOD
-# input: annual maximum series and relevant parameters
-# export: xarray dataset with return periods and confidence intervals
-
 
 def get_return_period(
     ams,
@@ -801,6 +786,9 @@ def get_return_period(
     conf_int_upper_bound=97.5,
     multiple_points=True,
 ):
+    """
+    Returns dataset with return periods and confidence intervals from maximum series.
+    """
 
     data_variable = "return_period"
     lmom_distr = get_lmom_distr(distr)
@@ -988,102 +976,3 @@ def get_return_period(
     new_ds.attrs["distribution"] = "{}".format(str(distr))
 
     return new_ds
-
-
-#####################################################################
-# ARCHIVE
-
-
-# def get_aicc_stat(ams, multiple_points=True):
-
-#     ams_attributes = ams.attrs
-
-#     if multiple_points:
-#         ams = ams.stack(allpoints=["x", "y"]).squeeze().groupby("allpoints")
-
-#     def aicc_stat(ams):
-
-#         try:
-#             lmoments_gev = ldistr.gev.lmom_fit(ams)
-#             aicc_gev = ["gev", lstats.AICc(ams, "gev", lmoments_gev)]
-#         except (ValueError, ZeroDivisionError):
-#             aicc_gev = ["gev", np.nan]
-
-#         try:
-#             lmoments_gum = ldistr.gum.lmom_fit(ams)
-#             aicc_gum = ["gumbel", lstats.AICc(ams, "gum", lmoments_gum)]
-#         except (ValueError, ZeroDivisionError):
-#             aicc_gum = ["gumbel", np.nan]
-
-#         try:
-#             lmoments_wei = ldistr.wei.lmom_fit(ams)
-#             aicc_wei = ["weibull", lstats.AICc(ams, "wei", lmoments_wei)]
-#         except (ValueError, ZeroDivisionError):
-#             aicc_wei = ["weibull", np.nan]
-
-#         try:
-#             lmoments_pe3 = ldistr.pe3.lmom_fit(ams)
-#             aicc_pe3 = ["pearson3", lstats.AICc(ams, "pe3", lmoments_pe3)]
-#         except (ValueError, ZeroDivisionError):
-#             aicc_pe3 = ["pearson3", np.nan]
-
-#         try:
-#             lmoments_gpa = ldistr.gpa.lmom_fit(ams)
-#             aicc_gpa = ["genpareto", lstats.AICc(ams, "gpa", lmoments_gpa)]
-#         except (ValueError, ZeroDivisionError):
-#             aicc_gpa = ["genpareto", np.nan]
-
-#         try:
-#             lmoments_gpa = ldistr.gpa.lmom_fit(ams)
-#             aicc_gpa = ["genpareto", lstats.AICc(ams, "gpa", lmoments_gpa)]
-#         except (ValueError, ZeroDivisionError):
-#             aicc_gpa = ["genpareto", np.nan]
-
-#         all_aicc_results = (
-#             str(aicc_gev)
-#             + str(aicc_gum)
-#             + str(aicc_wei)
-#             + str(aicc_pe3)
-#             + str(aicc_gpa)
-#         )
-#         all_aicc_results_string = str(all_aicc_results)
-
-#         lowest_aicc_value = min(
-#             aicc_gev[1], aicc_gum[1], aicc_wei[1], aicc_pe3[1], aicc_gpa[1]
-#         )
-
-#         if lowest_aicc_value == aicc_gev[1]:
-#             lowest_aicc_distr = aicc_gev[0]
-#         elif lowest_aicc_value == aicc_gum[1]:
-#             lowest_aicc_distr = aicc_gum[0]
-#         elif lowest_aicc_value == aicc_wei[1]:
-#             lowest_aicc_distr = aicc_wei[0]
-#         elif lowest_aicc_value == aicc_pe3[1]:
-#             lowest_aicc_distr = aicc_pe3[0]
-#         elif lowest_aicc_value == aicc_gpa[1]:
-#             lowest_aicc_distr = aicc_gpa[0]
-
-#         return all_aicc_results, lowest_aicc_distr, lowest_aicc_value
-
-#     all_aicc_results, lowest_aicc_distr, lowest_aicc_value = xr.apply_ufunc(
-#         aicc_stat,
-#         ams,
-#         input_core_dims=[["time"]],
-#         exclude_dims=set(("time",)),
-#         output_core_dims=[[], [], []]
-
-#         #dask_gufunc_kwargs=dict({"allow_rechunk"==True, "output_dtypes"==[ams.dtype]})
-#     )
-
-#     all_aicc_results = all_aicc_results.rename("all_aicc_results")
-#     new_ds = all_aicc_results.to_dataset()
-#     new_ds["lowest_aicc_distr"] = lowest_aicc_distr
-#     new_ds["lowest_aicc_value"] = lowest_aicc_value
-
-#     if multiple_points:
-#         new_ds = new_ds.unstack("allpoints")
-
-#     new_ds.attrs = ams_attributes
-#     new_ds.attrs["model selection technique"] = "AICc"
-
-#     return new_ds

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -423,6 +423,31 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
 
     return result
 
+#####################################################################
+
+def conf_int(ams, distr, data_variable, arg_value, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound):
+    """
+    Returns lower and upper limits of confidence interval given selected parameters.
+    """
+
+    bootstrap_values = []
+
+    for _ in range(bootstrap_runs):
+        result = bootstrap(
+            ams,
+            distr,
+            data_variable,
+            arg_value,
+        )
+        bootstrap_values.append(result)
+
+    conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+    
+    conf_int_lower_limit = conf_int_array[0]
+    conf_int_upper_limit = conf_int_array[1]
+
+    return conf_int_lower_limit, conf_int_upper_limit
+
 
 #####################################################################
 
@@ -458,21 +483,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_period,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
-            )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
 
         if distr == "gumbel":
             try:
@@ -484,21 +495,8 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_period,
-                )
-                bootstrap_values.append(result)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
 
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
-            )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "weibull":
             try:
@@ -510,21 +508,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_period,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
-            )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
 
         if distr == "pearson3":
             try:
@@ -536,21 +520,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_period,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
-            )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
 
         if distr == "genpareto":
             try:
@@ -562,21 +532,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_period,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
-            )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
 
         return return_value, conf_int_lower_limit, conf_int_upper_limit
 

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -132,7 +132,7 @@ def get_lmoments(ams, distr="gev", multiple_points=True):
     ams_attributes = ams.attrs
 
     if multiple_points:
-        ams = ams.stack(allpoints=["x", "y"]).squeeze().groupby("allpoints")
+        ams = ams.stack(allpoints=["y", "x"]).squeeze().groupby("allpoints")
 
     lmoments = xr.apply_ufunc(
         lmom_distr.lmom_fit,
@@ -166,7 +166,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
     ams_attributes = ams.attrs
 
     if multiple_points:
-        ams = ams.stack(allpoints=["x", "y"]).squeeze().groupby("allpoints")
+        ams = ams.stack(allpoints=["y", "x"]).squeeze().groupby("allpoints")
 
     def ks_stat(ams):
 
@@ -430,7 +430,7 @@ def get_return_value(
     ams_attributes = ams.attrs
 
     if multiple_points:
-        ams = ams.stack(allpoints=["x", "y"]).squeeze().groupby("allpoints")
+        ams = ams.stack(allpoints=["y", "x"]).squeeze().groupby("allpoints")
 
     def return_value(ams):
 
@@ -589,7 +589,7 @@ def get_return_prob(
     ams_attributes = ams.attrs
 
     if multiple_points:
-        ams = ams.stack(allpoints=["x", "y"]).squeeze().groupby("allpoints")
+        ams = ams.stack(allpoints=["y", "x"]).squeeze().groupby("allpoints")
 
     def return_prob(ams):
 
@@ -748,7 +748,7 @@ def get_return_period(
     ams_attributes = ams.attrs
 
     if multiple_points:
-        ams = ams.stack(allpoints=["x", "y"]).squeeze().groupby("allpoints")
+        ams = ams.stack(allpoints=["y", "x"]).squeeze().groupby("allpoints")
 
     def return_period(ams):
 

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -27,7 +27,7 @@ from holoviews import opts
 import hvplot.pandas
 import hvplot.xarray
 
-from .visualize import get_frequency_plot, get_geospatial_plot
+from .visualize import get_geospatial_plot
 
 #####################################################################
 # GET AMS

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -97,6 +97,7 @@ def get_lmom_distr(distr):
 # input: annual maximum series
 # export: xarray dataset of l-moment ratios
 
+
 def get_lmoments(ams, distr="gev", multiple_points=True):
 
     lmom_distr = get_lmom_distr(distr)
@@ -110,7 +111,7 @@ def get_lmoments(ams, distr="gev", multiple_points=True):
         ams,
         input_core_dims=[["time"]],
         exclude_dims=set(("time",)),
-        output_core_dims=[[]]
+        output_core_dims=[[]],
     )
 
     lmoments = lmoments.rename("lmoments")
@@ -129,6 +130,7 @@ def get_lmoments(ams, distr="gev", multiple_points=True):
 # GET KS STAT
 # input: annual maximum series
 # export: xarray dataset of ks test d-statistics and p-values
+
 
 def get_ks_stat(ams, distr="gev", multiple_points=True):
 
@@ -220,7 +222,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
         ams,
         input_core_dims=[["time"]],
         exclude_dims=set(("time",)),
-        output_core_dims=[[], []]
+        output_core_dims=[[], []],
     )
 
     d_statistic = d_statistic.rename("d_statistic")
@@ -243,26 +245,30 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 # input: annual maximum series and relevant parameters
 # export: boostrap-calculated value for relevant parameters
 
-def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
-        
+
+def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
+
     data_variables = ["return_value", "return_prob", "return_period"]
     if data_variable not in data_variables:
-        raise ValueError("invalid data variable type. expected one of the following: %s" % data_variables)
-    
+        raise ValueError(
+            "invalid data variable type. expected one of the following: %s"
+            % data_variables
+        )
+
     lmom_distr = get_lmom_distr(distr)
 
     sample_size = len(ams)
     new_ams = np.random.choice(ams, size=sample_size, replace=True)
 
     if distr == "gev":
-    
+
         try:
             lmoments = lmom_distr.lmom_fit(new_ams)
             fitted_distr = stats.genextreme(**lmoments)
 
             if data_variable == "return_value":
                 try:
-                    return_event = 1.0 - (1./arg_value)
+                    return_event = 1.0 - (1.0 / arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
                 except (ValueError, ZeroDivisionError):
@@ -284,9 +290,9 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                         result = round(return_period, 3)
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
-    
+
         except (ValueError, ZeroDivisionError):
-                    result = np.nan
+            result = np.nan
 
     if distr == "gumbel":
 
@@ -296,7 +302,7 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
 
             if data_variable == "return_value":
                 try:
-                    return_event = 1.0 - (1./arg_value)
+                    return_event = 1.0 - (1.0 / arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
                 except (ValueError, ZeroDivisionError):
@@ -318,9 +324,9 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                         result = round(return_period, 3)
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
-    
+
         except (ValueError, ZeroDivisionError):
-                    result = np.nan
+            result = np.nan
 
     if distr == "weibull":
 
@@ -330,7 +336,7 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
 
             if data_variable == "return_value":
                 try:
-                    return_event = 1.0 - (1./arg_value)
+                    return_event = 1.0 - (1.0 / arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
                 except (ValueError, ZeroDivisionError):
@@ -352,9 +358,9 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                         result = round(return_period, 3)
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
-    
+
         except (ValueError, ZeroDivisionError):
-                    result = np.nan
+            result = np.nan
 
     if distr == "pearson3":
 
@@ -364,7 +370,7 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
 
             if data_variable == "return_value":
                 try:
-                    return_event = 1.0 - (1./arg_value)
+                    return_event = 1.0 - (1.0 / arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
                 except (ValueError, ZeroDivisionError):
@@ -386,19 +392,19 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                         result = round(return_period, 3)
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
-    
+
         except (ValueError, ZeroDivisionError):
-                    result = np.nan
+            result = np.nan
 
     if distr == "genpareto":
-        
+
         try:
             lmoments = lmom_distr.lmom_fit(new_ams)
             fitted_distr = stats.genpareto(**lmoments)
 
             if data_variable == "return_value":
                 try:
-                    return_event = 1.0 - (1./arg_value)
+                    return_event = 1.0 - (1.0 / arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
                 except (ValueError, ZeroDivisionError):
@@ -422,19 +428,26 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                     result = np.nan
 
         except (ValueError, ZeroDivisionError):
-                    result = np.nan
+            result = np.nan
 
-    
     return result
+
 
 #####################################################################
 # GET RETURN VALUE
 # input: annual maximum series and relevant parameters
 # export: xarray dataset with return values and confidence intervals
 
-def get_return_value(ams, return_period=10, distr="gev", 
-                    bootstrap_runs=100, conf_int_lower_bound=2.5, 
-                    conf_int_upper_bound=97.5, multiple_points=True):
+
+def get_return_value(
+    ams,
+    return_period=10,
+    distr="gev",
+    bootstrap_runs=100,
+    conf_int_lower_bound=2.5,
+    conf_int_upper_bound=97.5,
+    multiple_points=True,
+):
 
     data_variable = "return_value"
     lmom_distr = get_lmom_distr(distr)
@@ -457,11 +470,17 @@ def get_return_value(ams, return_period=10, distr="gev",
 
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_period)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -477,11 +496,17 @@ def get_return_value(ams, return_period=10, distr="gev",
 
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_period)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -497,11 +522,17 @@ def get_return_value(ams, return_period=10, distr="gev",
 
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_period)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -514,14 +545,20 @@ def get_return_value(ams, return_period=10, distr="gev",
                 return_value = round(return_value, 5)
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
-            
+
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_period)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -537,22 +574,28 @@ def get_return_value(ams, return_period=10, distr="gev",
 
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_period)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
         return return_value, conf_int_lower_limit, conf_int_upper_limit
 
     return_value, conf_int_lower_limit, conf_int_upper_limit = xr.apply_ufunc(
-                                                                return_value,
-                                                                ams,
-                                                                input_core_dims=[["time"]],
-                                                                exclude_dims=set(("time",)),
-                                                                output_core_dims=[[],[],[]]
+        return_value,
+        ams,
+        input_core_dims=[["time"]],
+        exclude_dims=set(("time",)),
+        output_core_dims=[[], [], []],
     )
 
     return_value = return_value.rename("return_value")
@@ -566,9 +609,13 @@ def get_return_value(ams, return_period=10, distr="gev",
     new_ds["return_value"].attrs["return period"] = "1 in {} year event".format(
         str(return_period)
     )
-    new_ds["conf_int_lower_limit"].attrs["confidence interval lower bound"] = "{}th percentile".format(str(conf_int_lower_bound))
-    new_ds["conf_int_upper_limit"].attrs["confidence interval upper bound"] = "{}th percentile".format(str(conf_int_upper_bound))
-    
+    new_ds["conf_int_lower_limit"].attrs[
+        "confidence interval lower bound"
+    ] = "{}th percentile".format(str(conf_int_lower_bound))
+    new_ds["conf_int_upper_limit"].attrs[
+        "confidence interval upper bound"
+    ] = "{}th percentile".format(str(conf_int_upper_bound))
+
     new_ds.attrs = ams_attributes
     new_ds.attrs["distribution"] = "{}".format(str(distr))
 
@@ -580,9 +627,16 @@ def get_return_value(ams, return_period=10, distr="gev",
 # input: annual maximum series and relevant parameters
 # export: xarray dataset with return probabilities and confidence intervals
 
-def get_return_prob(ams, threshold, distr="gev", 
-                    bootstrap_runs=100, conf_int_lower_bound=2.5, 
-                    conf_int_upper_bound=97.5, multiple_points=True):
+
+def get_return_prob(
+    ams,
+    threshold,
+    distr="gev",
+    bootstrap_runs=100,
+    conf_int_lower_bound=2.5,
+    conf_int_upper_bound=97.5,
+    multiple_points=True,
+):
 
     data_variable = "return_prob"
     lmom_distr = get_lmom_distr(distr)
@@ -603,11 +657,14 @@ def get_return_prob(ams, threshold, distr="gev",
 
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=threshold)
+                result = bootstrap(
+                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -618,14 +675,17 @@ def get_return_prob(ams, threshold, distr="gev",
                 return_prob = 1 - (fitted_distr.cdf(threshold))
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
-            
+
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=threshold)
+                result = bootstrap(
+                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -639,11 +699,14 @@ def get_return_prob(ams, threshold, distr="gev",
 
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=threshold)
+                result = bootstrap(
+                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -654,14 +717,17 @@ def get_return_prob(ams, threshold, distr="gev",
                 return_prob = 1 - (fitted_distr.cdf(threshold))
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
-            
+
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=threshold)
+                result = bootstrap(
+                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -672,25 +738,28 @@ def get_return_prob(ams, threshold, distr="gev",
                 return_prob = 1 - (fitted_distr.cdf(threshold))
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
-            
+
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=threshold)
+                result = bootstrap(
+                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
         return return_prob, conf_int_lower_limit, conf_int_upper_limit
 
     return_prob, conf_int_lower_limit, conf_int_upper_limit = xr.apply_ufunc(
-                                                                return_prob,
-                                                                ams,
-                                                                input_core_dims=[["time"]],
-                                                                exclude_dims=set(("time",)),
-                                                                output_core_dims=[[],[],[]]
+        return_prob,
+        ams,
+        input_core_dims=[["time"]],
+        exclude_dims=set(("time",)),
+        output_core_dims=[[], [], []],
     )
 
     return_prob = return_prob.rename("return_prob")
@@ -704,9 +773,13 @@ def get_return_prob(ams, threshold, distr="gev",
     new_ds["return_prob"].attrs["threshold"] = "exceedance of {} value event".format(
         str(threshold)
     )
-    new_ds["conf_int_lower_limit"].attrs["confidence interval lower bound"] = "{}th percentile".format(str(conf_int_lower_bound))
-    new_ds["conf_int_upper_limit"].attrs["confidence interval upper bound"] = "{}th percentile".format(str(conf_int_upper_bound))
-    
+    new_ds["conf_int_lower_limit"].attrs[
+        "confidence interval lower bound"
+    ] = "{}th percentile".format(str(conf_int_lower_bound))
+    new_ds["conf_int_upper_limit"].attrs[
+        "confidence interval upper bound"
+    ] = "{}th percentile".format(str(conf_int_upper_bound))
+
     new_ds.attrs = ams_attributes
     new_ds.attrs["distribution"] = "{}".format(str(distr))
 
@@ -718,9 +791,16 @@ def get_return_prob(ams, threshold, distr="gev",
 # input: annual maximum series and relevant parameters
 # export: xarray dataset with return periods and confidence intervals
 
-def get_return_period(ams, return_value, distr="gev", 
-                    bootstrap_runs=100, conf_int_lower_bound=2.5, 
-                    conf_int_upper_bound=97.5, multiple_points=True):
+
+def get_return_period(
+    ams,
+    return_value,
+    distr="gev",
+    bootstrap_runs=100,
+    conf_int_lower_bound=2.5,
+    conf_int_upper_bound=97.5,
+    multiple_points=True,
+):
 
     data_variable = "return_period"
     lmom_distr = get_lmom_distr(distr)
@@ -746,11 +826,17 @@ def get_return_period(ams, return_value, distr="gev",
 
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_value)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -766,14 +852,20 @@ def get_return_period(ams, return_value, distr="gev",
                     return_period = round(return_period, 3)
             except (ValueError, ZeroDivisionError):
                 return_period = np.nan
-            
+
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_value)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -789,14 +881,20 @@ def get_return_period(ams, return_value, distr="gev",
                     return_period = round(return_period, 3)
             except (ValueError, ZeroDivisionError):
                 return_period = np.nan
-            
+
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_value)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -812,14 +910,20 @@ def get_return_period(ams, return_value, distr="gev",
                     return_period = round(return_period, 3)
             except (ValueError, ZeroDivisionError):
                 return_period = np.nan
-            
+
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_value)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
@@ -838,22 +942,28 @@ def get_return_period(ams, return_value, distr="gev",
 
             bootstrap_values = []
             for _ in range(bootstrap_runs):
-                result = bootstrap(ams, distr=distr, data_variable=data_variable,
-                               arg_value=return_value)
+                result = bootstrap(
+                    ams,
+                    distr=distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
                 bootstrap_values.append(result)
 
-            conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
+            conf_int_array = np.percentile(
+                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            )
             conf_int_lower_limit = conf_int_array[0]
             conf_int_upper_limit = conf_int_array[1]
 
         return return_period, conf_int_lower_limit, conf_int_upper_limit
-    
+
     return_period, conf_int_lower_limit, conf_int_upper_limit = xr.apply_ufunc(
-                                                                return_period,
-                                                                ams,
-                                                                input_core_dims=[["time"]],
-                                                                exclude_dims=set(("time",)),
-                                                                output_core_dims=[[],[],[]]
+        return_period,
+        ams,
+        input_core_dims=[["time"]],
+        exclude_dims=set(("time",)),
+        output_core_dims=[[], [], []],
     )
 
     return_period = return_period.rename("return_period")
@@ -867,13 +977,18 @@ def get_return_period(ams, return_value, distr="gev",
     new_ds["return_period"].attrs[
         "return value"
     ] = "occurrence of a {} value event".format(str(return_value))
-    new_ds["conf_int_lower_limit"].attrs["confidence interval lower bound"] = "{}th percentile".format(str(conf_int_lower_bound))
-    new_ds["conf_int_upper_limit"].attrs["confidence interval upper bound"] = "{}th percentile".format(str(conf_int_upper_bound))
+    new_ds["conf_int_lower_limit"].attrs[
+        "confidence interval lower bound"
+    ] = "{}th percentile".format(str(conf_int_lower_bound))
+    new_ds["conf_int_upper_limit"].attrs[
+        "confidence interval upper bound"
+    ] = "{}th percentile".format(str(conf_int_upper_bound))
 
     new_ds.attrs = ams_attributes
     new_ds.attrs["distribution"] = "{}".format(str(distr))
 
     return new_ds
+
 
 #####################################################################
 # ARCHIVE
@@ -956,7 +1071,7 @@ def get_return_period(ams, return_value, distr="gev",
 #         input_core_dims=[["time"]],
 #         exclude_dims=set(("time",)),
 #         output_core_dims=[[], [], []]
-        
+
 #         #dask_gufunc_kwargs=dict({"allow_rechunk"==True, "output_dtypes"==[ams.dtype]})
 #     )
 

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -868,7 +868,7 @@ def get_return_period(
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.pearson3(**lmoments)
-                return_prob = fitted_distr.cdf(threshold)
+                return_prob = fitted_distr.cdf(return_value)
                 if return_prob == 1.0:
                     return_period = np.nan
                 else:

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -97,39 +97,24 @@ def get_fitted_distr(ams, distr):
     lmom_distr = get_lmom_distr(distr)
 
     if distr == "gev":
-        try: 
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.genextreme(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            pass
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.genextreme(**lmoments)
 
     elif distr == "gumbel":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.gumbel_r(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            pass
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.gumbel_r(**lmoments)
 
     elif distr == "weibull":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.weibull_min(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            pass
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.weibull_min(**lmoments)
 
     elif distr == "pearson3":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.pearson3(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            pass
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.pearson3(**lmoments)
 
     elif distr == "genpareto":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.genpareto(**lmoments)
-        except:
-            pass
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.genpareto(**lmoments)
 
     return lmoments, fitted_distr
 
@@ -173,7 +158,6 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
     """
     Returns a dataset of ks test d-statistics and p-values from an inputed maximum series.
     """
-    lmoments, fitted_distr = get_fitted_distr(ams, distr)
     ams_attributes = ams.attrs
 
     if multiple_points:
@@ -183,6 +167,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         if distr == "gev":
             try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr)
                 ks = stats.kstest(
                     ams,
                     "genextreme",
@@ -196,6 +181,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         elif distr == "gumbel":
             try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr)
                 ks = stats.kstest(
                     ams, "gumbel_r", args=(lmoments["loc"], lmoments["scale"])
                 )
@@ -207,6 +193,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         elif distr == "weibull":
             try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr)
                 ks = stats.kstest(
                     ams,
                     "weibull_min",
@@ -220,6 +207,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         elif distr == "pearson3":
             try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr)
                 ks = stats.kstest(
                     ams,
                     "pearson3",
@@ -233,6 +221,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         elif distr == "genpareto":
             try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr)
                 ks = stats.kstest(
                     ams,
                     "genpareto",

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -99,35 +99,40 @@ def get_fitted_distr(ams, distr, lmom_distr):
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.genextreme(**lmoments)
         except (ValueError, ZeroDivisionError):
-            pass
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     elif distr == "gumbel":
         try:
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.gumbel_r(**lmoments)
         except (ValueError, ZeroDivisionError):
-            pass
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     elif distr == "weibull":
         try:
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.weibull_min(**lmoments)
         except (ValueError, ZeroDivisionError):
-            pass
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     elif distr == "pearson3":
         try:
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.pearson3(**lmoments)
         except (ValueError, ZeroDivisionError):
-            pass
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     elif distr == "genpareto":
         try:
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.genpareto(**lmoments)
         except (ValueError, ZeroDivisionError):
-            pass
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     return lmoments, fitted_distr
 
@@ -283,13 +288,13 @@ def calculate_return(fitted_distr, data_variable, arg_value):
             return_event = 1.0 - (1.0 / arg_value)
             return_value = fitted_distr.ppf(return_event)
             result = round(return_value, 5)
-        except (ValueError, ZeroDivisionError):
+        except (ValueError, ZeroDivisionError, AttributeError):
             result = np.nan
 
     elif data_variable == "return_prob":
         try:
             result = 1 - (fitted_distr.cdf(arg_value))
-        except (ValueError, ZeroDivisionError):
+        except (ValueError, ZeroDivisionError, AttributeError):
             result = np.nan
 
     elif data_variable == "return_period":
@@ -300,7 +305,7 @@ def calculate_return(fitted_distr, data_variable, arg_value):
             else:
                 return_period = -1.0 / (return_prob - 1.0)
                 result = round(return_period, 3)
-        except (ValueError, ZeroDivisionError):
+        except (ValueError, ZeroDivisionError, AttributeError):
             result = np.nan
 
     return result

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -98,44 +98,24 @@ def get_fitted_distr(ams, distr, lmom_distr):
     """
 
     if distr == "gev":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.genextreme(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.genextreme(**lmoments)
 
     elif distr == "gumbel":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.gumbel_r(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.gumbel_r(**lmoments)
 
     elif distr == "weibull":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.weibull_min(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.weibull_min(**lmoments)
 
     elif distr == "pearson3":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.pearson3(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.pearson3(**lmoments)
 
     elif distr == "genpareto":
-        try:
-            lmoments = lmom_distr.lmom_fit(ams)
-            fitted_distr = stats.genpareto(**lmoments)
-        except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+        lmoments = lmom_distr.lmom_fit(ams)
+        fitted_distr = stats.genpareto(**lmoments)
 
     return lmoments, fitted_distr
 
@@ -455,12 +435,15 @@ def get_return_value(
     def return_value(ams):
 
         if distr == "gev":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_period,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_value = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_value = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -472,12 +455,15 @@ def get_return_value(
             )
 
         elif distr == "gumbel":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_period,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_value = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_value = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -489,12 +475,15 @@ def get_return_value(
             )
 
         elif distr == "weibull":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_period,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_value = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_value = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -506,12 +495,15 @@ def get_return_value(
             )
 
         elif distr == "pearson3":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_period,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_value = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_value = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -523,12 +515,15 @@ def get_return_value(
             )
 
         elif distr == "genpareto":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_period,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_value = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_period,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_value = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -599,12 +594,15 @@ def get_return_prob(
     def return_prob(ams):
 
         if distr == "gev":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=threshold,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_prob = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=threshold,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_prob = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -616,12 +614,15 @@ def get_return_prob(
             )
 
         elif distr == "gumbel":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=threshold,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_prob = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=threshold,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_prob = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -633,12 +634,15 @@ def get_return_prob(
             )
 
         elif distr == "weibull":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=threshold,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_prob = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=threshold,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_prob = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -650,12 +654,15 @@ def get_return_prob(
             )
 
         elif distr == "pearson3":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=threshold,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_prob = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=threshold,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_prob = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -667,12 +674,15 @@ def get_return_prob(
             )
 
         elif distr == "genpareto":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=threshold,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_prob = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=threshold,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_prob = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -743,12 +753,15 @@ def get_return_period(
     def return_period(ams):
 
         if distr == "gev":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_period = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_value,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_period = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_period = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -760,12 +773,15 @@ def get_return_period(
             )
 
         elif distr == "gumbel":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_period = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_value,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_period = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_period = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -777,12 +793,15 @@ def get_return_period(
             )
 
         elif distr == "weibull":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_period = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_value,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_period = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_period = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -794,12 +813,15 @@ def get_return_period(
             )
 
         elif distr == "pearson3":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_period = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_value,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_period = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_period = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -811,12 +833,15 @@ def get_return_period(
             )
 
         elif distr == "genpareto":
-            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_period = calculate_return(
-                fitted_distr=fitted_distr,
-                data_variable=data_variable,
-                arg_value=return_value,
-            )
+            try:
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+                return_period = calculate_return(
+                    fitted_distr=fitted_distr,
+                    data_variable=data_variable,
+                    arg_value=return_value,
+                )
+            except (ValueError, ZeroDivisionError):
+                return_period = np.nan
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -151,7 +151,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 )
                 d_statistic = ks[0]
                 p_value = ks[1]
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 d_statistic = np.nan
                 p_value = np.nan
 
@@ -164,7 +164,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 )
                 d_statistic = ks[0]
                 p_value = ks[1]
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 d_statistic = np.nan
                 p_value = np.nan
 
@@ -179,7 +179,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 )
                 d_statistic = ks[0]
                 p_value = ks[1]
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 d_statistic = np.nan
                 p_value = np.nan
 
@@ -194,7 +194,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 )
                 d_statistic = ks[0]
                 p_value = ks[1]
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 d_statistic = np.nan
                 p_value = np.nan
 
@@ -209,7 +209,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 )
                 d_statistic = ks[0]
                 p_value = ks[1]
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 d_statistic = np.nan
                 p_value = np.nan
 
@@ -265,27 +265,27 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                     return_event = 1.0 - (1./arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
-                        return_period = np.nan
+                        result = np.nan
                     else:
                         return_period = -1.0 / (return_prob - 1.0)
                         result = round(return_period, 3)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
     
-        except ValueError:
+        except (ValueError, ZeroDivisionError):
                     result = np.nan
 
     if distr == "gumbel":
@@ -299,27 +299,27 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                     return_event = 1.0 - (1./arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
-                        return_period = np.nan
+                        result = np.nan
                     else:
                         return_period = -1.0 / (return_prob - 1.0)
                         result = round(return_period, 3)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
     
-        except ValueError:
+        except (ValueError, ZeroDivisionError):
                     result = np.nan
 
     if distr == "weibull":
@@ -346,7 +346,7 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
-                        return_period = np.nan
+                        result = np.nan
                     else:
                         return_period = -1.0 / (return_prob - 1.0)
                         result = round(return_period, 3)
@@ -367,27 +367,27 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                     return_event = 1.0 - (1./arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
-                        return_period = np.nan
+                        result = np.nan
                     else:
                         return_period = -1.0 / (return_prob - 1.0)
                         result = round(return_period, 3)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
     
-        except ValueError:
+        except (ValueError, ZeroDivisionError):
                     result = np.nan
 
     if distr == "genpareto":
@@ -401,27 +401,27 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                     return_event = 1.0 - (1./arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
-                        return_period = np.nan
+                        result = np.nan
                     else:
                         return_period = -1.0 / (return_prob - 1.0)
                         result = round(return_period, 3)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-        except ValueError:
+        except (ValueError, ZeroDivisionError):
                     result = np.nan
 
     
@@ -452,7 +452,7 @@ def get_return_value(ams, return_period=10, distr="gev",
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
             bootstrap_values = []
@@ -472,7 +472,7 @@ def get_return_value(ams, return_period=10, distr="gev",
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
             bootstrap_values = []
@@ -512,7 +512,7 @@ def get_return_value(ams, return_period=10, distr="gev",
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_value = np.nan
             
             bootstrap_values = []
@@ -532,7 +532,7 @@ def get_return_value(ams, return_period=10, distr="gev",
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
             bootstrap_values = []
@@ -598,7 +598,7 @@ def get_return_prob(ams, threshold, distr="gev",
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.genextreme(**lmoments)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
 
             bootstrap_values = []
@@ -616,7 +616,7 @@ def get_return_prob(ams, threshold, distr="gev",
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.gumbel_r(**lmoments)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
             
             bootstrap_values = []
@@ -634,7 +634,7 @@ def get_return_prob(ams, threshold, distr="gev",
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.weibull_min(**lmoments)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
 
             bootstrap_values = []
@@ -652,7 +652,7 @@ def get_return_prob(ams, threshold, distr="gev",
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.pearson3(**lmoments)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
             
             bootstrap_values = []
@@ -670,7 +670,7 @@ def get_return_prob(ams, threshold, distr="gev",
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.genpareto(**lmoments)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
             
             bootstrap_values = []
@@ -741,7 +741,7 @@ def get_return_period(ams, return_value, distr="gev",
                 else:
                     return_period = -1.0 / (return_prob - 1.0)
                     return_period = round(return_period, 3)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_period = np.nan
 
             bootstrap_values = []
@@ -764,7 +764,7 @@ def get_return_period(ams, return_value, distr="gev",
                 else:
                     return_period = -1.0 / (return_prob - 1.0)
                     return_period = round(return_period, 3)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_period = np.nan
             
             bootstrap_values = []
@@ -787,7 +787,7 @@ def get_return_period(ams, return_value, distr="gev",
                 else:
                     return_period = -1.0 / (return_prob - 1.0)
                     return_period = round(return_period, 3)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_period = np.nan
             
             bootstrap_values = []
@@ -810,7 +810,7 @@ def get_return_period(ams, return_value, distr="gev",
                 else:
                     return_period = -1.0 / (return_prob - 1.0)
                     return_period = round(return_period, 3)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_period = np.nan
             
             bootstrap_values = []
@@ -833,7 +833,7 @@ def get_return_period(ams, return_value, distr="gev",
                 else:
                     return_period = -1.0 / (return_prob - 1.0)
                     return_period = round(return_period, 3)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_period = np.nan
 
             bootstrap_values = []

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -89,13 +89,11 @@ def get_lmom_distr(distr):
 
 #####################################################################
 
-def get_fitted_distr(ams, distr):
+def get_fitted_distr(ams, distr, lmom_distr):
     """
     Returns fitted l-moments distribution function from l-moments.
     """
-
-    lmom_distr = get_lmom_distr(distr)
-
+    
     if distr == "gev":
         lmoments = lmom_distr.lmom_fit(ams)
         fitted_distr = stats.genextreme(**lmoments)
@@ -158,6 +156,8 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
     """
     Returns a dataset of ks test d-statistics and p-values from an inputed maximum series.
     """
+
+    lmom_distr = get_lmom_distr(distr)
     ams_attributes = ams.attrs
 
     if multiple_points:
@@ -167,7 +167,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         if distr == "gev":
             try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 ks = stats.kstest(
                     ams,
                     "genextreme",
@@ -181,7 +181,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         elif distr == "gumbel":
             try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 ks = stats.kstest(
                     ams, "gumbel_r", args=(lmoments["loc"], lmoments["scale"])
                 )
@@ -193,7 +193,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         elif distr == "weibull":
             try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 ks = stats.kstest(
                     ams,
                     "weibull_min",
@@ -207,7 +207,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         elif distr == "pearson3":
             try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 ks = stats.kstest(
                     ams,
                     "pearson3",
@@ -221,7 +221,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         elif distr == "genpareto":
             try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 ks = stats.kstest(
                     ams,
                     "genpareto",

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -93,7 +93,7 @@ def get_fitted_distr(ams, distr, lmom_distr):
     """
     Returns fitted l-moments distribution function from l-moments.
     """
-    
+
     if distr == "gev":
         lmoments = lmom_distr.lmom_fit(ams)
         fitted_distr = stats.genextreme(**lmoments)
@@ -281,8 +281,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     if distr == "gev":
 
         try:
-            lmoments = lmom_distr.lmom_fit(new_ams)
-            fitted_distr = stats.genextreme(**lmoments)
+            lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
 
             if data_variable == "return_value":
                 try:
@@ -292,13 +291,13 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_prob":
+            elif data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_period":
+            elif data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
@@ -315,8 +314,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     elif distr == "gumbel":
 
         try:
-            lmoments = lmom_distr.lmom_fit(new_ams)
-            fitted_distr = stats.gumbel_r(**lmoments)
+            lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
 
             if data_variable == "return_value":
                 try:
@@ -326,13 +324,13 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_prob":
+            elif data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_period":
+            elif data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
@@ -349,8 +347,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     elif distr == "weibull":
 
         try:
-            lmoments = lmom_distr.lmom_fit(new_ams)
-            fitted_distr = stats.weibull_min(**lmoments)
+            lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
 
             if data_variable == "return_value":
                 try:
@@ -360,13 +357,13 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_prob":
+            elif data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_period":
+            elif data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
@@ -383,8 +380,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     elif distr == "pearson3":
 
         try:
-            lmoments = lmom_distr.lmom_fit(new_ams)
-            fitted_distr = stats.pearson3(**lmoments)
+            lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
 
             if data_variable == "return_value":
                 try:
@@ -394,13 +390,13 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_prob":
+            elif data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_period":
+            elif data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
@@ -417,8 +413,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     elif distr == "genpareto":
 
         try:
-            lmoments = lmom_distr.lmom_fit(new_ams)
-            fitted_distr = stats.genpareto(**lmoments)
+            lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
 
             if data_variable == "return_value":
                 try:
@@ -428,13 +423,13 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_prob":
+            elif data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
                 except (ValueError, ZeroDivisionError):
                     result = np.nan
 
-            if data_variable == "return_period":
+            elif data_variable == "return_period":
                 try:
                     return_prob = fitted_distr.cdf(arg_value)
                     if return_prob == 1.0:
@@ -510,8 +505,7 @@ def get_return_value(
 
         if distr == "gev":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.genextreme(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
@@ -530,8 +524,7 @@ def get_return_value(
 
         elif distr == "gumbel":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.gumbel_r(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
@@ -550,8 +543,7 @@ def get_return_value(
 
         elif distr == "weibull":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.weibull_min(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
@@ -570,8 +562,7 @@ def get_return_value(
 
         elif distr == "pearson3":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.pearson3(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
@@ -590,8 +581,7 @@ def get_return_value(
 
         elif distr == "genpareto":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.genpareto(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
@@ -669,8 +659,7 @@ def get_return_prob(
 
         if distr == "gev":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.genextreme(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
@@ -687,8 +676,7 @@ def get_return_prob(
 
         elif distr == "gumbel":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.gumbel_r(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
@@ -705,8 +693,7 @@ def get_return_prob(
 
         elif distr == "weibull":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.weibull_min(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
@@ -723,8 +710,7 @@ def get_return_prob(
 
         elif distr == "pearson3":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.pearson3(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
@@ -741,8 +727,7 @@ def get_return_prob(
 
         elif distr == "genpareto":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.genpareto(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = 1 - (fitted_distr.cdf(threshold))
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
@@ -818,8 +803,7 @@ def get_return_period(
 
         if distr == "gev":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.genextreme(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = fitted_distr.cdf(return_value)
                 if return_prob == 1.0:
                     return_period = np.nan
@@ -841,8 +825,7 @@ def get_return_period(
 
         elif distr == "gumbel":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.gumbel_r(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = fitted_distr.cdf(return_value)
                 if return_prob == 1.0:
                     return_period = np.nan
@@ -864,8 +847,7 @@ def get_return_period(
 
         elif distr == "weibull":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.weibull_min(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = fitted_distr.cdf(return_value)
                 if return_prob == 1.0:
                     return_period = np.nan
@@ -887,8 +869,7 @@ def get_return_period(
 
         elif distr == "pearson3":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.pearson3(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = fitted_distr.cdf(return_value)
                 if return_prob == 1.0:
                     return_period = np.nan
@@ -910,8 +891,7 @@ def get_return_period(
 
         elif distr == "genpareto":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.genpareto(**lmoments)
+                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
                 return_prob = fitted_distr.cdf(return_value)
                 if return_prob == 1.0:
                     return_period = np.nan

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -483,7 +483,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
 
         if distr == "gumbel":
             try:
@@ -495,7 +495,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
 
 
         if distr == "weibull":
@@ -508,7 +508,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
 
         if distr == "pearson3":
             try:
@@ -520,7 +520,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
 
         if distr == "genpareto":
             try:
@@ -532,7 +532,7 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams, distr, data_variable, arg_value=return_period, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
 
         return return_value, conf_int_lower_limit, conf_int_upper_limit
 

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -57,8 +57,7 @@ def get_ams(da, extremes_type="max"):
     return ams
 
 
-#####################################################################a
-
+#####################################################################
 
 def get_lmom_distr(distr):
     """
@@ -74,23 +73,67 @@ def get_lmom_distr(distr):
     if distr == "gev":
         lmom_distr = ldistr.gev
 
-    if distr == "gumbel":
+    elif distr == "gumbel":
         lmom_distr = ldistr.gum
 
-    if distr == "weibull":
+    elif distr == "weibull":
         lmom_distr = ldistr.wei
 
-    if distr == "pearson3":
+    elif distr == "pearson3":
         lmom_distr = ldistr.pe3
 
-    if distr == "genpareto":
+    elif distr == "genpareto":
         lmom_distr = ldistr.gpa
 
     return lmom_distr
 
-
 #####################################################################
 
+def get_fitted_distr(ams, distr):
+    """
+    Returns fitted l-moments distribution function from l-moments.
+    """
+
+    lmom_distr = get_lmom_distr(distr)
+
+    if distr == "gev":
+        try: 
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.genextreme(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            pass
+
+    elif distr == "gumbel":
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.gumbel_r(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            pass
+
+    elif distr == "weibull":
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.weibull_min(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            pass
+
+    elif distr == "pearson3":
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.pearson3(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            pass
+
+    elif distr == "genpareto":
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.genpareto(**lmoments)
+        except:
+            pass
+
+    return lmoments, fitted_distr
+
+#####################################################################
 
 def get_lmoments(ams, distr="gev", multiple_points=True):
     """
@@ -130,8 +173,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
     """
     Returns a dataset of ks test d-statistics and p-values from an inputed maximum series.
     """
-
-    lmom_distr = get_lmom_distr(distr)
+    lmoments, fitted_distr = get_fitted_distr(ams, distr)
     ams_attributes = ams.attrs
 
     if multiple_points:
@@ -141,8 +183,6 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
         if distr == "gev":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.genextreme(**lmoments)
                 ks = stats.kstest(
                     ams,
                     "genextreme",
@@ -154,10 +194,8 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 d_statistic = np.nan
                 p_value = np.nan
 
-        if distr == "gumbel":
+        elif distr == "gumbel":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.gumbel_r(**lmoments)
                 ks = stats.kstest(
                     ams, "gumbel_r", args=(lmoments["loc"], lmoments["scale"])
                 )
@@ -167,10 +205,8 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 d_statistic = np.nan
                 p_value = np.nan
 
-        if distr == "weibull":
+        elif distr == "weibull":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.weibull_min(**lmoments)
                 ks = stats.kstest(
                     ams,
                     "weibull_min",
@@ -182,10 +218,8 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 d_statistic = np.nan
                 p_value = np.nan
 
-        if distr == "pearson3":
+        elif distr == "pearson3":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.pearson3(**lmoments)
                 ks = stats.kstest(
                     ams,
                     "pearson3",
@@ -197,10 +231,8 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
                 d_statistic = np.nan
                 p_value = np.nan
 
-        if distr == "genpareto":
+        elif distr == "genpareto":
             try:
-                lmoments = lmom_distr.lmom_fit(ams)
-                fitted_distr = stats.genpareto(**lmoments)
                 ks = stats.kstest(
                     ams,
                     "genpareto",
@@ -291,7 +323,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
-    if distr == "gumbel":
+    elif distr == "gumbel":
 
         try:
             lmoments = lmom_distr.lmom_fit(new_ams)
@@ -325,7 +357,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
-    if distr == "weibull":
+    elif distr == "weibull":
 
         try:
             lmoments = lmom_distr.lmom_fit(new_ams)
@@ -359,7 +391,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
-    if distr == "pearson3":
+    elif distr == "pearson3":
 
         try:
             lmoments = lmom_distr.lmom_fit(new_ams)
@@ -393,7 +425,7 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
-    if distr == "genpareto":
+    elif distr == "genpareto":
 
         try:
             lmoments = lmom_distr.lmom_fit(new_ams)
@@ -507,7 +539,7 @@ def get_return_value(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "gumbel":
+        elif distr == "gumbel":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.gumbel_r(**lmoments)
@@ -527,7 +559,7 @@ def get_return_value(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "weibull":
+        elif distr == "weibull":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.weibull_min(**lmoments)
@@ -547,7 +579,7 @@ def get_return_value(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "pearson3":
+        elif distr == "pearson3":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.pearson3(**lmoments)
@@ -567,7 +599,7 @@ def get_return_value(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "genpareto":
+        elif distr == "genpareto":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.genpareto(**lmoments)
@@ -664,7 +696,7 @@ def get_return_prob(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "gumbel":
+        elif distr == "gumbel":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.gumbel_r(**lmoments)
@@ -682,7 +714,7 @@ def get_return_prob(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "weibull":
+        elif distr == "weibull":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.weibull_min(**lmoments)
@@ -700,7 +732,7 @@ def get_return_prob(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "pearson3":
+        elif distr == "pearson3":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.pearson3(**lmoments)
@@ -718,7 +750,7 @@ def get_return_prob(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "genpareto":
+        elif distr == "genpareto":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.genpareto(**lmoments)
@@ -818,7 +850,7 @@ def get_return_period(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "gumbel":
+        elif distr == "gumbel":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.gumbel_r(**lmoments)
@@ -841,7 +873,7 @@ def get_return_period(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "weibull":
+        elif distr == "weibull":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.weibull_min(**lmoments)
@@ -864,7 +896,7 @@ def get_return_period(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "pearson3":
+        elif distr == "pearson3":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.pearson3(**lmoments)
@@ -887,7 +919,7 @@ def get_return_period(
                 conf_int_upper_bound=conf_int_upper_bound,
             )
 
-        if distr == "genpareto":
+        elif distr == "genpareto":
             try:
                 lmoments = lmom_distr.lmom_fit(ams)
                 fitted_distr = stats.genpareto(**lmoments)

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -99,40 +99,35 @@ def get_fitted_distr(ams, distr, lmom_distr):
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.genextreme(**lmoments)
         except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+            pass
 
     elif distr == "gumbel":
         try:
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.gumbel_r(**lmoments)
         except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+            pass
 
     elif distr == "weibull":
         try:
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.weibull_min(**lmoments)
         except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+            pass
 
     elif distr == "pearson3":
         try:
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.pearson3(**lmoments)
         except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+            pass
 
     elif distr == "genpareto":
         try:
             lmoments = lmom_distr.lmom_fit(ams)
             fitted_distr = stats.genpareto(**lmoments)
         except (ValueError, ZeroDivisionError):
-            lmoments = np.nan
-            fitted_distr = np.nan
+            pass
 
     return lmoments, fitted_distr
 

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -28,6 +28,7 @@ from .visualize import get_geospatial_plot
 
 #####################################################################
 
+
 def get_ams(da, extremes_type="max"):
     """
     Returns a data array of annual maximums.
@@ -55,7 +56,9 @@ def get_ams(da, extremes_type="max"):
 
     return ams
 
+
 #####################################################################a
+
 
 def get_lmom_distr(distr):
     """
@@ -87,6 +90,7 @@ def get_lmom_distr(distr):
 
 
 #####################################################################
+
 
 def get_lmoments(ams, distr="gev", multiple_points=True):
     """
@@ -120,6 +124,7 @@ def get_lmoments(ams, distr="gev", multiple_points=True):
 
 
 #####################################################################
+
 
 def get_ks_stat(ams, distr="gev", multiple_points=True):
     """
@@ -233,6 +238,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
 
 #####################################################################
+
 
 def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     """
@@ -423,9 +429,19 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
 
     return result
 
+
 #####################################################################
 
-def conf_int(ams, distr, data_variable, arg_value, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound):
+
+def conf_int(
+    ams,
+    distr,
+    data_variable,
+    arg_value,
+    bootstrap_runs,
+    conf_int_lower_bound,
+    conf_int_upper_bound,
+):
     """
     Returns lower and upper limits of confidence interval given selected parameters.
     """
@@ -433,16 +449,13 @@ def conf_int(ams, distr, data_variable, arg_value, bootstrap_runs, conf_int_lowe
     bootstrap_values = []
 
     for _ in range(bootstrap_runs):
-        result = bootstrap(
-            ams,
-            distr,
-            data_variable,
-            arg_value,
-        )
+        result = bootstrap(ams, distr, data_variable, arg_value,)
         bootstrap_values.append(result)
 
-    conf_int_array = np.percentile(bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound])
-    
+    conf_int_array = np.percentile(
+        bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+    )
+
     conf_int_lower_limit = conf_int_array[0]
     conf_int_upper_limit = conf_int_array[1]
 
@@ -450,6 +463,7 @@ def conf_int(ams, distr, data_variable, arg_value, bootstrap_runs, conf_int_lowe
 
 
 #####################################################################
+
 
 def get_return_value(
     ams,
@@ -483,7 +497,15 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
+            )
 
         if distr == "gumbel":
             try:
@@ -495,8 +517,15 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
-
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
+            )
 
         if distr == "weibull":
             try:
@@ -508,7 +537,15 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
+            )
 
         if distr == "pearson3":
             try:
@@ -520,7 +557,15 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
+            )
 
         if distr == "genpareto":
             try:
@@ -532,7 +577,15 @@ def get_return_value(
             except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
-            conf_int_lower_limit, conf_int_upper_limit = conf_int(ams=ams, distr=distr, data_variable=data_variable, arg_value=return_period, bootstrap_runs=bootstrap_runs, conf_int_lower_bound=conf_int_lower_bound, conf_int_upper_bound=conf_int_upper_bound)
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
+            )
 
         return return_value, conf_int_lower_limit, conf_int_upper_limit
 
@@ -570,6 +623,7 @@ def get_return_value(
 
 #####################################################################
 
+
 def get_return_prob(
     ams,
     threshold,
@@ -600,18 +654,15 @@ def get_return_prob(
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "gumbel":
             try:
@@ -621,18 +672,15 @@ def get_return_prob(
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "weibull":
             try:
@@ -642,18 +690,15 @@ def get_return_prob(
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "pearson3":
             try:
@@ -663,18 +708,15 @@ def get_return_prob(
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "genpareto":
             try:
@@ -684,18 +726,15 @@ def get_return_prob(
             except (ValueError, ZeroDivisionError):
                 return_prob = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams, distr=distr, data_variable=data_variable, arg_value=threshold
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         return return_prob, conf_int_lower_limit, conf_int_upper_limit
 
@@ -733,6 +772,7 @@ def get_return_prob(
 
 #####################################################################
 
+
 def get_return_period(
     ams,
     return_value,
@@ -768,21 +808,15 @@ def get_return_period(
             except (ValueError, ZeroDivisionError):
                 return_period = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_value,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "gumbel":
             try:
@@ -797,21 +831,15 @@ def get_return_period(
             except (ValueError, ZeroDivisionError):
                 return_period = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_value,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "weibull":
             try:
@@ -826,21 +854,15 @@ def get_return_period(
             except (ValueError, ZeroDivisionError):
                 return_period = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_value,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "pearson3":
             try:
@@ -855,21 +877,15 @@ def get_return_period(
             except (ValueError, ZeroDivisionError):
                 return_period = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_value,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         if distr == "genpareto":
             try:
@@ -884,21 +900,15 @@ def get_return_period(
             except (ValueError, ZeroDivisionError):
                 return_period = np.nan
 
-            bootstrap_values = []
-            for _ in range(bootstrap_runs):
-                result = bootstrap(
-                    ams,
-                    distr=distr,
-                    data_variable=data_variable,
-                    arg_value=return_value,
-                )
-                bootstrap_values.append(result)
-
-            conf_int_array = np.percentile(
-                bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound]
+            conf_int_lower_limit, conf_int_upper_limit = conf_int(
+                ams=ams,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
             )
-            conf_int_lower_limit = conf_int_array[0]
-            conf_int_upper_limit = conf_int_array[1]
 
         return return_period, conf_int_lower_limit, conf_int_upper_limit
 

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -148,9 +148,7 @@ def get_lmoments(ams, distr="gev", multiple_points=True):
 
     return new_ds
 
-
 #####################################################################
-
 
 def get_ks_stat(ams, distr="gev", multiple_points=True):
     """
@@ -260,6 +258,39 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
 #####################################################################
 
+def calculate_return(fitted_distr, data_variable, arg_value)
+    """
+    Returns corresponding extreme value calculation for selected data variable.
+    """
+
+    if data_variable == "return_value":
+        try:
+            return_event = 1.0 - (1.0 / arg_value)
+            return_value = fitted_distr.ppf(return_event)
+            result = round(return_value, 5)
+        except (ValueError, ZeroDivisionError):
+            result = np.nan
+
+    elif data_variable == "return_prob":
+        try:
+            result = 1 - (fitted_distr.cdf(arg_value))
+        except (ValueError, ZeroDivisionError):
+            result = np.nan
+
+    elif data_variable == "return_period":
+        try:
+            return_prob = fitted_distr.cdf(arg_value)
+            if return_prob == 1.0:
+                result = np.nan
+            else:
+                return_period = -1.0 / (return_prob - 1.0)
+                result = round(return_period, 3)
+        except (ValueError, ZeroDivisionError):
+            result = np.nan
+
+    return result
+
+#####################################################################
 
 def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     """
@@ -279,167 +310,37 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     new_ams = np.random.choice(ams, size=sample_size, replace=True)
 
     if distr == "gev":
-
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-
-            if data_variable == "return_value":
-                try:
-                    return_event = 1.0 - (1.0 / arg_value)
-                    return_value = fitted_distr.ppf(return_event)
-                    result = round(return_value, 5)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_prob":
-                try:
-                    result = 1 - (fitted_distr.cdf(arg_value))
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_period":
-                try:
-                    return_prob = fitted_distr.cdf(arg_value)
-                    if return_prob == 1.0:
-                        result = np.nan
-                    else:
-                        return_period = -1.0 / (return_prob - 1.0)
-                        result = round(return_period, 3)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
+            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
     elif distr == "gumbel":
-
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-
-            if data_variable == "return_value":
-                try:
-                    return_event = 1.0 - (1.0 / arg_value)
-                    return_value = fitted_distr.ppf(return_event)
-                    result = round(return_value, 5)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_prob":
-                try:
-                    result = 1 - (fitted_distr.cdf(arg_value))
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_period":
-                try:
-                    return_prob = fitted_distr.cdf(arg_value)
-                    if return_prob == 1.0:
-                        result = np.nan
-                    else:
-                        return_period = -1.0 / (return_prob - 1.0)
-                        result = round(return_period, 3)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
+            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
     elif distr == "weibull":
-
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-
-            if data_variable == "return_value":
-                try:
-                    return_event = 1.0 - (1.0 / arg_value)
-                    return_value = fitted_distr.ppf(return_event)
-                    result = round(return_value, 5)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_prob":
-                try:
-                    result = 1 - (fitted_distr.cdf(arg_value))
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_period":
-                try:
-                    return_prob = fitted_distr.cdf(arg_value)
-                    if return_prob == 1.0:
-                        result = np.nan
-                    else:
-                        return_period = -1.0 / (return_prob - 1.0)
-                        result = round(return_period, 3)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
+            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
     elif distr == "pearson3":
-
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-
-            if data_variable == "return_value":
-                try:
-                    return_event = 1.0 - (1.0 / arg_value)
-                    return_value = fitted_distr.ppf(return_event)
-                    result = round(return_value, 5)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_prob":
-                try:
-                    result = 1 - (fitted_distr.cdf(arg_value))
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_period":
-                try:
-                    return_prob = fitted_distr.cdf(arg_value)
-                    if return_prob == 1.0:
-                        result = np.nan
-                    else:
-                        return_period = -1.0 / (return_prob - 1.0)
-                        result = round(return_period, 3)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
+            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
     elif distr == "genpareto":
-
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-
-            if data_variable == "return_value":
-                try:
-                    return_event = 1.0 - (1.0 / arg_value)
-                    return_value = fitted_distr.ppf(return_event)
-                    result = round(return_value, 5)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_prob":
-                try:
-                    result = 1 - (fitted_distr.cdf(arg_value))
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
-            elif data_variable == "return_period":
-                try:
-                    return_prob = fitted_distr.cdf(arg_value)
-                    if return_prob == 1.0:
-                        result = np.nan
-                    else:
-                        return_period = -1.0 / (return_prob - 1.0)
-                        result = round(return_period, 3)
-                except (ValueError, ZeroDivisionError):
-                    result = np.nan
-
+            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
@@ -504,14 +405,8 @@ def get_return_value(
     def return_value(ams):
 
         if distr == "gev":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_event = 1.0 - (1.0 / return_period)
-                return_value = fitted_distr.ppf(return_event)
-                return_value = round(return_value, 5)
-            except (ValueError, ZeroDivisionError):
-                return_value = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -523,14 +418,8 @@ def get_return_value(
             )
 
         elif distr == "gumbel":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_event = 1.0 - (1.0 / return_period)
-                return_value = fitted_distr.ppf(return_event)
-                return_value = round(return_value, 5)
-            except (ValueError, ZeroDivisionError):
-                return_value = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -542,14 +431,8 @@ def get_return_value(
             )
 
         elif distr == "weibull":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_event = 1.0 - (1.0 / return_period)
-                return_value = fitted_distr.ppf(return_event)
-                return_value = round(return_value, 5)
-            except (ValueError, ZeroDivisionError):
-                return_value = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -561,14 +444,8 @@ def get_return_value(
             )
 
         elif distr == "pearson3":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_event = 1.0 - (1.0 / return_period)
-                return_value = fitted_distr.ppf(return_event)
-                return_value = round(return_value, 5)
-            except (ValueError, ZeroDivisionError):
-                return_value = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -580,14 +457,8 @@ def get_return_value(
             )
 
         elif distr == "genpareto":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_event = 1.0 - (1.0 / return_period)
-                return_value = fitted_distr.ppf(return_event)
-                return_value = round(return_value, 5)
-            except (ValueError, ZeroDivisionError):
-                return_value = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -658,12 +529,8 @@ def get_return_prob(
     def return_prob(ams):
 
         if distr == "gev":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = 1 - (fitted_distr.cdf(threshold))
-            except (ValueError, ZeroDivisionError):
-                return_prob = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -675,12 +542,8 @@ def get_return_prob(
             )
 
         elif distr == "gumbel":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = 1 - (fitted_distr.cdf(threshold))
-            except (ValueError, ZeroDivisionError):
-                return_prob = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -692,12 +555,8 @@ def get_return_prob(
             )
 
         elif distr == "weibull":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = 1 - (fitted_distr.cdf(threshold))
-            except (ValueError, ZeroDivisionError):
-                return_prob = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -709,12 +568,8 @@ def get_return_prob(
             )
 
         elif distr == "pearson3":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = 1 - (fitted_distr.cdf(threshold))
-            except (ValueError, ZeroDivisionError):
-                return_prob = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -726,12 +581,8 @@ def get_return_prob(
             )
 
         elif distr == "genpareto":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = 1 - (fitted_distr.cdf(threshold))
-            except (ValueError, ZeroDivisionError):
-                return_prob = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -802,17 +653,8 @@ def get_return_period(
     def return_period(ams):
 
         if distr == "gev":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = fitted_distr.cdf(return_value)
-                if return_prob == 1.0:
-                    return_period = np.nan
-                else:
-                    return_period = -1.0 / (return_prob - 1.0)
-                    return_period = round(return_period, 3)
-            except (ValueError, ZeroDivisionError):
-                return_period = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -824,17 +666,8 @@ def get_return_period(
             )
 
         elif distr == "gumbel":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = fitted_distr.cdf(return_value)
-                if return_prob == 1.0:
-                    return_period = np.nan
-                else:
-                    return_period = -1.0 / (return_prob - 1.0)
-                    return_period = round(return_period, 3)
-            except (ValueError, ZeroDivisionError):
-                return_period = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -846,17 +679,8 @@ def get_return_period(
             )
 
         elif distr == "weibull":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = fitted_distr.cdf(return_value)
-                if return_prob == 1.0:
-                    return_period = np.nan
-                else:
-                    return_period = -1.0 / (return_prob - 1.0)
-                    return_period = round(return_period, 3)
-            except (ValueError, ZeroDivisionError):
-                return_period = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -868,17 +692,8 @@ def get_return_period(
             )
 
         elif distr == "pearson3":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = fitted_distr.cdf(return_value)
-                if return_prob == 1.0:
-                    return_period = np.nan
-                else:
-                    return_period = -1.0 / (return_prob - 1.0)
-                    return_period = round(return_period, 3)
-            except (ValueError, ZeroDivisionError):
-                return_period = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -890,17 +705,8 @@ def get_return_period(
             )
 
         elif distr == "genpareto":
-            try:
-                lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-                return_prob = fitted_distr.cdf(return_value)
-                if return_prob == 1.0:
-                    return_period = np.nan
-                else:
-                    return_period = -1.0 / (return_prob - 1.0)
-                    return_period = round(return_period, 3)
-            except (ValueError, ZeroDivisionError):
-                return_period = np.nan
-
+            lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
+            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -95,24 +95,44 @@ def get_fitted_distr(ams, distr, lmom_distr):
     """
 
     if distr == "gev":
-        lmoments = lmom_distr.lmom_fit(ams)
-        fitted_distr = stats.genextreme(**lmoments)
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.genextreme(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     elif distr == "gumbel":
-        lmoments = lmom_distr.lmom_fit(ams)
-        fitted_distr = stats.gumbel_r(**lmoments)
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.gumbel_r(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     elif distr == "weibull":
-        lmoments = lmom_distr.lmom_fit(ams)
-        fitted_distr = stats.weibull_min(**lmoments)
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.weibull_min(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     elif distr == "pearson3":
-        lmoments = lmom_distr.lmom_fit(ams)
-        fitted_distr = stats.pearson3(**lmoments)
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.pearson3(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     elif distr == "genpareto":
-        lmoments = lmom_distr.lmom_fit(ams)
-        fitted_distr = stats.genpareto(**lmoments)
+        try:
+            lmoments = lmom_distr.lmom_fit(ams)
+            fitted_distr = stats.genpareto(**lmoments)
+        except (ValueError, ZeroDivisionError):
+            lmoments = np.nan
+            fitted_distr = np.nan
 
     return lmoments, fitted_distr
 

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -333,13 +333,13 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                     return_event = 1.0 - (1./arg_value)
                     return_value = fitted_distr.ppf(return_event)
                     result = round(return_value, 5)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_prob":
                 try:
                     result = 1 - (fitted_distr.cdf(arg_value))
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
 
             if data_variable == "return_period":
@@ -350,10 +350,10 @@ def bootstrap(ams, distr='gev', data_variable="return_value", arg_value=10):
                     else:
                         return_period = -1.0 / (return_prob - 1.0)
                         result = round(return_period, 3)
-                except ValueError:
+                except (ValueError, ZeroDivisionError):
                     result = np.nan
     
-        except ValueError:
+        except (ValueError, ZeroDivisionError):
                     result = np.nan
 
     if distr == "pearson3":
@@ -492,7 +492,7 @@ def get_return_value(ams, return_period=10, distr="gev",
                 return_event = 1.0 - (1.0 / return_period)
                 return_value = fitted_distr.ppf(return_event)
                 return_value = round(return_value, 5)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 return_value = np.nan
 
             bootstrap_values = []

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -59,6 +59,7 @@ def get_ams(da, extremes_type="max"):
 
 #####################################################################
 
+
 def get_lmom_distr(distr):
     """
     Returns corresponding l-moments distribution function from selected distribution name.
@@ -87,7 +88,9 @@ def get_lmom_distr(distr):
 
     return lmom_distr
 
+
 #####################################################################
+
 
 def get_fitted_distr(ams, distr, lmom_distr):
     """
@@ -136,7 +139,9 @@ def get_fitted_distr(ams, distr, lmom_distr):
 
     return lmoments, fitted_distr
 
+
 #####################################################################
+
 
 def get_lmoments(ams, distr="gev", multiple_points=True):
     """
@@ -168,7 +173,9 @@ def get_lmoments(ams, distr="gev", multiple_points=True):
 
     return new_ds
 
+
 #####################################################################
+
 
 def get_ks_stat(ams, distr="gev", multiple_points=True):
     """
@@ -278,6 +285,7 @@ def get_ks_stat(ams, distr="gev", multiple_points=True):
 
 #####################################################################
 
+
 def calculate_return(fitted_distr, data_variable, arg_value):
     """
     Returns corresponding extreme value calculation for selected data variable.
@@ -310,7 +318,9 @@ def calculate_return(fitted_distr, data_variable, arg_value):
 
     return result
 
+
 #####################################################################
+
 
 def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     """
@@ -332,35 +342,55 @@ def bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     if distr == "gev":
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
+            result = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=arg_value,
+            )
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
     elif distr == "gumbel":
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
+            result = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=arg_value,
+            )
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
     elif distr == "weibull":
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
+            result = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=arg_value,
+            )
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
     elif distr == "pearson3":
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
+            result = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=arg_value,
+            )
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
     elif distr == "genpareto":
         try:
             lmoments, fitted_distr = get_fitted_distr(new_ams, distr, lmom_distr)
-            result = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value)
+            result = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=arg_value,
+            )
         except (ValueError, ZeroDivisionError):
             result = np.nan
 
@@ -426,7 +456,11 @@ def get_return_value(
 
         if distr == "gev":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
+            return_value = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -439,7 +473,11 @@ def get_return_value(
 
         elif distr == "gumbel":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
+            return_value = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -452,7 +490,11 @@ def get_return_value(
 
         elif distr == "weibull":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
+            return_value = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -465,7 +507,11 @@ def get_return_value(
 
         elif distr == "pearson3":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
+            return_value = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -478,7 +524,11 @@ def get_return_value(
 
         elif distr == "genpareto":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_value = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_period)
+            return_value = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_period,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -550,7 +600,11 @@ def get_return_prob(
 
         if distr == "gev":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
+            return_prob = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -563,7 +617,11 @@ def get_return_prob(
 
         elif distr == "gumbel":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
+            return_prob = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -576,7 +634,11 @@ def get_return_prob(
 
         elif distr == "weibull":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
+            return_prob = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -589,7 +651,11 @@ def get_return_prob(
 
         elif distr == "pearson3":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
+            return_prob = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -602,7 +668,11 @@ def get_return_prob(
 
         elif distr == "genpareto":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=threshold)
+            return_prob = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=threshold,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -674,7 +744,11 @@ def get_return_period(
 
         if distr == "gev":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
+            return_period = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -687,7 +761,11 @@ def get_return_period(
 
         elif distr == "gumbel":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
+            return_period = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -700,7 +778,11 @@ def get_return_period(
 
         elif distr == "weibull":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
+            return_period = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -713,7 +795,11 @@ def get_return_period(
 
         elif distr == "pearson3":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
+            return_period = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,
@@ -726,7 +812,11 @@ def get_return_period(
 
         elif distr == "genpareto":
             lmoments, fitted_distr = get_fitted_distr(ams, distr, lmom_distr)
-            return_prob = calculate_return(fitted_distr=fitted_distr, data_variable=data_variable, arg_value=return_value)
+            return_period = calculate_return(
+                fitted_distr=fitted_distr,
+                data_variable=data_variable,
+                arg_value=return_value,
+            )
             conf_int_lower_limit, conf_int_upper_limit = conf_int(
                 ams=ams,
                 distr=distr,

--- a/climakitae/visualize.py
+++ b/climakitae/visualize.py
@@ -4,9 +4,6 @@
 #                                      #
 ########################################
 
-#####################################################################
-# import packages
-
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -23,9 +20,6 @@ import hvplot.pandas
 import hvplot.xarray
 
 #####################################################################
-# GET GEOSPATIAL PLOT
-# input: xarray dataset
-# export: geospatial plot (hvplot)
 
 def get_geospatial_plot(
     ds,
@@ -37,6 +31,9 @@ def get_geospatial_plot(
     cmap="Wistia",
     hover_fill_color="blue",
 ):
+    """
+    Returns a geospatial plot (hvplot) from inputed dataset and selected data variable.
+    """
 
     data_variables = [
         "d_statistic",
@@ -116,31 +113,3 @@ def get_geospatial_plot(
     )
 
     return geospatial_plot
-
-#####################################################################
-# ARCHIVE
-
-# def get_frequency_plot(ds, data_variable, color="orange", hover_fill_color="blue"):
-
-#     data_variables = ["lowest_aicc_distr"]
-#     if data_variable not in data_variables:
-#         raise ValueError(
-#             "invalid data variable type. expected one of the following: %s"
-#             % data_variables
-#         )
-
-#     if data_variable in ["lowest_aicc_distr"]:
-#         categories, counts = np.unique(ds[data_variable].values, return_counts=True)
-#         d = {"Distributions": categories, "Number of Lowest AICc Occurrences": counts}
-#         df = pd.DataFrame(data=d, index=np.arange(len(categories)))
-#         title = "Frequency of Different Distributions Having the Lowest AICc Statistic"
-
-#     frequency_plot = df.hvplot.bar(
-#         x="Distributions",
-#         y="Number of Lowest AICc Occurrences",
-#         title=title,
-#         color=color,
-#         hover_fill_color=hover_fill_color,
-#     )
-
-#     return frequency_plot

--- a/climakitae/visualize.py
+++ b/climakitae/visualize.py
@@ -1,3 +1,12 @@
+########################################
+#                                      #
+# VISUALIZE                            #
+#                                      #
+########################################
+
+#####################################################################
+# import packages
+
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -14,36 +23,9 @@ import hvplot.pandas
 import hvplot.xarray
 
 #####################################################################
-
-
-def get_frequency_plot(ds, data_variable, color="orange", hover_fill_color="blue"):
-
-    data_variables = ["lowest_aicc_distr"]
-    if data_variable not in data_variables:
-        raise ValueError(
-            "invalid data variable type. expected one of the following: %s"
-            % data_variables
-        )
-
-    if data_variable in ["lowest_aicc_distr"]:
-        categories, counts = np.unique(ds[data_variable].values, return_counts=True)
-        d = {"Distributions": categories, "Number of Lowest AICc Occurrences": counts}
-        df = pd.DataFrame(data=d, index=np.arange(len(categories)))
-        title = "Frequency of Different Distributions Having the Lowest AICc Statistic"
-
-    frequency_plot = df.hvplot.bar(
-        x="Distributions",
-        y="Number of Lowest AICc Occurrences",
-        title=title,
-        color=color,
-        hover_fill_color=hover_fill_color,
-    )
-
-    return frequency_plot
-
-
-#####################################################################
-
+# GET GEOSPATIAL PLOT
+# input: xarray dataset
+# export: geospatial plot (hvplot)
 
 def get_geospatial_plot(
     ds,
@@ -134,3 +116,31 @@ def get_geospatial_plot(
     )
 
     return geospatial_plot
+
+#####################################################################
+# ARCHIVE
+
+# def get_frequency_plot(ds, data_variable, color="orange", hover_fill_color="blue"):
+
+#     data_variables = ["lowest_aicc_distr"]
+#     if data_variable not in data_variables:
+#         raise ValueError(
+#             "invalid data variable type. expected one of the following: %s"
+#             % data_variables
+#         )
+
+#     if data_variable in ["lowest_aicc_distr"]:
+#         categories, counts = np.unique(ds[data_variable].values, return_counts=True)
+#         d = {"Distributions": categories, "Number of Lowest AICc Occurrences": counts}
+#         df = pd.DataFrame(data=d, index=np.arange(len(categories)))
+#         title = "Frequency of Different Distributions Having the Lowest AICc Statistic"
+
+#     frequency_plot = df.hvplot.bar(
+#         x="Distributions",
+#         y="Number of Lowest AICc Occurrences",
+#         title=title,
+#         color=color,
+#         hover_fill_color=hover_fill_color,
+#     )
+
+#     return frequency_plot


### PR DESCRIPTION
added confidence intervals to threshold_tools functions

updates:
- added new function "bootstrap"
- added bootstrap capabilities to "return_value", "return_prob", and "return_period" capabilities
- changed ValueError exceptions to also include ZeroDivisionError (_note: this does not impact calculations but removes an error that would occur with the gumbel distribution and instead outputs an np.nan for that gridcell if either of these two errors occurs_).
- ran black for formatting