### PR TITLE
Use S3 based parquet files to run subsetting plus code streamlining and cleanup

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -140,6 +140,9 @@ def _read_from_catalog(selections, location, cat):
 
     assert not selections.scenario == [], "Please select as least one scenario."
 
+    def set_subarea(boundary_dataset):
+        return boundary_dataset[boundary_dataset.index == shape_index].iloc[0].geometry
+
     if location.area_subset == "lat/lon":
         geom = _get_as_shapely(location)
         if not geom.is_valid:
@@ -154,12 +157,12 @@ def _read_from_catalog(selections, location, cat):
         shape_index = int(
             location._geography_choose[location.area_subset][location.cached_area]
         )
-        if location.area_subset == "CA watersheds":
-            shape = location._geographies._ca_watersheds
-            shape = shape[shape["OBJECTID"] == shape_index].iloc[0].geometry
+        if location.area_subset == "states":
+            shape = set_subarea(location._geographies._us_states)
         elif location.area_subset == "CA counties":
-            shape = location._geographies._ca_counties
-            shape = shape[shape.index == shape_index].iloc[0].geometry
+            shape = set_subarea(location._geographies._ca_counties)
+        elif location.area_subset == "CA watersheds":
+            shape = set_subarea(location._geographies._ca_watersheds)
         ds_region = regionmask.Regions(
             [shape], abbrevs=["geographic area"], name="area mask"
         )

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -157,10 +157,6 @@ def _read_from_catalog(selections, location, cat):
         if location.area_subset == "CA watersheds":
             shape = location._geographies._ca_watersheds
             shape = shape[shape["OBJECTID"] == shape_index].iloc[0].geometry
-            wgs84 = pyproj.CRS('EPSG:4326')
-            psdo_merc = pyproj.CRS('EPSG:3857')
-            project = pyproj.Transformer.from_crs(psdo_merc, wgs84, always_xy=True).transform
-            shape = transform(project, shape)
         elif location.area_subset == "CA counties":
             shape = location._geographies._ca_counties
             shape = shape[shape.index == shape_index].iloc[0].geometry

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -148,11 +148,6 @@ def _read_from_catalog(selections, location, cat):
         if not geom.is_valid:
             raise ValueError("Please go back to 'select' and choose a valid lat/lon range.")
         ds_region = regionmask.Regions([geom], abbrevs=["lat/lon box"], name="box mask")
