### PR TITLE
Update environment.yml file to current HUB package versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,24 +3,22 @@ name: climakitae-tests
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
-  - black=22.3.0
+  - python=3.9.7
   - cartopy=0.20.1
-  - flake8=4.0.1
   - geopandas=0.10.2
   - geoviews=1.9.2
   - holoviews=1.14.6
   - hvplot=0.7.3
   - intake=0.6.4
   - intake-xarray=0.5.0
-  - jinja2=3.0.3
+  - jinja2=3.0.2
   - matplotlib=3.4.3
   - numpy=1.21.2
   - pandas=1.3.4
   - panel=0.12.4
   - param=1.11.1
   - pyproj=3.2.1
-  - pytest=7.1.2
+  - pytest=7.1.3
   - proj=8.1.1
   - rioxarray==0.7.1
   - s3fs=2021.10.1

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - hvplot=0.7.3
   - intake=0.6.4
   - intake-xarray=0.5.0
+  - jinja2=3.0.2
   - matplotlib=3.4.3
   - metpy=1.1.0
   - numpy=1.21.2

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - intake-xarray=0.5.0
   - jinja2=3.0.2
   - matplotlib=3.4.3
+  - metpy=1.1.0
   - numpy=1.21.2
   - pandas=1.3.4
   - panel=0.12.4

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - hvplot=0.7.3
   - intake=0.6.4
   - intake-xarray=0.5.0
-  - jinja2=3.0.2
   - matplotlib=3.4.3
   - metpy=1.1.0
   - numpy=1.21.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ holoviews==1.14.6
 hvplot==0.7.3
 intake==0.6.4
 intake-xarray==0.5.0
+jinja2==3.0.2
 lmoments3
 matplotlib==3.4.3
 metpy==1.1.0
@@ -14,6 +15,9 @@ numpy==1.21.2
 pandas==1.3.4
 panel==0.12.4
 param==1.11.1
+pyproj==3.2.1
+pytest==7.1.3
+proj==8.1.1
 rioxarray==0.7.1
 s3fs==2021.10.1
 scipy==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ geopandas==0.10.2
 geoviews==1.9.2
 holoviews==1.14.6
 hvplot==0.7.3
+intake==0.6.4
 intake-xarray==0.5.0
 lmoments3
 matplotlib==3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ holoviews==1.14.6
 hvplot==0.7.3
 intake==0.6.4
 intake-xarray==0.5.0
-jinja2==3.0.2
 lmoments3
 matplotlib==3.4.3
 metpy==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ holoviews==1.14.6
 hvplot==0.7.3
 intake==0.6.4
 intake-xarray==0.5.0
+jinja2==3.0.2
 lmoments3
 matplotlib==3.4.3
 metpy==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ intake==0.6.4
 intake-xarray==0.5.0
 lmoments3
 matplotlib==3.4.3
+metpy==1.1.0
 numpy==1.21.2
 pandas==1.3.4
 panel==0.12.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ install_requires =
     hvplot
     intake
     intake-xarray
-    jinja2
     lmoments3
     matplotlib
     metpy
@@ -33,7 +32,6 @@ install_requires =
     param
     pyproj
     pytest
-    proj
     rioxarray
     s3fs
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,9 @@ install_requires =
     geoviews
     holoviews
     hvplot
+    intake
     intake-xarray
+    jinja2
     lmoments3
     matplotlib
     metpy
@@ -29,8 +31,10 @@ install_requires =
     pandas
     panel
     param
+    pyproj
     pytest
-    regionmask
+    proj
+    rioxarray
     s3fs
     scipy
     shapely


### PR DESCRIPTION
This PR updates the `environment.yml` file used by the testing environment to the package versions currently on the CA:AE HUB server. Also removes `black` and `flake8` as they are not used at this time.

Also updates `requirements.txt` to match `environments.yml`