### PR TITLE
Plot overlay options

### DIFF
--- a/climakitae/__init__.py
+++ b/climakitae/__init__.py
@@ -1,1 +1,2 @@
 from .core import Application
+from .plotting import plot

--- a/climakitae/plotting.py
+++ b/climakitae/plotting.py
@@ -1,0 +1,35 @@
+import cartopy.crs as ccrs
+import hvplot.xarray
+import hvplot.pandas
+
+def plot(to_plot, overlay=None, overlay_dims=None):
+    """
+    Function for plotting climate data, with optional overlay point data.
+
+    Arguments:
+    to_plot -- xarray DataArray
+    overlay -- optional point data, pandas dataframe 
+    overlay_dims -- tuple indicating the names of the longitude and lattitude
+        variables in the overlay data. May be ("x", "y"), for example. Will 
+        default to ("lon", "lat") if None provided.
+    """
+
+    _groupby = [d for d in ['time','scenario','simulation'] if d in to_plot.dims]
+
+    # Make the gridded variable map
+    quadmesh_plot = to_plot.hvplot.quadmesh('lon', 'lat', 
+        groupby=_groupby, 
+        crs=ccrs.PlateCarree(),
+        projection=ccrs.Orthographic(-118, 40),
+        project=True,
+        rasterize=True,
+        coastline=True, 
+        features=['borders'])
+
+    # Add overlay points if provided
+    if overlay is not None:
+        overlay_dims = ("lon", "lat") if overlay_dims is None else overlay_dims
+        overlay_plot = overlay.hvplot.scatter(*overlay_dims, color="black")
+        return quadmesh_plot * overlay_plot
+    else:
+        return quadmesh_plot


### PR DESCRIPTION
This PR implements a `ck.plot()` function, which plots a gridded xarray variable, with optional overlay points.

Here is example code to render a plot, which relies on a CA power plant point data file. (Do we want to add this data file to the repo somewhere for example use?)

```python
import pandas as pd
import climakitae as ck

app = ck.Application()
app.select()

# make data selections

to_plot = app.retrieve()
to_plot = to_plot.compute()

# import example point data from CEC (power plants and substations available)
URLS = {
    'power_plants' : "https://opendata.arcgis.com/api/v3/datasets/4a702cd67be24ae7ab8173423a768e1b_0/downloads/data?format=csv&spatialRefId=4269&where=1%3D1",
    'substations' : "https://opendata.arcgis.com/api/v3/datasets/7f37f2535d3144e898a53b9385737ee0_0/downloads/data?format=csv&spatialRefId=3857&where=1%3D1"
}
power_plants = pd.read_csv(URLS['power_plants']).rename(columns = {'X':'lon', 'Y':'lat'})

# Call the plot function
ck.plot(to_plot, overlay=power_plants)
```

Notes/questions:
- I haven't been able to test this for a map of all of CA yet because of data retrieval issues, so I'm not sure how exactly it looks for large areas
- I added the function to "\_\_init\_\_.py" so that it can be called by `ck.plot()`. Is this okay? or should we have a plotting module we need to import, like `from climakitae import plotting` then call `plotting.plot()`? 
- Do we want to add options for labels or title for the provided overlay data (i.e. should the plot indicate that these are powerplants somewhere)?
- not sure about the aesthetics in general-- size, color, etc.
	
