### PR TITLE
Add back in grid_mapping attribute for relative humidity

### DIFF
--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -46,8 +46,8 @@ def _compute_relative_humidity(pressure, temperature, mixing_ratio, variable_nam
     # For some reason, the grid_mapping attr is lost by the metpy function
     # We want to add it back in to allow for projecting the data
     for var in [pressure, temperature, mixing_ratio]:
-        if “grid_mapping” in var.attrs:
-            rel_hum.attrs[“grid_mapping”] = var.attrs[“grid_mapping”]
+        if "grid_mapping" in var.attrs:
+            rel_hum.attrs["grid_mapping"] = var.attrs["grid_mapping"]
             
     return rel_hum
 

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -43,6 +43,12 @@ def _compute_relative_humidity(pressure, temperature, mixing_ratio, variable_nam
     rel_hum.name = variable_name
     rel_hum.attrs["description"] = "Relative humidity"
 
+    # For some reason, the grid_mapping attr is lost by the metpy function
+    # We want to add it back in to allow for projecting the data
+    for var in [pressure, temperature, mixing_ratio]:
+        if “grid_mapping” in var.attrs:
+            rel_hum.attrs[“grid_mapping”] = var.attrs[“grid_mapping”]
+            
     return rel_hum
 
 


### PR DESCRIPTION
**Information:** The grid_mapping attribute is lost for some reason by the metpy function that computes relative humidity in our derive_variables module. This is causing issues with reprojecting the data, as grid_mapping is used by rioxarray to determine information about the data's CRS. In this PR, I just add back in that attribute. 

**To test:** Try just selecting relative humidity from app.select() and make sure the attribute "grid_mapping" appears. 