-    elif location.area_subset == "states":
-        shape_index = int(
-            location._geography_choose[location.area_subset][location.cached_area]
-        )
-        ds_region = location._geographies._us_states[[shape_index]]
     elif location.area_subset != "none":
         shape_index = int(
             location._geography_choose[location.area_subset][location.cached_area]

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -256,7 +256,7 @@ class LocSelectorArea(param.Parameterized):
             ax.add_geometries(
                 [geometry], crs=ccrs.PlateCarree(), edgecolor="b", facecolor="None"
             )
-        elif location.area_subset != "none":
+        elif self.area_subset != "none":
             shape_index = int(
                 self._geography_choose[self.area_subset][self.cached_area]
             )

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -263,7 +263,7 @@ class LocSelectorArea(param.Parameterized):
             shape_index = int(
                 self._geography_choose[self.area_subset][self.cached_area]
             )
-            self._geographies._us_states[[shape_index]].plot(
+            self._geographies._us_states.iloc[[shape_index]].plot(
                 ax=ax, add_label=False, line_kws=dict(color="b")
             )
             mpl_pane.param.trigger("object")

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -6,8 +6,6 @@ from matplotlib.figure import Figure
 import matplotlib.ticker as ticker
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
-import regionmask
-import numpy as np
 import geopandas as gpd
 import pandas as pd
 import datetime as dt

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -255,7 +255,7 @@ class LocSelectorArea(param.Parameterized):
         def plot_subarea(boundary_dataset, extent, shape_index):
             ax.set_extent(extent, crs=xy)
             subarea = boundary_dataset[boundary_dataset.index == shape_index]
-            df_ae = county.to_crs(crs_proj4)
+            df_ae = subarea.to_crs(crs_proj4)
             df_ae.plot(ax=ax, color="b", zorder=2)
             mpl_pane.param.trigger("object")
 

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -256,36 +256,31 @@ class LocSelectorArea(param.Parameterized):
             ax.add_geometries(
                 [geometry], crs=ccrs.PlateCarree(), edgecolor="b", facecolor="None"
             )
-        elif self.area_subset == "states":
-            ax.set_extent([-130, -100, 25, 50], crs=xy)
+        elif location.area_subset != "none":
             shape_index = int(
                 self._geography_choose[self.area_subset][self.cached_area]
             )
-            df_ae = self._geographies._us_states.iloc[[shape_index]].to_crs(crs_proj4)
-            df_ae.plot(
-                ax=ax, line_kws=dict(color="b")
-            )
-            mpl_pane.param.trigger("object")
-        elif self.area_subset == "CA counties":
-            ax.set_extent([-125, -114, 31, 43], crs=xy)
-            parquetfile = self._geographies._ca_counties
-            shape_index = int(
-                self._geography_choose[self.area_subset][self.cached_area]
-            )
-            county = parquetfile[parquetfile.index == shape_index]
-            df_ae = county.to_crs(crs_proj4)
-            df_ae.plot(ax=ax, color="b", zorder=2)
-            mpl_pane.param.trigger("object")
-        elif self.area_subset == "CA watersheds":
-            ax.set_extent([-125, -114, 31, 43], crs=xy)
-            parquetfile = self._geographies._ca_watersheds
-            shape_index = int(
-                self._geography_choose[self.area_subset][self.cached_area]
-            )
-            basin = parquetfile[parquetfile["OBJECTID"] == shape_index]
-            df_ae = basin.to_crs(crs_proj4)
-            df_ae.plot(ax=ax, color="b", zorder=2)
-            mpl_pane.param.trigger("object")
+            if self.area_subset == "states":
+                ax.set_extent([-130, -100, 25, 50], crs=xy)
+                parquetfile = self._geographies._us_states
+                state = parquetfile[parquetfile.index == shape_index]
+                df_ae = state.to_crs(crs_proj4)
+                df_ae.plot(ax=ax, color="b", zorder=2)
+                mpl_pane.param.trigger("object")
+            elif self.area_subset == "CA counties":
+                ax.set_extent([-125, -114, 31, 43], crs=xy)
+                parquetfile = self._geographies._ca_counties
+                county = parquetfile[parquetfile.index == shape_index]
+                df_ae = county.to_crs(crs_proj4)
+                df_ae.plot(ax=ax, color="b", zorder=2)
+                mpl_pane.param.trigger("object")
+            elif self.area_subset == "CA watersheds":
+                ax.set_extent([-125, -114, 31, 43], crs=xy)
+                parquetfile = self._geographies._ca_watersheds
+                basin = parquetfile[parquetfile["OBJECTID"] == shape_index]
+                df_ae = basin.to_crs(crs_proj4)
+                df_ae.plot(ax=ax, color="b", zorder=2)
+                mpl_pane.param.trigger("object")
 
         return mpl_pane
 

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -252,7 +252,7 @@ class LocSelectorArea(param.Parameterized):
         )
         mpl_pane = pn.pane.Matplotlib(fig0, dpi=144)
 
-        def plot_subarea(boundary_dataset, extent, shape_index):
+        def plot_subarea(boundary_dataset, extent):
             ax.set_extent(extent, crs=xy)
             subarea = boundary_dataset[boundary_dataset.index == shape_index]
             df_ae = subarea.to_crs(crs_proj4)
@@ -269,11 +269,11 @@ class LocSelectorArea(param.Parameterized):
                 self._geography_choose[self.area_subset][self.cached_area]
             )
             if self.area_subset == "states":
-                plot_subarea(self._geographies._us_states, [-130, -100, 25, 50], shape_index)
+                plot_subarea(self._geographies._us_states, [-130, -100, 25, 50])
             elif self.area_subset == "CA counties":
