### PR TITLE
Fix typo in environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pyproj=3.2.1
   - pytest=7.1.3
   - proj=8.1.1
-  - rioxarray==0.7.1
+  - rioxarray=0.7.1
   - s3fs=2021.10.1
   - scipy=1.7.1
   - shapely=1.7.1


### PR DESCRIPTION
I have 2 equal signs for a package version and that is not the right format for this file