### PR TITLE
Dynamically populate param classes

### DIFF
--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -1,8 +1,15 @@
-from .selectors import (DataSelector, _display_select, LocSelectorArea,
-                        UserFileChoices, _user_export_select, FileTypeSelector)
+from .selectors import (
+    DataSelector,
+    _display_select,
+    LocSelectorArea,
+    UserFileChoices,
+    _user_export_select,
+    FileTypeSelector,
+)
 from .data_loaders import _read_from_catalog
 from .data_export import _export_to_user
 import intake
+
 
 class Application(object):
     """
@@ -13,7 +20,7 @@ class Application(object):
     def __init__(self):
         self._cat = intake.open_catalog("https://cadcat.s3.amazonaws.com/cae.yaml")
         self.selections = DataSelector(choices=_get_catalog_contents(self._cat))
-                            
+
         self.location = LocSelectorArea()
         self.user_export_format = FileTypeSelector()
 
@@ -45,13 +52,14 @@ class Application(object):
         export_select_panel = _user_export_select(self.user_export_format)
         return export_select_panel
 
-    def export_dataset(self,data_to_export,file_name,**kwargs):
+    def export_dataset(self, data_to_export, file_name, **kwargs):
         """
         Uses the selection from 'export_as' to create a file in the specified
         format and write it to the working directory.
         """
-        return _export_to_user(self.user_export_format,data_to_export,
-                               file_name,**kwargs)
+        return _export_to_user(
+            self.user_export_format, data_to_export, file_name, **kwargs
+        )
 
 
 def _get_catalog_contents(_cat):
@@ -62,7 +70,7 @@ def _get_catalog_contents(_cat):
     }
     _variable_choices_hourly_wrf.update(
         {"Precipitation (total)": ""}
-        )  # which we'll derive from what's there
+    )  # which we'll derive from what's there
     # remove some variables from the list, which will be superceded by higher quality hydrology
     _to_drop = ["Surface runoff", "Subsurface runoff", "Snow water equivalent"]
     [_variable_choices_hourly_wrf.pop(k) for k in _to_drop]
@@ -71,25 +79,25 @@ def _get_catalog_contents(_cat):
         "Sfc pressure"
     ]
     _variable_choices_hourly_wrf.pop("Sfc pressure")
-    _variable_choices_hourly_wrf[
-        "2m Air Temperature"
-        ] = _variable_choices_hourly_wrf["Temp at 2 m"]
+    _variable_choices_hourly_wrf["2m Air Temperature"] = _variable_choices_hourly_wrf[
+        "Temp at 2 m"
+    ]
     _variable_choices_hourly_wrf.pop("Temp at 2 m")
     _variable_choices_hourly_wrf[
         "2m Water Vapor Mixing Ratio"
-        ] = _variable_choices_hourly_wrf["Qv at 2 m"]
+    ] = _variable_choices_hourly_wrf["Qv at 2 m"]
     _variable_choices_hourly_wrf.pop("Qv at 2 m")
     _variable_choices_hourly_wrf[
         "West-East component of Wind at 10m"
-        ] = _variable_choices_hourly_wrf["U at 10 m"]
+    ] = _variable_choices_hourly_wrf["U at 10 m"]
     _variable_choices_hourly_wrf.pop("U at 10 m")
     _variable_choices_hourly_wrf[
         "North-South component of Wind at 10m"
-        ] = _variable_choices_hourly_wrf["V at 10 m"]
+    ] = _variable_choices_hourly_wrf["V at 10 m"]
     _variable_choices_hourly_wrf.pop("V at 10 m")
     _variable_choices_hourly_wrf[
         "Snowfall (snow and ice)"
-        ] = _variable_choices_hourly_wrf["Accumulated total grid scale snow and ice"]
+    ] = _variable_choices_hourly_wrf["Accumulated total grid scale snow and ice"]
     _variable_choices_hourly_wrf.pop("Accumulated total grid scale snow and ice")
     _move_to_end = [k for k in _variable_choices_hourly_wrf if "Instantaneous" in k]
     for k in _move_to_end:
@@ -130,9 +138,7 @@ def _get_catalog_contents(_cat):
         "ssp585": "SSP 5-8.5 -- Burn it All",
     }
 
-    _resolutions = list(
-        set(e.metadata["nominal_resolution"] for e in _cat.values())
-    )
+    _resolutions = list(set(e.metadata["nominal_resolution"] for e in _cat.values()))
 
     _scenario_list = []
     for resolution in _resolutions:
@@ -140,14 +146,17 @@ def _get_catalog_contents(_cat):
             set(
                 e.metadata["experiment_id"]
                 for e in _cat.values()
-                    if e.metadata["nominal_resolution"] == resolution
-                )
+                if e.metadata["nominal_resolution"] == resolution
             )
+        )
         _temp.sort()  # consistent order
         _scenario_subset = [(_scenario_choices[e], e) for e in _temp]
         _scenario_subset = dict(_scenario_subset)
         _scenario_list.append((resolution, _scenario_subset))
     _scenarios = dict(_scenario_list)
-    return {'scenarios':_scenarios, 'resolutions':_resolutions, 'scenario_choices':_scenario_choices,
-                        'variable_choices':_variable_choices} 
-
+    return {
+        "scenarios": _scenarios,
+        "resolutions": _resolutions,
+        "scenario_choices": _scenario_choices,
+        "variable_choices": _variable_choices,
+    }

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -2,16 +2,18 @@ from .selectors import (DataSelector, _display_select, LocSelectorArea,
                         UserFileChoices, _user_export_select, FileTypeSelector)
 from .data_loaders import _read_from_catalog
 from .data_export import _export_to_user
-
+import intake
 
 class Application(object):
     """
