### PR TITLE
geotiff export refinement

### DIFF
--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -145,7 +145,7 @@ def export_to_geotiff(data_to_export,save_name,**kwargs):
                 print("Saving as multiband raster in which"+
                  " each band corresponds to a climate scenario.")
                 
-        non_spatial_dims = data_to_export.isel(x=0,y=0).squeeze.shape()
+        non_spatial_dims = data_to_export.isel(x=0,y=0).squeeze().shape
         
     print("Saving as GeoTIFF...")
     data_to_export.rio.to_raster(save_name)

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -144,9 +144,7 @@ def export_to_geotiff(data_to_export,save_name,**kwargs):
             if (len(data_to_export.scenario) > 1):
                 print("Saving as multiband raster in which"+
                  " each band corresponds to a climate scenario.")
-                
-        non_spatial_dims = data_to_export.isel(x=0,y=0).squeeze().shape
-        
+                    
     print("Saving as GeoTIFF...")
     data_to_export.rio.to_raster(save_name)
     meta_data_dict = ds_attrs

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -5,6 +5,7 @@ import dask
 import warnings
 import datetime
 import numpy as np
+import rasterio
 xr.set_options(keep_attrs=True)
 import os
 
@@ -62,9 +63,13 @@ def export_to_geotiff(data_to_export,save_name,**kwargs):
     if ('time' in data_to_export.dims):
         print("NOTE: Saving as multiband raster in which "+
              "each band corresponds to a time step.")
-        print("See metadata file for more information.")
     print("Saving as GeoTIFF...")
+    
     data_to_export.rio.to_raster(save_name)
+    meta_data_dict = data_to_export.attrs
+    with rasterio.open(save_name, 'r+') as raster:
+        raster.update_tags(**meta_data_dict)
+        raster.close()
     
 def _export_to_user(user_export_format,data_to_export,
                     file_name,**kwargs):
@@ -159,7 +164,7 @@ def _export_to_user(user_export_format,data_to_export,
             elif ("GeoTIFF" in req_format):
                 assert ndims <= 3,("Cannot export data with more than 3"+
                        " dimensions as GeoTIFF, please subset data"+
-                       " appropriately to fewer dimensions.")
+                       " appropriately to 3 or fewer dimensions.")
                 export_to_geotiff(data_to_export,save_name,**kwargs)    
                   
     return(print("Saved! You can find your file(s) in the panel to the left "+


### PR DESCRIPTION
### About this pull request

- adds global data array attributes as raster tags when exporting to GeoTIFF
- addresses various dimensionality issues:
  - GeoTIFFs can have a max of 3 dimensions and require both x and y dimensions
  - Allows z dimension to be time, simulation, or scenario and prints information accordingly 
  - Squeezes non-spatial singleton dimensions while retaining coordinate information (eg, which simulation was sampled) as possible

To test:

1. Export a data array (not a dataset - unless you want to test the error message thrown) as GeoTIFF.
-   Have some fun with it. Leave as many dimensions as you want, of whatever length you want. This will help test out the error codes! 

2. Then load the resulting .tif into the notebook and check the tags:
`import rasterio`
`ds = rasterio.open('file_name.tif')`
`ds.tags()`

the output should contain the same information as the variable attributes of the original data array, plus some extra information. 