### PR TITLE
New feature: app.view()

### DIFF
--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -48,7 +48,7 @@ class Application(object):
         return _read_from_catalog(self.selections, self.location, self._cat)
     
     # === View =====================================
-    def view(self, data, lat_lon=True, width=None, height=None, cmap="viridis"): 
+    def view(self, data, lat_lon=True, width=None, height=None, cmap="inferno_r"): 
         """Create a generic visualization of the data
     
         Args: 

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -48,14 +48,25 @@ class Application(object):
         return _read_from_catalog(self.selections, self.location, self._cat)
     
     # === View =====================================
-    def view(self, data): 
-        """Create generic visualization of data"""
-        return _visualize(data)
+    def view(self, data, lat_lon=True, width=None, height=None): 
+        """Create a generic visualization of the data
+    
+        Args: 
+            data (xr.DataArray)
+            lat_lon (boolean): reproject to lat/lon coords? (default to True) 
+            width (int): width of plot (default to hvplot.image default) 
+            height (int): hight of plot (default to hvplot.image default) 
+        
+        Returns: 
+            hvplot.image()
+
+        """
+        return _visualize(data, lat_lon=lat_lon, width=width, height=height)
     
     # === Explore ===================================
     def explore(self): 
         """
-        Calls a method to display a plot of the data 
+        Display warming levels panel 
         """
         return _display_warming_levels(self.selections, self.location, self._cat)
     

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -48,7 +48,7 @@ class Application(object):
         return _read_from_catalog(self.selections, self.location, self._cat)
     
     # === View =====================================
-    def view(self, data, lat_lon=True, width=None, height=None): 
+    def view(self, data, lat_lon=True, width=None, height=None, cmap="viridis"): 
         """Create a generic visualization of the data
     
         Args: 
@@ -56,12 +56,13 @@ class Application(object):
             lat_lon (boolean): reproject to lat/lon coords? (default to True) 
             width (int): width of plot (default to hvplot.image default) 
             height (int): hight of plot (default to hvplot.image default) 
+            cmap (str): colormap to apply to data (default to "viridis"); applies only to mapped data 
         
         Returns: 
             hvplot.image()
 
         """
-        return _visualize(data, lat_lon=lat_lon, width=width, height=height)
+        return _visualize(data, lat_lon=lat_lon, width=width, height=height, cmap=cmap)
     
     # === Explore ===================================
     def explore(self): 

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -10,6 +10,7 @@ from .data_loaders import _read_from_catalog
 from .data_export import _export_to_user
 from .utils import _read_var_csv
 from .explore import _display_warming_levels
+from .view import _visualize
 import intake
 import pkg_resources # Import package data 
 CSV_FILE = pkg_resources.resource_filename('climakitae', 'data/variable_descriptions.csv')
@@ -45,6 +46,11 @@ class Application(object):
         """
         # to do: insert additional 'hang in there' statement if it's taking a while
         return _read_from_catalog(self.selections, self.location, self._cat)
+    
+    # === View =====================================
+    def view(self, data): 
+        """Create generic visualization of data"""
+        return _visualize(data)
     
     # === Explore ===================================
     def explore(self): 

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -11,7 +11,7 @@ from .data_export import _export_to_user
 from .utils import _read_var_csv
 from .explore import _display_warming_levels
 from .view import _visualize
-from .tmy import _display_tmy
+#from .tmy import _display_tmy
 import intake
 import pkg_resources # Import package data
 CSV_FILE = pkg_resources.resource_filename('climakitae', 'data/variable_descriptions.csv')

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -21,19 +21,21 @@ def _visualize(data, lat_lon=True, width=None, height=None):
     # Warn user about speed if passing a zarr to the function
     if data.chunks is not None: 
         warnings.warn("This function may be quite slow unless you call .compute() on your data before passing it to app.view()")
-        
-    # Raise warning if width or height not provided as a pair 
-    if (width is None and height is not None) or (height is None and width is not None): 
-        warnings.warn("You must pass both a width and a height. Setting to plotting defaults.")
-        
+          
     # Workflow if data contains spatial coordinates 
     if set(["x","y"]).issubset(set(data.dims)):