-    The main control center of the library. Users can select and read-in datasets (generate),
+    The main control center of the library. Users can select and read-in datasets (retrieve),
     visualize, transform, interpret, and export them.
     """
 
     def __init__(self):
-        self.selections = DataSelector()
+        _cat = intake.open_catalog("https://cdcat.s3.amazonaws.com/cae.yaml")
+        self.selections = DataSelector(choices=_get_catalog_contents(_cat))
+                            
         self.location = LocSelectorArea()
         self.user_export_format = FileTypeSelector()
 
@@ -25,11 +27,11 @@ class Application(object):
         select_panel = _display_select(self.selections, self.location)
         return select_panel
 
-    # === Generate ===================================
+    # === Retrieve ===================================
     def retrieve(self):
         """
-        Uses the information gathered in 'select' and store in 'selections' and 'location'
-        to generate an xarray Dataset as specified, and return that Dataset object.
+        Uses the information gathered in 'select' and stored in 'selections' and 'location'
+        to generate an xarray DataArray as specified, and return that DataArray object.
         """
         # to do: insert additional 'hang in there' statement if it's taking a while
         return _read_from_catalog(self.selections, self.location)
@@ -50,4 +52,102 @@ class Application(object):
         """
         return _export_to_user(self.user_export_format,data_to_export,
                                file_name,**kwargs)
