### PR TITLE
Pin intake to 0.6.4 in environmental.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - geoviews=1.9.2
   - holoviews=1.14.6
   - hvplot=0.7.3
+  - intake=0.6.4
   - intake-xarray=0.5.0
   - jinja2=3.0.3
   - matplotlib=3.4.3


### PR DESCRIPTION
This PR will hopefully fix the broken test environment. `intake` was updated to `0.6.6` and since it wasn't pinned this was used by the runners in the github workflow. It is incompatible with the version of `intake_xarray` installed. 