-
+        
         # Define colorbar label using variable and units 
         try: 
             clabel = data.name + " ("+data.attrs["units"]+")"
         except: # Try except just in case units attribute is missing from data 
             clabel = data.name
+            
+        # Set default width & height 
+        if width is None: 
+            width = 550
+        if height is None: 
+            height = 450
         
         # Reproject data to lat/lon
         if lat_lon == True:
@@ -43,34 +45,27 @@ def _visualize(data, lat_lon=True, width=None, height=None):
                 fill_value=np.nan
             ) 
         
-        # Create map with width/height arguments 
-        if width is not None and height is not None: 
-            _plot = data.hvplot.image(
-                x="x", y="y", 
-                grid=True, 
-                clabel=clabel, 
-                width=width, height=height
-            )
+        # Create map 
+        _plot = data.hvplot.image(
+            x="x", y="y", 
+            grid=True, 
+            clabel=clabel, 
+            width=width, 
+            height=height
+        )
         
-        # Create plot without width/height arguments
-        else: 
-            _plot = data.hvplot.image(
-                x="x", y="y", 
-                grid=True, 
-                clabel=clabel
-            )
-
     # Workflow if data contains only time dimension
     elif "time" in data.dims: 
-
-        # Create lineplot with width/height arguments 
-        if width is not None and height is not None: 
-            _plot = data.hvplot.line(x="time", width=width, height=height)
         
-        # Create plot without width/height arguments
-        else: 
-            _plot = data.hvplot.line(x="time")
-    
+        # Set default width & height 
+        if width is None: 
+            width = 600 
+        if height is None: 
+            height = 300
+
+        # Create lineplot
+        _plot = data.hvplot.line(x="time", width=width, height=height)
+
     # Error raised if data does not contain [x,y] or time dimensions 
     else: 
         raise ValueError("Input data must contain valid spatial and/or time dimensions")

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -1,0 +1,14 @@
+import xarray as xr 
+import hvplot.xarray
+import holoviews as hv
+from holoviews import opts
+
+def _visualize(data): 
+    """Make single map"""
+    data_i = data.isel(time=0,scenario=0,simulation=0)
+    _plot = data_i.hvplot.image(
+        x="x", y="y", 
+        grid=True, 
+        title="Generic map"
+    )
+    return _plot

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -1,31 +1,78 @@
 import xarray as xr 
+import numpy as np
 import hvplot.xarray
+import warnings 
+from .utils import _reproject_data
 
-def _visualize(data): 
-    """Create a generic plot or map of the data"""
+def _visualize(data, lat_lon=True, width=None, height=None): 
+    """Create a generic visualization of the data
+
+    Args: 
+        data (xr.DataArray)
+        lat_lon (boolean): reproject to lat/lon coords? (default to True) 
+        width (int): width of plot (default to hvplot.image default) 
+        height (int): hight of plot (default to hvplot.image default) 
+
+    Returns: 
+        hvplot.image()
+
+    """
     
+    # Warn user about speed if passing a zarr to the function
+    if data.chunks is not None: 
+        warnings.warn("This function may be quite slow unless you call .compute() on your data before passing it to app.view()")
+        
+    # Raise warning if width or height not provided as a pair 
+    if (width is None and height is not None) or (height is None and width is not None): 
+        warnings.warn("You must pass both a width and a height. Setting to plotting defaults.")
+        
     # Workflow if data contains spatial coordinates 
     if set(["x","y"]).issubset(set(data.dims)):
 
-        # Plotting inputs
-        non_spatial_dims = [dim for dim in data.dims if dim not in ["x","y"]]
+        # Define colorbar label using variable and units 
         try: 
             clabel = data.name + " ("+data.attrs["units"]+")"
         except: # Try except just in case units attribute is missing from data 
             clabel = data.name