+
+
+def _get_catalog_contents(_cat):
+    # get the list of data variables from one of the zarr files:
+    _ds = _cat[list(_cat)[0]].to_dask()
+    _variable_choices_hourly_wrf = {
+        v.attrs["description"].capitalize(): k for k, v in _ds.data_vars.items()
+    }
+    _variable_choices_hourly_wrf.update(
+        {"Precipitation (total)": ""}
+        )  # which we'll derive from what's there
+    # remove some variables from the list, which will be superceded by higher quality hydrology
+    _to_drop = ["Surface runoff", "Subsurface runoff", "Snow water equivalent"]
+    [_variable_choices_hourly_wrf.pop(k) for k in _to_drop]
+    # give better names to some descriptions, and reorder:
+    _variable_choices_hourly_wrf["Surface Pressure"] = _variable_choices_hourly_wrf[
+        "Sfc pressure"
+    ]
+    _variable_choices_hourly_wrf.pop("Sfc pressure")
+    _variable_choices_hourly_wrf[
+        "2m Air Temperature"
+        ] = _variable_choices_hourly_wrf["Temp at 2 m"]
+    _variable_choices_hourly_wrf.pop("Temp at 2 m")
+    _variable_choices_hourly_wrf[
+        "2m Water Vapor Mixing Ratio"
+        ] = _variable_choices_hourly_wrf["Qv at 2 m"]
+    _variable_choices_hourly_wrf.pop("Qv at 2 m")
+    _variable_choices_hourly_wrf[
+        "West-East component of Wind at 10m"
+        ] = _variable_choices_hourly_wrf["U at 10 m"]
+    _variable_choices_hourly_wrf.pop("U at 10 m")
+    _variable_choices_hourly_wrf[
+        "North-South component of Wind at 10m"
+        ] = _variable_choices_hourly_wrf["V at 10 m"]
+    _variable_choices_hourly_wrf.pop("V at 10 m")
+    _variable_choices_hourly_wrf[
+        "Snowfall (snow and ice)"
+        ] = _variable_choices_hourly_wrf["Accumulated total grid scale snow and ice"]
+    _variable_choices_hourly_wrf.pop("Accumulated total grid scale snow and ice")
+    _move_to_end = [k for k in _variable_choices_hourly_wrf if "Instantaneous" in k]
+    for k in _move_to_end:
+        _variable_choices_hourly_wrf[k] = _variable_choices_hourly_wrf.pop(k)
+
+    # expand this dictionary to also be dependent on LOCA vs WRF:
+    _variable_choices_daily_loca = [
+        "Temperature",
+        "Maximum Relative Humidity",
+        "Minimum Relative Humidity",
+        "Solar Radiation",
+        "Wind Speed",
+        "Wind Direction",
+        "Precipitation",
+    ]
+    _variable_choices_hourly_loca = ["Temperature", "Precipitation"]
+
+    _variable_choices_hourly = {
+        "Dynamical": _variable_choices_hourly_wrf,
+        "Statistical": _variable_choices_hourly_loca,
+    }
+    _variable_choices_daily = {
+        "Dynamical": _variable_choices_hourly_wrf,
+        "Statistical": _variable_choices_daily_loca,
+    }
+
+    _variable_choices = {
+        "hourly": _variable_choices_hourly,
+        "daily": _variable_choices_daily,
+    }
+
+    # hard-coded options:
+    _scenario_choices = {
+        "historical": "Historical Climate",
+        "": "Historical Reconstruction",
+        "ssp245": "SSP 2-4.5 -- Middle of the Road",
+        "ssp370": "SSP 3-7.0 -- Business as Usual",
+        "ssp585": "SSP 5-8.5 -- Burn it All",
+    }
+
+    _resolutions = list(
+        set(e.metadata["nominal_resolution"] for e in _cat.values())
+    )
+
+    _scenario_list = []
+    for resolution in _resolutions:
+        _temp = list(
+            set(
+                e.metadata["experiment_id"]
+                for e in _cat.values()
+                    if e.metadata["nominal_resolution"] == resolution
+                )
+            )
+        _temp.sort()  # consistent order
+        _scenario_subset = [(_scenario_choices[e], e) for e in _temp]
+        _scenario_subset = dict(_scenario_subset)
+        _scenario_list.append((resolution, _scenario_subset))
+    _scenarios = dict(_scenario_list)
+    return {'scenarios':_scenarios, 'resolutions':_resolutions, 'scenario_choices':_scenario_choices,
+                        'variable_choices':_variable_choices} 
 

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -11,8 +11,8 @@ class Application(object):
     """
 
     def __init__(self):
-        _cat = intake.open_catalog("https://cadcat.s3.amazonaws.com/cae.yaml")
-        self.selections = DataSelector(choices=_get_catalog_contents(_cat))
+        self._cat = intake.open_catalog("https://cadcat.s3.amazonaws.com/cae.yaml")
+        self.selections = DataSelector(choices=_get_catalog_contents(self._cat))
                             
         self.location = LocSelectorArea()
         self.user_export_format = FileTypeSelector()
@@ -34,7 +34,7 @@ class Application(object):
         to generate an xarray DataArray as specified, and return that DataArray object.
         """
         # to do: insert additional 'hang in there' statement if it's taking a while
-        return _read_from_catalog(self.selections, self.location)
+        return _read_from_catalog(self.selections, self.location, self._cat)
 
     # === Export ======================================
     def export_as(self):

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -11,7 +11,7 @@ class Application(object):
     """
 
     def __init__(self):
-        _cat = intake.open_catalog("https://cdcat.s3.amazonaws.com/cae.yaml")
+        _cat = intake.open_catalog("https://cadcat.s3.amazonaws.com/cae.yaml")
         self.selections = DataSelector(choices=_get_catalog_contents(_cat))
                             
         self.location = LocSelectorArea()

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -14,12 +14,12 @@ def _get_file_list(selections, scenario, cat):
     Returns a list of simulation names for all of the simulations present in the catalog
     for a given scenario, contingent on other user-supplied constraints in 'selections'.
     """
-    lookup = {v: k for k, v in selections.choices['scenario_choices'].items()}
+    lookup = {v: k for k, v in selections.choices["scenario_choices"].items()}
     file_list = []
     for item in list(cat):
         if cat[item].metadata["nominal_resolution"] == selections.resolution:
             if cat[item].metadata["experiment_id"] == lookup[scenario]:
