### PR TITLE
Rewired Watersheds with WGS84 Geojson and stopped reprojection

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -140,10 +140,6 @@ def _read_from_catalog(selections, location, cat):
         if location.area_subset == "CA watersheds":
             shape = location._geographies._ca_watersheds
             shape = shape[shape["OBJECTID"] == shape_index].iloc[0].geometry
-            wgs84 = pyproj.CRS('EPSG:4326')
-            psdo_merc = pyproj.CRS('EPSG:3857')
-            project = pyproj.Transformer.from_crs(psdo_merc, wgs84, always_xy=True).transform
-            shape = transform(project, shape)
         elif location.area_subset == "CA counties":
             shape = location._geographies._ca_counties
             shape = shape[shape.index == shape_index].iloc[0].geometry

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -57,7 +57,7 @@ class Boundaries:
         )
         self._ca_counties = self._ca_counties.sort_values("NAME")
 
-        self._ca_watersheds_file = "https://gis.data.cnra.ca.gov/datasets/02ff4971b8084ca593309036fb72289c_0.zip?outSR=%7B%22latestWkid%22%3A3857%2C%22wkid%22%3A102100%7D"
+        self._ca_watersheds_file = "https://cal-adapt.github.io/cae-data/huc8_ca_simplified_wgs84.geojson"
         self._ca_watersheds = gpd.read_file(self._ca_watersheds_file)
         self._ca_watersheds = self._ca_watersheds.sort_values("Name")
 


### PR DESCRIPTION
This PR rewires the CA Watershed boundaries file to use a WGS84 geojson reprojection served out of a GitHub repo:

https://github.com/cal-adapt/cae-data

It then removes the unnecessary reprojection from the code base.