-
-        # Create map 
-        _plot = data.hvplot.image(
-            x="x", y="y", 
-            grid=True, 
-            groupby=non_spatial_dims, 
-            clabel=clabel
-        )
+        
+        # Reproject data to lat/lon
+        if lat_lon == True:
+            data = _reproject_data(
+                xr_da = data, 
+                proj="EPSG:4326", 
+                fill_value=np.nan
+            ) 
+        
+        # Create map with width/height arguments 
+        if width is not None and height is not None: 
+            _plot = data.hvplot.image(
+                x="x", y="y", 
+                grid=True, 
+                clabel=clabel, 
+                width=width, height=height
+            )
+        
+        # Create plot without width/height arguments
+        else: 
+            _plot = data.hvplot.image(
+                x="x", y="y", 
+                grid=True, 
+                clabel=clabel
+            )
 
     # Workflow if data contains only time dimension
     elif "time" in data.dims: 
 
-        # Create lineplot
-        _plot = data.hvplot.line(x="time")
+        # Create lineplot with width/height arguments 
+        if width is not None and height is not None: 
+            _plot = data.hvplot.line(x="time", width=width, height=height)
         
+        # Create plot without width/height arguments
+        else: 
+            _plot = data.hvplot.line(x="time")
+    
+    # Error raised if data does not contain [x,y] or time dimensions 
+    else: 
+        raise ValueError("Input data must contain valid spatial and/or time dimensions")
+   
     return _plot

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -46,7 +46,8 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap="inferno_r"):
                     proj="EPSG:4326", 
                     fill_value=np.nan
                 ) 
-            except: # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error) 
+            except: # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error)
+                warnings.warn("Data reprojection to lat/lon failed. Using native x,y grid.")
                 pass 
         
         # Create map 

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -4,7 +4,7 @@ import hvplot.xarray
 import warnings 
 from .utils import _reproject_data
 
-def _visualize(data, lat_lon=True, width=None, height=None): 
+def _visualize(data, lat_lon=True, width=None, height=None, cmap="viridis"): 
     """Create a generic visualization of the data
 
     Args: 
@@ -12,6 +12,7 @@ def _visualize(data, lat_lon=True, width=None, height=None):
         lat_lon (boolean): reproject to lat/lon coords? (default to True) 
         width (int): width of plot (default to hvplot.image default) 
         height (int): hight of plot (default to hvplot.image default) 
+        cmap (str): colormap to apply to data (default to "viridis"); applies only to mapped data 
 
     Returns: 
         hvplot.image()
@@ -39,11 +40,15 @@ def _visualize(data, lat_lon=True, width=None, height=None):
         
         # Reproject data to lat/lon
         if lat_lon == True:
-            data = _reproject_data(
-                xr_da = data, 
-                proj="EPSG:4326", 
-                fill_value=np.nan
-            ) 
+            try: 
+                data = _reproject_data(
+                    xr_da = data, 
+                    proj="EPSG:4326", 
+                    fill_value=np.nan, 
+                    cmap=cmap
+                ) 
+            except: # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error) 
+                pass 
         
         # Create map 
         _plot = data.hvplot.image(

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -29,7 +29,7 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap="inferno_r"):
             
         # Must have more than one grid cell to generate a map 
         if (len(data["x"]) <= 1) and (len(data["y"]) <= 1):  
-            print("Your data contains only one grid cell. A plot will be created using a default method that may or may not have the spatial coordinates as the x and y axes.") # Warn user that plot may be weird 
+            print("Your data contains only one grid cell. A plot will be created using a default method that may or may not have spatial coordinates as the x and y axes.") # Warn user that plot may be weird 
             
             with warnings.catch_warnings():
                 

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -1,14 +1,31 @@
 import xarray as xr 
 import hvplot.xarray
-import holoviews as hv
-from holoviews import opts
 
 def _visualize(data): 
-    """Make single map"""
-    data_i = data.isel(time=0,scenario=0,simulation=0)
-    _plot = data_i.hvplot.image(
-        x="x", y="y", 
-        grid=True, 
-        title="Generic map"
-    )
+    """Create a generic plot or map of the data"""
+    
+    # Workflow if data contains spatial coordinates 
+    if set(["x","y"]).issubset(set(data.dims)):
+
+        # Plotting inputs
+        non_spatial_dims = [dim for dim in data.dims if dim not in ["x","y"]]
+        try: 
+            clabel = data.name + " ("+data.attrs["units"]+")"
+        except: # Try except just in case units attribute is missing from data 
+            clabel = data.name
+
+        # Create map 
+        _plot = data.hvplot.image(
+            x="x", y="y", 
+            grid=True, 
+            groupby=non_spatial_dims, 
+            clabel=clabel
+        )
+
+    # Workflow if data contains only time dimension
+    elif "time" in data.dims: 
+
+        # Create lineplot
+        _plot = data.hvplot.line(x="time")
+        
     return _plot

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -4,7 +4,7 @@ import hvplot.xarray
 import warnings 
 from .utils import _reproject_data
 
-def _visualize(data, lat_lon=True, width=None, height=None, cmap="viridis"): 
+def _visualize(data, lat_lon=True, width=None, height=None, cmap="inferno_r"): 
     """Create a generic visualization of the data
 
     Args: 