-                file_list.append(cat[item].name)  
+                file_list.append(cat[item].name)
     return file_list
 
 
@@ -35,7 +35,11 @@ def _open_and_concat(file_list, selections, cat, ds_region):
         attributes = deepcopy(data.attrs)
         source_id = data.attrs["source_id"]
         if selections.variable not in ("Precipitation (total)", "wind 10m magnitude"):
-            data = data[selections.choices['variable_choices']['hourly']['Dynamical'][selections.variable]]
+            data = data[
+                selections.choices["variable_choices"]["hourly"]["Dynamical"][
+                    selections.variable
+                ]
+            ]
         elif selections.variable == "Precipitation (total)":
             data = data["RAINC"] + data["RAINNC"]
         elif selections.variable == "wind 10m magnitude":
@@ -103,7 +107,7 @@ def _read_from_catalog(selections, location, cat):
     stored in 'selections' and 'location').
     """
     assert not selections.scenario == [], "Please select as least one scenario."
-    
+
     if location.area_subset == "lat/lon":
         geom = _get_as_shapely(location)
         assert (
@@ -132,7 +136,9 @@ def _read_from_catalog(selections, location, cat):
         ds_region = None
 
     if selections.append_historical:
-        assert True in ["SSP" in one for one in app.selections.scenario], "Please also select at least one SSP to which the historical simulation should be appended."
+        assert True in [
+            "SSP" in one for one in app.selections.scenario
+        ], "Please also select at least one SSP to which the historical simulation should be appended."
         one_scenario = "Historical Climate"
         files_by_scenario = _get_file_list(selections, one_scenario, cat)
         historical = _open_and_concat(files_by_scenario, selections, cat, ds_region)

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -9,35 +9,33 @@ from copy import deepcopy
 xr.set_options(keep_attrs=True)
 
 
-def _get_file_list(selections, scenario):
+def _get_file_list(selections, scenario, cat):
     """
     Returns a list of simulation names for all of the simulations present in the catalog
     for a given scenario, contingent on other user-supplied constraints in 'selections'.
     """
-    cat = selections._choices._cat
-    lookup = {v: k for k, v in selections._choices._scenario_choices.items()}
+    lookup = {v: k for k, v in selections.choices['scenario_choices'].items()}
     file_list = []
     for item in list(cat):
         if cat[item].metadata["nominal_resolution"] == selections.resolution:
             if cat[item].metadata["experiment_id"] == lookup[scenario]:
-                file_list.append(cat[item].name)
+                file_list.append(cat[item].name)  
     return file_list
 
 
-def _open_and_concat(file_list, selections, ds_region):
+def _open_and_concat(file_list, selections, cat, ds_region):
     """
     Open multiple zarr files, and add them to one big xarray Dataset. Coarsens in time, and/or
     subsets in space if selections so-indicates. Won't work unless the file_list supplied
     contains files of only one nominal resolution (_get_file_list ensures this).
     """
-    cat = selections._choices._cat
     all_files = xr.Dataset()
     for one_file in file_list:
         data = cat[one_file].to_dask()
         attributes = deepcopy(data.attrs)
         source_id = data.attrs["source_id"]
         if selections.variable not in ("Precipitation (total)", "wind 10m magnitude"):
-            data = data[selections.variable]
+            data = data[selections.choices['variable_choices']['hourly']['Dynamical'][selections.variable]]
         elif selections.variable == "Precipitation (total)":
             data = data["RAINC"] + data["RAINNC"]
         elif selections.variable == "wind 10m magnitude":
@@ -98,14 +96,14 @@ def _get_as_shapely(location):
     )
 
 
-def _read_from_catalog(selections, location):
+def _read_from_catalog(selections, location, cat):
     """
     The primary and first data loading method, called by core.Application.generate, it returns
     a dataset (which can be quite large) containing everything requested by the user (which is
     stored in 'selections' and 'location').
     """
-    assert not selections.scenario[0] is None, "Please select at least one scenario."
-
+    assert not selections.scenario == [], "Please select as least one scenario."
+    
     if location.area_subset == "lat/lon":
         geom = _get_as_shapely(location)
         assert (
@@ -136,25 +134,25 @@ def _read_from_catalog(selections, location):
     if selections.append_historical:
         assert True in ["SSP" in one for one in app.selections.scenario], "Please also select at least one SSP to which the historical simulation should be appended."
         one_scenario = "Historical Climate"
-        files_by_scenario = _get_file_list(selections, one_scenario)
-        historical = _open_and_concat(files_by_scenario, selections, ds_region)
+        files_by_scenario = _get_file_list(selections, one_scenario, cat)
+        historical = _open_and_concat(files_by_scenario, selections, cat, ds_region)
 
     all_files_list = []
     for one_scenario in selections.scenario:
         if selections.append_historical:
             if "SSP" in one_scenario:
-                files_by_scenario = _get_file_list(selections, one_scenario)
-                temp = _open_and_concat(files_by_scenario, selections, ds_region)
+                files_by_scenario = _get_file_list(selections, one_scenario, cat)
+                temp = _open_and_concat(files_by_scenario, selections, cat, ds_region)
                 temp = xr.concat([historical, temp], dim="time")
                 temp.name = "Historical + " + one_scenario
             elif one_scenario != "Historical Climate":
-                files_by_scenario = _get_file_list(selections, one_scenario)
-                temp = _open_and_concat(files_by_scenario, selections, ds_region)
+                files_by_scenario = _get_file_list(selections, one_scenario, cat)
+                temp = _open_and_concat(files_by_scenario, selections, cat, ds_region)
                 temp.name = one_scenario
 
         else:
-            files_by_scenario = _get_file_list(selections, one_scenario)
-            temp = _open_and_concat(files_by_scenario, selections, ds_region)
+            files_by_scenario = _get_file_list(selections, one_scenario, cat)
+            temp = _open_and_concat(files_by_scenario, selections, cat, ds_region)
             temp.name = one_scenario
 
         all_files_list.append(temp)

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -144,7 +144,6 @@ class LocSelectorArea(param.Parameterized):
         self.param["cached_area"].objects = list(
             self._geography_choose["states"].keys()
         )
-        self.cached_area = "CA"
 
     _wrf_bb = {
         "45 km": Polygon(
@@ -340,6 +339,7 @@ class DataSelector(param.Parameterized):
         self.resolution = self.choices["resolutions"][0]
         _list_of_scenarios = list(self.choices["scenarios"]["45 km"].keys())
         self.param["scenario"].objects = _list_of_scenarios
+        self.scenario = ["Historical Climate"]
         self.param["variable"].objects = self.choices["variable_choices"]["hourly"][
             "Dynamical"
         ]

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -132,11 +132,16 @@ class LocSelectorArea(param.Parameterized):
     # would be nice if these lat/lon sliders were greyed-out when lat/lon subset option is not selected
     latitude = param.Range(default=(32.5, 42), bounds=(10, 67))
     longitude = param.Range(default=(-125.5, -114), bounds=(-156.82317, -84.18701))
-    _geographies = Boundaries()
-    _geography_choose = _geographies.boundary_dict()
     cached_area = param.ObjectSelector(
-        default="CA", objects=list(_geography_choose["states"].keys())
+        objects=dict()
     )
+
+    def __init__(self,**params):
+        super().__init__(**params)
+        self._geographies = Boundaries()
+        self._geography_choose = self._geographies.boundary_dict()
+        self.param["cached_area"].objects = list(self._geography_choose["states"].keys())
+        self.cached_area = "CA"
 
     @param.depends("area_subset", watch=True)
     def _update_cached_area(self):
@@ -249,14 +254,17 @@ class DataSelector(param.Parameterized):
     #    self.variable = variables[0]
 
     scenario = param.ListSelector(
-        objects=dict(), allow_None=True
+        objects=dict()
     )
-    resolution = param.ObjectSelector(objects=dict())
+    resolution = param.ObjectSelector(
+        objects=dict()
+    )
     append_historical = param.Boolean(default=False)
 
     def __init__(self,**params):
         super().__init__(**params)
         self.param["resolution"].objects = self.choices["resolutions"]
+        self.resolution = self.choices["resolutions"][0]
         _list_of_scenarios = list(self.choices["scenarios"]["45 km"].keys())
         self.param["scenario"].objects = _list_of_scenarios
         self.param["variable"].objects = self.choices['variable_choices']["hourly"]["Dynamical"]
@@ -311,7 +319,7 @@ def _display_select(selections, location, location_type="area average"):
 
 # === For export functionality ==========================================================
 
-class UserFileChoices:
+class UserFileChoices():
 
     # reserved for later: text boxes for dataset to export
     # as well as a file name

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -53,7 +53,7 @@ class Boundaries:
     def __init__(self):
         self._us_states = regionmask.defined_regions.natural_earth_v4_1_0.us_states_50
         self._ca_counties = gpd.read_file(
-            "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE=06&f=geojson"
+            "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE='06'&f=geojson"
         )
         self._ca_counties = self._ca_counties.sort_values("NAME")
 

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -53,7 +53,7 @@ class Boundaries:
     def __init__(self):
         self._us_states = regionmask.defined_regions.natural_earth_v4_1_0.us_states_50
         self._ca_counties = gpd.read_file(
-            "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE='06'&f=geojson"
+            "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE=06&f=geojson"
         )
         self._ca_counties = self._ca_counties.sort_values("NAME")
 

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -132,15 +132,15 @@ class LocSelectorArea(param.Parameterized):
     # would be nice if these lat/lon sliders were greyed-out when lat/lon subset option is not selected
     latitude = param.Range(default=(32.5, 42), bounds=(10, 67))
     longitude = param.Range(default=(-125.5, -114), bounds=(-156.82317, -84.18701))
-    cached_area = param.ObjectSelector(
-        objects=dict()
-    )
+    cached_area = param.ObjectSelector(objects=dict())
 
-    def __init__(self,**params):
+    def __init__(self, **params):
         super().__init__(**params)
         self._geographies = Boundaries()
         self._geography_choose = self._geographies.boundary_dict()
-        self.param["cached_area"].objects = list(self._geography_choose["states"].keys())
+        self.param["cached_area"].objects = list(
+            self._geography_choose["states"].keys()
+        )
         self.cached_area = "CA"
 
     @param.depends("area_subset", watch=True)
@@ -233,9 +233,7 @@ class DataSelector(param.Parameterized):
     """
 
     choices = param.Dict(dict())