-                plot_subarea(self._geographies._ca_counties, [-125, -114, 31, 43], shape_index)
+                plot_subarea(self._geographies._ca_counties, [-125, -114, 31, 43])
             elif self.area_subset == "CA watersheds":
-                plot_subarea(self._geographies._ca_watersheds, [-125, -114, 31, 43], shape_index)
+                plot_subarea(self._geographies._ca_watersheds, [-125, -114, 31, 43])
 
         return mpl_pane
 

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -261,9 +261,8 @@ class LocSelectorArea(param.Parameterized):
             shape_index = int(
                 self._geography_choose[self.area_subset][self.cached_area]
             )
-            self._geographies._us_states.iloc[[shape_index]].plot(
-                ax=ax, add_label=False, line_kws=dict(color="b")
-            )
+            df_ae = self._geographies._us_states.iloc[[shape_index]].to_crs(crs_proj4)
+            df_ae.plot(ax=ax, color="b", zorder=2)
             mpl_pane.param.trigger("object")
         elif self.area_subset == "CA counties":
             ax.set_extent([-125, -114, 31, 43], crs=xy)

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -267,21 +267,21 @@ class LocSelectorArea(param.Parameterized):
             mpl_pane.param.trigger("object")
         elif self.area_subset == "CA counties":
             ax.set_extent([-125, -114, 31, 43], crs=xy)
-            shapefile = self._geographies._ca_counties
+            parquetfile = self._geographies._ca_counties
             shape_index = int(
                 self._geography_choose[self.area_subset][self.cached_area]
             )
-            county = shapefile[shapefile.index == shape_index]
+            county = parquetfile[parquetfile.index == shape_index]
             df_ae = county.to_crs(crs_proj4)
             df_ae.plot(ax=ax, color="b", zorder=2)
             mpl_pane.param.trigger("object")
         elif self.area_subset == "CA watersheds":
             ax.set_extent([-125, -114, 31, 43], crs=xy)
-            shapefile = self._geographies._ca_watersheds
+            parquetfile = self._geographies._ca_watersheds
             shape_index = int(
                 self._geography_choose[self.area_subset][self.cached_area]
             )