@@ -44,8 +44,7 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap="viridis"):
                 data = _reproject_data(
                     xr_da = data, 
                     proj="EPSG:4326", 
-                    fill_value=np.nan, 
-                    cmap=cmap
+                    fill_value=np.nan
                 ) 
             except: # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error) 
                 pass 
@@ -56,7 +55,8 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap="viridis"):
             grid=True, 
             clabel=clabel, 
             width=width, 
-            height=height
+            height=height, 
+            cmap=cmap
         )
         
     # Workflow if data contains only time dimension

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -68,6 +68,6 @@ def _visualize(data, lat_lon=True, width=None, height=None):
 
     # Error raised if data does not contain [x,y] or time dimensions 
     else: 
-        raise ValueError("Input data must contain valid spatial and/or time dimensions")
+        raise ValueError("Input data must contain valid spatial dimensions (x,y) and/or time dimensions")
    
     return _plot


### PR DESCRIPTION
### Basic info about this PR 
This new feature is designed to allow the user a quick glance at their selected data. It generates a map for data with spatial coordinates, and a line plot for data with only a time coordinate. 

At the moment it only works for DataArrays, but we could later add functionality to work with Datasets if we envision that as a part of our workflow. 

**Examples (screenshots) of the new feature is at the bottom!**

### Additional Information
As an example, the steps to call app.view() from the getting_started notebook would be: 
`app.select()`
`data = app.retrieve()`
`data = data.compute()`
`app.view(data) `

You don't _need_ to call `data.compute()` beforehand, but `app.view()` is quite slow without it. Thus, I've set up the code to raise a warning if you try to pass it a zarr store. It will still generate a map/plot, just warn the user that it may take a while. 

This PR includes a new (and beefy) function that reprojects 1D x,y data to 1D lat, lon data. This is used to generate the map if app.view is fed data with spatial coordinates. I had to do this instead of using the native lat,lon coords because the native coords are curvilinear, and the plotting library hvplot.image() requires 1D coordinates. 

For some reason, the reprojection occasionally fails for certain data selections. I've set `app.view` to plot the data anyways on the native x,y grid, and raise a warning that the projection didn't occur. 

### Function Arguments 
`app.view` allows for several user arguments to modify the plot/map shown. These arguments are: 
1. height & width of plot:  modify dimensions of map/plot
2. lat/lon: option to show the data in lat/lon or x/y (default to lat/lon) 
3. cmap: modify the colorbar (applies to maps only)

The colormap defaults to inferno_r (we could easily change this) 

### Examples
(1) Spatial data: 45km, surface pressure, entire grid

<img width="600" alt="45km surface pressure" src="https://user-images.githubusercontent.com/66140951/189425018-07a0c885-3541-4d51-b668-c37c088ecb1e.png">

(2) Temporal data: Area-averaged radiation data 

<img width="600" alt="line_plot" src="https://user-images.githubusercontent.com/66140951/189412681-a27e6055-8549-4914-8c3d-bf134f668aa1.png">

(3) Spatial data: 45km, 2m air temp with user-defined width, height, cmap, & projection (x,y)
<img width="600" alt="ca_map" src="https://user-images.githubusercontent.com/66140951/189419707-ebd6bc8d-c487-40cc-a7eb-0bf56b5477d7.png">