-    variable = param.ObjectSelector(
-        default="T2", objects=dict()
-    )
+    variable = param.ObjectSelector(default="T2", objects=dict())
     timescale = param.ObjectSelector(
         default="monthly", objects=["hourly", "daily", "monthly"]
     )  # for WRF, will just coarsen data to start
@@ -253,21 +251,19 @@ class DataSelector(param.Parameterized):
     #    self.param['variable'].objects = variables
     #    self.variable = variables[0]
 
-    scenario = param.ListSelector(
-        objects=dict()
-    )
-    resolution = param.ObjectSelector(
-        objects=dict()
-    )
+    scenario = param.ListSelector(objects=dict())
+    resolution = param.ObjectSelector(objects=dict())
     append_historical = param.Boolean(default=False)
 
-    def __init__(self,**params):
+    def __init__(self, **params):
         super().__init__(**params)
         self.param["resolution"].objects = self.choices["resolutions"]
         self.resolution = self.choices["resolutions"][0]
         _list_of_scenarios = list(self.choices["scenarios"]["45 km"].keys())
         self.param["scenario"].objects = _list_of_scenarios
-        self.param["variable"].objects = self.choices['variable_choices']["hourly"]["Dynamical"]
+        self.param["variable"].objects = self.choices["variable_choices"]["hourly"][
+            "Dynamical"
+        ]
         self.variable = "2m Air Temperature"
 
     @param.depends("resolution", "append_historical", watch=True)
