### PR TITLE
Reproject watershed polygon to WGS84 before regionmask

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -2,6 +2,7 @@ import xarray as xr
 import cartopy.crs as ccrs
 import pyproj
 from shapely.geometry import box
+from shapely.ops import transform
 import regionmask
 import intake
 import numpy as np
@@ -137,6 +138,10 @@ def _read_from_catalog(selections, location):
         if location.area_subset == "CA watersheds":
             shape = location._geographies._ca_watersheds
             shape = shape[shape["OBJECTID"] == shape_index].iloc[0].geometry
+            wgs84 = pyproj.CRS('EPSG:4326')
+            psdo_merc = pyproj.CRS('EPSG:3857')
+            project = pyproj.Transformer.from_crs(psdo_merc, wgs84, always_xy=True).transform
+            shape = transform(project, shape)
         elif location.area_subset == "CA counties":
             shape = location._geographies._ca_counties
             shape = shape[shape.index == shape_index].iloc[0].geometry


### PR DESCRIPTION
This PR reprojects the Watershed shape selected from GUI from Pseudo Mercator to WGS84 to be compatible with the other boundary files used.

I have tested this on the HUB. I picked the "Carrizo Plain" watershed and works fine for 3km and 9km, but the 45km returns the "Insufficient Gridcells" assertion. I guess that is because the watershed is in 1 cell and not getting the centroid? Or some similar behavior (not majority?). Is this the behavior we want or should we work on having it return any cells it intersects instead?

Please test this in your own environments as well. Thanks.