-            basin = shapefile[shapefile["OBJECTID"] == shape_index]
+            basin = parquetfile[parquetfile["OBJECTID"] == shape_index]
             df_ae = basin.to_crs(crs_proj4)
             df_ae.plot(ax=ax, color="b", zorder=2)
             mpl_pane.param.trigger("object")

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -95,7 +95,7 @@ class Boundaries:
         Returns a lookup dictionary for CA watersheds that references the geoparquet file.
         """
         return pd.Series(
-            self._ca_watersheds["OBJECTID"].values, index=self._ca_watersheds["Name"]
+            self._ca_watersheds.index, index=self._ca_watersheds["Name"]
         ).to_dict()
 
     def boundary_dict(self):
@@ -251,6 +251,14 @@ class LocSelectorArea(param.Parameterized):
             color="k",
         )
         mpl_pane = pn.pane.Matplotlib(fig0, dpi=144)
+
+        def plot_subarea(boundary_dataset, extent, shape_index):
+            ax.set_extent(extent, crs=xy)
+            subarea = boundary_dataset[boundary_dataset.index == shape_index]
+            df_ae = county.to_crs(crs_proj4)
+            df_ae.plot(ax=ax, color="b", zorder=2)
+            mpl_pane.param.trigger("object")
+
         if self.area_subset == "lat/lon":
             ax.set_extent([-150, -88, 8, 66], crs=xy)
             ax.add_geometries(
@@ -261,26 +269,11 @@ class LocSelectorArea(param.Parameterized):
                 self._geography_choose[self.area_subset][self.cached_area]
             )
             if self.area_subset == "states":
-                ax.set_extent([-130, -100, 25, 50], crs=xy)
-                parquetfile = self._geographies._us_states
-                state = parquetfile[parquetfile.index == shape_index]
-                df_ae = state.to_crs(crs_proj4)
-                df_ae.plot(ax=ax, color="b", zorder=2)
-                mpl_pane.param.trigger("object")
+                plot_subarea(self._geographies._us_states, [-130, -100, 25, 50], shape_index)
             elif self.area_subset == "CA counties":
-                ax.set_extent([-125, -114, 31, 43], crs=xy)
-                parquetfile = self._geographies._ca_counties
-                county = parquetfile[parquetfile.index == shape_index]
-                df_ae = county.to_crs(crs_proj4)
-                df_ae.plot(ax=ax, color="b", zorder=2)
-                mpl_pane.param.trigger("object")
+                plot_subarea(self._geographies._ca_counties, [-125, -114, 31, 43], shape_index)
             elif self.area_subset == "CA watersheds":
-                ax.set_extent([-125, -114, 31, 43], crs=xy)
-                parquetfile = self._geographies._ca_watersheds
-                basin = parquetfile[parquetfile["OBJECTID"] == shape_index]
-                df_ae = basin.to_crs(crs_proj4)
-                df_ae.plot(ax=ax, color="b", zorder=2)
-                mpl_pane.param.trigger("object")
+                plot_subarea(self._geographies._ca_watersheds, [-125, -114, 31, 43], shape_index)
 
         return mpl_pane
 

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -56,15 +56,10 @@ _cached_stations = [
 # === Select ===================================
 class Boundaries:
     def __init__(self):
-        self._us_states = regionmask.defined_regions.natural_earth_v4_1_0.us_states_50
-        self._ca_counties = gpd.read_file(
-            "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE='06'&f=geojson"
-        )
-        self._ca_counties = self._ca_counties.sort_values("NAME")
-
-        self._ca_watersheds_file = "https://gis.data.cnra.ca.gov/datasets/02ff4971b8084ca593309036fb72289c_0.zip?outSR=%7B%22latestWkid%22%3A3857%2C%22wkid%22%3A102100%7D"
-        self._ca_watersheds = gpd.read_file(self._ca_watersheds_file)
-        self._ca_watersheds = self._ca_watersheds.sort_values("Name")
+        self._cat = intake.open_catalog("https://cadcat.s3.amazonaws.com/parquet/catalog.yaml")
+        self._us_states = self._cat.states.read()
+        self._ca_counties = self._cat.counties.read().sort_values("NAME")
+        self._ca_watersheds = self._cat.huc8.read().sort_values("Name")
 
     def get_us_states(self):
         """

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -263,6 +263,9 @@ class LocSelectorArea(param.Parameterized):
             )
             df_ae = self._geographies._us_states.iloc[[shape_index]].to_crs(crs_proj4)
             df_ae.plot(ax=ax, color="b", zorder=2)
+            df_ae.plot(
+                ax=ax, add_label=False, line_kws=dict(color="b")
+            )
             mpl_pane.param.trigger("object")
         elif self.area_subset == "CA counties":
             ax.set_extent([-125, -114, 31, 43], crs=xy)

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -262,9 +262,8 @@ class LocSelectorArea(param.Parameterized):
                 self._geography_choose[self.area_subset][self.cached_area]
             )
             df_ae = self._geographies._us_states.iloc[[shape_index]].to_crs(crs_proj4)
-            df_ae.plot(ax=ax, color="b", zorder=2)
             df_ae.plot(
-                ax=ax, add_label=False, line_kws=dict(color="b")
+                ax=ax, line_kws=dict(color="b")
             )
             mpl_pane.param.trigger("object")
         elif self.area_subset == "CA counties":


### PR DESCRIPTION
This PR tackles replacing the current boundary data with parquet files based within an intake catalog on CA:AE S3 bucket. It modifies `selectors.py` and `data_loaders.py`. In selectors in replaces the Boundary data refs with the S3 parquet files and redos how the states dictionary is created removing regionmask and numpy as dependencies. The watersheds dataset also switches to using the index instead of the objectid as a primary key. This is so ALL subset area types can be handled in a similar way and the code compacted into a function call and logic streamlined. The same treatment of code compacting and streamlining is done in `data_loaders` and logic is same as in `selectors`.