@@ -317,48 +313,53 @@ def _display_select(selections, location, location_type="area average"):
     )
     return pn.Column(first_row, location_chooser)
 
+
 # === For export functionality ==========================================================
 
-class UserFileChoices():
+
+class UserFileChoices:
 
     # reserved for later: text boxes for dataset to export
     # as well as a file name
     # data_var_name = param.String()
     # output_file_name = param.String()
-    
+
     def __init__(self):
-        self._export_format_choices = ["Pick a file format" , "CSV" ,
-                                      "GeoTIFF" , "NetCDF" ]
+        self._export_format_choices = ["Pick a file format", "CSV", "GeoTIFF", "NetCDF"]
+
 
 class FileTypeSelector(param.Parameterized):
     """
     If the user wants to export an xarray dataset, they can choose
-    their preferred format here. Produces a panel from which to select a 
+    their preferred format here. Produces a panel from which to select a
     supported file type.
     """
+
     user_options = UserFileChoices()
-    output_file_format = param.ObjectSelector(objects=user_options._export_format_choices)
+    output_file_format = param.ObjectSelector(
+        objects=user_options._export_format_choices
+    )
 
     def _export_file_type(self):
         """Updates the 'user_export_format' object to be the format specified by the user."""
         user_export_format = self.output_file_format
-        
+
+
 def _user_export_select(user_export_format):
     """
     Called by 'export' at the end of the workflow. Displays panel
     from which to select the export file format. Modifies 'user_export_format' object, which is used
     by data_export() to export data to the user in their specified format.
     """
-    
-    data_to_export = pn.widgets.TextInput(name="Data to export", 
-                                placeholder="Type name of dataset here")
-    
+
+    data_to_export = pn.widgets.TextInput(
+        name="Data to export", placeholder="Type name of dataset here"
+    )
+
     # reserved for later: text boxes for dataset to export
     # as well as a file name
-    # file_name = pn.widgets.TextInput(name='File name', 
-    #                                 placeholder='Type file name here')    
+    # file_name = pn.widgets.TextInput(name='File name',
+    #                                 placeholder='Type file name here')
     # file_input_col = pn.Column(user_export_format.param, data_to_export, file_name)
 
-
     return pn.Row(user_export_format.param)
-

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -352,7 +352,7 @@ class DataSelector(param.Parameterized):
         than 3km for WRF eventually). Also ensures that "Historical Climate" is not
         redundantly displayed when "Append historical" is also selected.
         """
-        _list_of_scenarios = list(self._choices._scenarios[self.resolution].keys())
+        _list_of_scenarios = list(self.choices["scenarios"][self.resolution].keys())
         self.param["scenario"].objects = _list_of_scenarios
         if self.append_historical and self.scenario is not None:
             if "Historical Climate" in self.scenario:

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -1,6 +1,5 @@
 import param
 import panel as pn
-import intake
 from shapely.geometry import box  # , Point, Polygon
 from matplotlib.figure import Figure
 import cartopy.crs as ccrs
@@ -219,105 +218,7 @@ class LocSelectorPoint(param.Parameterized):
     def _update_location(self):
         """Updates the 'location' object to be the point associated with the selected station."""
         location = _stations_database[self.cached_station]
-
-
-class CatalogContents:
-    def __init__(self):
-        # get the list of data variables from one of the zarr files:
-        self._cat = intake.open_catalog("https://cdcat.s3.amazonaws.com/cae.yaml")
-        _ds = self._cat[list(self._cat)[0]].to_dask()
-        _variable_choices_hourly_wrf = {
-            v.attrs["description"].capitalize(): k for k, v in _ds.data_vars.items()
-        }
-        _variable_choices_hourly_wrf.update(
-            {"Precipitation (total)": ""}
-        )  # which we'll derive from what's there
-        # remove some variables from the list, which will be superceded by higher quality hydrology
-        _to_drop = ["Surface runoff", "Subsurface runoff", "Snow water equivalent"]
-        [_variable_choices_hourly_wrf.pop(k) for k in _to_drop]
-        # give better names to some descriptions, and reorder:
-        _variable_choices_hourly_wrf["Surface Pressure"] = _variable_choices_hourly_wrf[
-            "Sfc pressure"
-        ]
-        _variable_choices_hourly_wrf.pop("Sfc pressure")
-        _variable_choices_hourly_wrf[
-            "2m Air Temperature"
-        ] = _variable_choices_hourly_wrf["Temp at 2 m"]
-        _variable_choices_hourly_wrf.pop("Temp at 2 m")
-        _variable_choices_hourly_wrf[
-            "2m Water Vapor Mixing Ratio"
-        ] = _variable_choices_hourly_wrf["Qv at 2 m"]
-        _variable_choices_hourly_wrf.pop("Qv at 2 m")
-        _variable_choices_hourly_wrf[
-            "West-East component of Wind at 10m"
-        ] = _variable_choices_hourly_wrf["U at 10 m"]
-        _variable_choices_hourly_wrf.pop("U at 10 m")
-        _variable_choices_hourly_wrf[
-            "North-South component of Wind at 10m"
-        ] = _variable_choices_hourly_wrf["V at 10 m"]
-        _variable_choices_hourly_wrf.pop("V at 10 m")
-        _variable_choices_hourly_wrf[
-            "Snowfall (snow and ice)"
-        ] = _variable_choices_hourly_wrf["Accumulated total grid scale snow and ice"]
-        _variable_choices_hourly_wrf.pop("Accumulated total grid scale snow and ice")
-        _move_to_end = [k for k in _variable_choices_hourly_wrf if "Instantaneous" in k]
-        for k in _move_to_end:
-            _variable_choices_hourly_wrf[k] = _variable_choices_hourly_wrf.pop(k)
-
-        # expand this dictionary to also be dependent on LOCA vs WRF:
-        _variable_choices_daily_loca = [
-            "Temperature",
-            "Maximum Relative Humidity",
-            "Minimum Relative Humidity",
-            "Solar Radiation",
-            "Wind Speed",
-            "Wind Direction",
-            "Precipitation",
-        ]
-        _variable_choices_hourly_loca = ["Temperature", "Precipitation"]
-
-        _variable_choices_hourly = {
-            "Dynamical": _variable_choices_hourly_wrf,
-            "Statistical": _variable_choices_hourly_loca,
-        }
-        _variable_choices_daily = {
-            "Dynamical": _variable_choices_hourly_wrf,
-            "Statistical": _variable_choices_daily_loca,
-        }
-
-        self._variable_choices = {
-            "hourly": _variable_choices_hourly,
-            "daily": _variable_choices_daily,
-        }
-
-        # hard-coded options:
-        self._scenario_choices = {
-            "historical": "Historical Climate",
-            "": "Historical Reconstruction",
-            "ssp245": "SSP 2-4.5 -- Middle of the Road",
-            "ssp370": "SSP 3-7.0 -- Business as Usual",
-            "ssp585": "SSP 5-8.5 -- Burn it All",
-        }
-
-        self._resolutions = list(
-            set(e.metadata["nominal_resolution"] for e in self._cat.values())
-        )
-
-        _scenario_list = []
-        for resolution in self._resolutions:
-            _temp = list(
-                set(
-                    e.metadata["experiment_id"]
-                    for e in self._cat.values()
-                    if e.metadata["nominal_resolution"] == resolution
-                )
-            )
-            _temp.sort()  # consistent order
-            _scenario_subset = [(self._scenario_choices[e], e) for e in _temp]
-            _scenario_subset = dict(_scenario_subset)
-            _scenario_list.append((resolution, _scenario_subset))
-        self._scenarios = dict(_scenario_list)
-
+        
 
 class DataSelector(param.Parameterized):
     """
@@ -326,9 +227,9 @@ class DataSelector(param.Parameterized):
     UI could in principle be used to update these parameters instead.
     """
 
-    _choices = CatalogContents()
+    choices = param.Dict(dict())
     variable = param.ObjectSelector(
-        default="T2", objects=_choices._variable_choices["hourly"]["Dynamical"]
+        default="T2", objects=dict()
     )
     timescale = param.ObjectSelector(
         default="monthly", objects=["hourly", "daily", "monthly"]
@@ -348,14 +249,22 @@ class DataSelector(param.Parameterized):
     #    self.variable = variables[0]
 
     scenario = param.ListSelector(
-        objects=list(_choices._scenarios["45 km"].keys()), allow_None=True
+        objects=dict(), allow_None=True
     )
-    resolution = param.ObjectSelector(default="45 km", objects=_choices._resolutions)
+    resolution = param.ObjectSelector(objects=dict())
     append_historical = param.Boolean(default=False)
+
+    def __init__(self,**params):
+        super().__init__(**params)
+        self.param["resolution"].objects = self.choices["resolutions"]
+        _list_of_scenarios = list(self.choices["scenarios"]["45 km"].keys())
+        self.param["scenario"].objects = _list_of_scenarios
+        self.param["variable"].objects = self.choices['variable_choices']["hourly"]["Dynamical"]
+        self.variable = "2m Air Temperature"
 
     @param.depends("resolution", "append_historical", watch=True)
     def _update_scenarios(self):
-        _list_of_scenarios = list(self._choices._scenarios[self.resolution].keys())
+        _list_of_scenarios = list(self.choices["scenarios"][self.resolution].keys())
         if self.append_historical:
             if "Historical Climate" in _list_of_scenarios:
                 _list_of_scenarios.remove("Historical Climate")


### PR DESCRIPTION
The primary purpose of this PR is to speed up the import of climakitae. It achieves this by:
- delaying the reading of the catalog to the call to ck.Application()
- delaying the reading of area-selection shapefiles to ck.Application()
As a result, ck.Application() is slower to execute, but climakitae imports immediately, as one might expect it to.

This was accomplished by learning to pass parameter values to classes that inherit from param.Parameterized, and adding an __init__ on top of the inherited one from the metaclass for both DataSelector and LocSelectorArea classes in selectors.py. 

Then the resulting changes in core.py and data_loaders.py were brought into agreement with the new data organization. The catalog is read in core.py now, and a get_catalog_contents function was added there to get a dictionary of choices to pass to select(); this is in place of the data class that held the same content previously (plus the catalog) in selectors.py
