### PR TITLE
Average Meteorological Year via app.explore2.amy()

### DIFF
--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -11,7 +11,6 @@ from .data_export import _export_to_user
 from .utils import _read_var_csv
 from .explore import _display_warming_levels
 from .explore2 import AppExplore
-# from .tmy import _display_tmy
 import intake
 import pkg_resources # Import package data
 CSV_FILE = pkg_resources.resource_filename('climakitae', 'data/variable_descriptions.csv')
@@ -55,15 +54,6 @@ class Application(object):
         Calls a method to display a plot of the data
         """
         return _display_warming_levels(self.selections, self.location, self._cat)
-
-
-    # # Goal is to have: app.explore.tmy()
-    # def tmy(self):
-    #     """
-    #     Calls a method to display a plot of hourly data
-    #     """
-    #     return _display_tmy(self.selections, self.location, self._cat)
-
 
     # === Export ======================================
     def export_as(self):

--- a/climakitae/explore2.py
+++ b/climakitae/explore2.py
@@ -1,12 +1,76 @@
 # A class for holding the app explore options
 
 import panel as pn
-from .tmy import _display_tmy
+import param
+from .tmy import _tmy_visualize
+
+
+class TMYParams(param.Parameterized):
+    """
+    An object that holds the "Data Options" parameters for the
+    explore.tmy panel.
+    """
+    def __init__(self, *args, **params):
+        super().__init__(*args, **params)
+
+        # Selectors defaults
+        self.selections.append_historical = False
+        self.selections.area_average = True
+        self.selections.resolution = "45 km"
+        self.selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
+        self.selections.time_slice = (1980,2100)
+        self.selections.timescale = "hourly"
+        self.selections.variable = "Air Temperature at 2m"
+
+        # Location defaults
+        self.location.area_subset = 'states'
+        self.location.cached_area = 'CA'
+
+    variable2 = param.ObjectSelector(default="Air Temperature at 2m",
+        objects=["Air Temperature at 2m", "Surface Pressure"]
+    )
+
+    cached_area2 = param.ObjectSelector(default="CA",
+        objects=["CA"]
+    )
+
+    area_subset2 = param.ObjectSelector(
+        default="states",
+        objects=["states", "CA counties"],
+    )
+
+    @param.depends("variable2", watch=True)
+    def _update_variable(self):
+        """Update variable in selections object to reflect variable chosen in panel"""
+        self.selections.variable = self.variable2
+
+    @param.depends("area_subset2", watch=True)
+    def _update_cached_area(self):
+        """
+        Makes the dropdown options for 'cached area' reflect the type of area subsetting
+        selected in 'area_subset' (currently state, county, or watershed boundaries).
+        """
+        if self.area_subset2 == "CA counties":
+            # setting this to the dict works for initializing, but not updating an objects list:
+            self.param["cached_area2"].objects = ["Santa Clara County", "Los Angeles County"]
+            self.cached_area2 = "Santa Clara County"
+        elif self.area_subset2 == "states":
+            self.param["cached_area2"].objects = ["CA"]
+            self.cached_area2 = "CA"
+
+    @param.depends("area_subset2","cached_area2",watch=True)
+    def _updated_location(self):
+        """Update locations object to reflect location chosen in panel"""
+        self.location.area_subset = self.area_subset2
+        self.location.cached_area = self.cached_area2
+
+
+#-----------------------------------------------------------------------
 
 class AppExplore(object):
     """
     A class for holding the following app explore options:
-        app.explore2.TMY()
+        app.explore2.tmy()
         app.explore2.thresholds()
     """
 
@@ -15,8 +79,33 @@ class AppExplore(object):
         self.location = location,
         self._cat = _cat
 
-    def tmy(self):
-        return pn.Card(title = "Typical Meteorological Year", collapsible = False)
 
-    def thresholds(self):
-        return pn.Card(title = "Explore extreme events", collapsible = False)
+    def tmy():
+        # tmy_data = TMYParams(selections=self.selections, location=self.location)
+        #
+        # data_options = pn.Card(
+        #     pn.Row(
+        #         pn.Column(
+        #             pn.widgets.Select.from_param(tmy_data.param.variable2, name="Data variable"),
+        #             # selections.param.variable,
+        #             pn.widgets.StaticText.from_param(selections.param.variable_description),
+        #             pn.widgets.StaticText(name="", value="Variable Units"),
+        #             pn.widgets.RadioButtonGroup.from_param(selections.param.units),
+        #             width=230),
+        #     )
+        # , title="Data Options - Absolute TMY", collapsible=False, width=460, height=515
+        # )
+        #
+        # mthd_box = pn.Card(
+        #     "Here is where I describe the methods of the TMY.",
+        #     title="Methodology", collapsible=False
+        # )
+        #
+        # return pn.Row(
+        #     pn.Column(
+        #         (data_options),
+        #         mthd_box
+        #     )
+        # )
+
+        return _tmy_visualize()

--- a/climakitae/explore2.py
+++ b/climakitae/explore2.py
@@ -1,6 +1,7 @@
 # A class for holding the app explore options
 
 import panel as pn
+from .tmy import _display_tmy
 
 class AppExplore(object):
     """
@@ -14,7 +15,7 @@ class AppExplore(object):
         self.location = location,
         self._cat = _cat
 
-    def TMY(self):
+    def tmy(self):
         return pn.Card(title = "Typical Meteorological Year", collapsible = False)
 
     def thresholds(self):

--- a/climakitae/explore2.py
+++ b/climakitae/explore2.py
@@ -2,68 +2,7 @@
 
 import panel as pn
 import param
-from .tmy import _tmy_visualize
-
-
-class TMYParams(param.Parameterized):
-    """
-    An object that holds the "Data Options" parameters for the
-    explore.tmy panel.
-    """
-    def __init__(self, *args, **params):
-        super().__init__(*args, **params)
-
-        # Selectors defaults
-        self.selections.append_historical = False
-        self.selections.area_average = True
-        self.selections.resolution = "45 km"
-        self.selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
-        self.selections.time_slice = (1980,2100)
-        self.selections.timescale = "hourly"
-        self.selections.variable = "Air Temperature at 2m"
-
-        # Location defaults
-        self.location.area_subset = 'states'
-        self.location.cached_area = 'CA'
-
-    variable2 = param.ObjectSelector(default="Air Temperature at 2m",
-        objects=["Air Temperature at 2m", "Surface Pressure"]
-    )
-
-    cached_area2 = param.ObjectSelector(default="CA",
-        objects=["CA"]
-    )
-
-    area_subset2 = param.ObjectSelector(
-        default="states",
-        objects=["states", "CA counties"],
-    )
-
-    @param.depends("variable2", watch=True)
-    def _update_variable(self):
-        """Update variable in selections object to reflect variable chosen in panel"""
-        self.selections.variable = self.variable2
-
-    @param.depends("area_subset2", watch=True)
-    def _update_cached_area(self):
-        """
-        Makes the dropdown options for 'cached area' reflect the type of area subsetting
-        selected in 'area_subset' (currently state, county, or watershed boundaries).
-        """
-        if self.area_subset2 == "CA counties":
-            # setting this to the dict works for initializing, but not updating an objects list:
-            self.param["cached_area2"].objects = ["Santa Clara County", "Los Angeles County"]
-            self.cached_area2 = "Santa Clara County"
-        elif self.area_subset2 == "states":
-            self.param["cached_area2"].objects = ["CA"]
-            self.cached_area2 = "CA"
-
-    @param.depends("area_subset2","cached_area2",watch=True)
-    def _updated_location(self):
-        """Update locations object to reflect location chosen in panel"""
-        self.location.area_subset = self.area_subset2
-        self.location.cached_area = self.cached_area2
-
+from .tmy import TypicalMeteorologicalYear, _tmy_visualize
 
 #-----------------------------------------------------------------------
 
@@ -79,33 +18,6 @@ class AppExplore(object):
         self.location = location,
         self._cat = _cat
 
-
-    def tmy():
-        # tmy_data = TMYParams(selections=self.selections, location=self.location)
-        #
-        # data_options = pn.Card(
-        #     pn.Row(
-        #         pn.Column(
-        #             pn.widgets.Select.from_param(tmy_data.param.variable2, name="Data variable"),
-        #             # selections.param.variable,
-        #             pn.widgets.StaticText.from_param(selections.param.variable_description),
-        #             pn.widgets.StaticText(name="", value="Variable Units"),
-        #             pn.widgets.RadioButtonGroup.from_param(selections.param.units),
-        #             width=230),
-        #     )
-        # , title="Data Options - Absolute TMY", collapsible=False, width=460, height=515
-        # )
-        #
-        # mthd_box = pn.Card(
-        #     "Here is where I describe the methods of the TMY.",
-        #     title="Methodology", collapsible=False
-        # )
-        #
-        # return pn.Row(
-        #     pn.Column(
-        #         (data_options),
-        #         mthd_box
-        #     )
-        # )
-
-        return _tmy_visualize()
+    def tmy(selections, location):
+        tmy_ob = TypicalMeteorologicalYear(selections=selections, location=location)
+        return _tmy_visualize(tmy_ob.selections, tmy_ob.location)

--- a/climakitae/explore2.py
+++ b/climakitae/explore2.py
@@ -2,14 +2,14 @@
 
 import panel as pn
 import param
-from .tmy import TypicalMeteorologicalYear, _tmy_visualize
+from .tmy import AverageMeteorologicalYear, _amy_visualize
 
 #-----------------------------------------------------------------------
 
 class AppExplore(object):
     """
     A class for holding the following app explore options:
-        app.explore2.tmy()
+        app.explore2.amy()
         app.explore2.thresholds()
     """
 
@@ -18,6 +18,6 @@ class AppExplore(object):
         self.location = location
         self._cat = _cat
 
-    def tmy(self):
-        tmy_ob = TypicalMeteorologicalYear(selections=self.selections, location=self.location, catalog=self._cat)
-        return _tmy_visualize(tmy_ob=tmy_ob, selections=self.selections, location=self.location)
+    def amy(self):
+        tmy_ob = AverageMeteorologicalYear(selections=self.selections, location=self.location, catalog=self._cat)
+        return _amy_visualize(tmy_ob=tmy_ob, selections=self.selections, location=self.location)

--- a/climakitae/explore2.py
+++ b/climakitae/explore2.py
@@ -15,9 +15,9 @@ class AppExplore(object):
 
     def __init__(self, selections, location, _cat):
         self.selections = selections
-        self.location = location,
+        self.location = location
         self._cat = _cat
 
-    def tmy(selections, location):
-        tmy_ob = TypicalMeteorologicalYear(selections=selections, location=location)
-        return _tmy_visualize(tmy_ob.selections, tmy_ob.location)
+    def tmy(self):
+        tmy_ob = TypicalMeteorologicalYear(selections=self.selections, location=self.location, catalog=self._cat)
+        return _tmy_visualize(tmy_ob=tmy_ob, selections=self.selections, location=self.location)

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -35,7 +35,6 @@ import panel as pn
 import intake
 import warnings
 from .data_loaders import _read_from_catalog
-from .selectors import DataSelector, LocSelectorArea
 # from .utils import _read_var_csv, _read_ae_colormap
 import intake
 import pkg_resources
@@ -73,7 +72,7 @@ class TypicalMeteorologicalYear(param.Parameterized):
     )
 
     # For reloading data and plots
-    reload_data2 = param.Action(lambda x: x.param.trigger('reload_data2'), label='Reload Data')
+    reload_data = param.Action(lambda x: x.param.trigger('reload_data'), label='Reload Data')
     changed_loc_and_var = param.Boolean(default=True)
 
     variable2 = param.ObjectSelector(default="Air Temperature at 2m",
@@ -212,7 +211,7 @@ class TypicalMeteorologicalYear(param.Parameterized):
         # tmy_future = tmy_calc(data_future)
 
         ## Funnel data into pandas DataFrame object
-        df_hist = pd.DataFrame(tmy_hourly, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
+        df_hist = pd.DataFrame(tmy_hist, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
         df_hist = df_hist.iloc[::-1] # Reverse index
         # df_future = pd.DataFrame(tmy_future, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
         # df_future = df_future.iloc[::-1]
@@ -222,12 +221,12 @@ class TypicalMeteorologicalYear(param.Parameterized):
         # df = df_future - df_hist # future difference version
         # df = df_extreme - df_hist # extreme version
 
-        ## Set to PST time -- hardcoded
-        df = df[['8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','1','2','3','4','5','6','7']]
-        col_h=[]
-        for i in np.arange(1,25,1):
-            col_h.append(str(i))
-        df.columns = col_h
+        # ## Set to PST time -- hardcoded
+        # df = df[['8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','1','2','3','4','5','6','7']]
+        # col_h=[]
+        # for i in np.arange(1,25,1):
+        #     col_h.append(str(i))
+        # df.columns = col_h
 
         # # think about best practices data presentation here
         # if self.variable2 == "Air Temperature at 2m":
@@ -254,23 +253,21 @@ class TypicalMeteorologicalYear(param.Parameterized):
 
 #--------------------------------------------------------------------------------------------
 # def _tmy_visualize(data, cmap=None):
-def _tmy_visualize(self):
+def _tmy_visualize(tmy_ob, selections, location):
     """
     Creates a new TMY focus panel object to display user selections
     """
-    tmy_ob = TypicalMeteorologicalYear(selections=self.selections, location=self.location)
-
     user_options = pn.Card(
             pn.Row(
                 pn.Column(
                     pn.widgets.StaticText(name="", value='Typical Meteorological Year Options'),
                     pn.widgets.Select.from_param(tmy_ob.param.variable2, name="Data variable"),
-                    pn.widgets.StaticText.from_param(self.selections.param.variable_description),
+                    pn.widgets.StaticText.from_param(selections.param.variable_description),
                     pn.widgets.Button.from_param(tmy_ob.param.reload_data, button_type="primary", width=150, height=30),
                     width = 230),
                 pn.Column(
                     pn.widgets.Select.from_param(tmy_ob.param.area_subset2, name="Location"),
-                    self.location.view,
+                    location.view,
                     width = 230)
                 )
         , title="Data Options", collapsible=False, width=460, height=500

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -240,7 +240,7 @@ class TypicalMeteorologicalYear(param.Parameterized):
             x='columns',
             y='index',
             # title='Typical Meteorological Year\nDifference between a {}°C-warming level future and the historical baseline'.format(self.warmlevel),
-            title='Typical Meteorological Year\nAbsolute value for Historical Baseline\n{}'.format(self.location_subset2),
+            title='Typical Meteorological Year',
             cmap="YlOrRd",
             xaxis='bottom',
             xlabel="Hour of Day (UTC)",

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -18,8 +18,6 @@ Working Group 4 (Aug 31, 2022) version focuses on air temperature and relative h
 # can also select diurnal cycle
 # download/export functionality
 # watch cluster worker numbers for a target time to complete computations
-# potential recent data transformation data cacheing
-
 
 import cartopy.crs as ccrs
 import hvplot.xarray
@@ -68,7 +66,7 @@ class TypicalMeteorologicalYear(param.Parameterized):
 
     # TMY options to display
     tmy_options = param.ObjectSelector(default='Absolute TMY',
-        objects=['Absolute TMY', 'Warming Level TMY', 'Extreme TMY']
+        objects=['Absolute TMY', 'Warming Level TMY', 'Severe TMY']
     )
 
     # For the difference TMY maps
@@ -232,12 +230,6 @@ class TypicalMeteorologicalYear(param.Parameterized):
         # df = df_extreme - df_hist # extreme version
 
         ## Visual ease of orientation elements
-        # ## Set to PST time -- hardcoded
-        # df = df[['8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','1','2','3','4','5','6','7']]
-        # col_h=[]
-        # for i in np.arange(1,25,1):
-        #     col_h.append(str(i))
-        # df.columns = col_h
 
         # # think about best practices data presentation here
         # if self.variable2 == "Air Temperature at 2m":
@@ -259,7 +251,16 @@ class TypicalMeteorologicalYear(param.Parameterized):
         #     title = "Typical Meteorological Year\nDifference between 90% percentile extreme and the historical baseline\n{}".format(self._get_hist_heatmap_data.area_subset2)
 
         clabel = self.variable2 #+ " ("+self.variable2.attrs["units"]+")"
-        title = "Typical Meteorological Year\nAbsolute Value for Historical Baseline\nLOCATION"
+        title = "Typical Meteorological Year\nAbsolute Value for Historical Baseline\n{}".format(self.cached_area2)
+
+        df.columns = ['Midnight','1am','2am','3am','4am','5am','6am','7am','8am','9am','10am','11am','Noon','1pm','2pm','3pm','4pm','5pm','6pm','7pm','8pm','9pm','10pm','11pm']
+
+        dy_labs = []
+        for x in np.arange(1,367,1):
+            dy_labs.append(x)
+        # m_days = ['Jan 1','Feb 1','Mar 1','Apr 1','Mar 1','Jun 1','Jul 1','Aug 1','Sep 1','Oct 1','Nov 1','Dec 1']
+        # d = dict(zip([0,31,59,90,120,151,181,212,243,273,304,334], m_days))
+        # df.index = [d.get(i, j) for i,j in enumerate(dy_labs)]
 
         heatmap = df.hvplot.heatmap(
             x='columns',
@@ -267,11 +268,12 @@ class TypicalMeteorologicalYear(param.Parameterized):
             title=title,
             cmap="YlOrRd",
             xaxis='bottom',
-            xlabel="Hour of Day (FIX ME)",
-            ylabel="Day of Year (FIX ME)",clabel=clabel,
+            xlabel="Hour of Day (PST)",
+            ylabel="Day of Year", clabel=clabel, rot=60,
             width=800, height=350).opts(
             fontsize={'title': 15, 'xlabel':12, 'ylabel':12} # clim=(0,6) is for air temperature; clim=(-1,1) for relative humidity?
         )
+
         return heatmap
 
 

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -260,12 +260,12 @@ class AverageMeteorologicalYear(param.Parameterized):
         elif self.tmy_options == "Difference":
             if self.diff_tmy_options == "Warming Level Future":
                 df = df_future - df_hist
-                title = "Average Meteorological Year\Difference between {} at {}°C and Historical Baseline \n{}".format(self.diff_tmy_options, self.warmlevel, self.cached_area2)
+                title = "Average Meteorological Year\nDifference between {} at {}°C and Historical Baseline \n{}".format(self.diff_tmy_options, self.warmlevel, self.cached_area2)
             else:
                 df = df_future - df_hist # placeholder for now for severe amy
-                title = "Average Meteorological Year\Difference between {} at Xth percentile and Historical Baseline \n{}".format(self.diff_tmy_options, self.cached_area2)
+                title = "Average Meteorological Year\nDifference between {} at Xth percentile and Historical Baseline \n{}".format(self.diff_tmy_options, self.cached_area2)
         else:
-            title = "Average Meteorological Year\{}".format(self.cached_area2)
+            title = "Average Meteorological Year\n{}".format(self.cached_area2)
 
         df = df[[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,1,2,3,4,5,6,7]]
         df.columns = ['12am','1am','2am','3am','4am','5am','6am','7am','8am','9am','10am','11am','12pm','1pm','2pm','3pm','4pm','5pm','6pm','7pm','8pm','9pm','10pm','11pm']

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -21,250 +21,265 @@ Working Group 4 (Aug 31, 2022) version focuses on air temperature and relative h
 # potential recent data transformation data cacheing
 
 
-## Import libraries
+import cartopy.crs as ccrs
+import hvplot.xarray
+import hvplot.pandas
+import xarray as xr
+import holoviews as hv
+from holoviews import opts
+from matplotlib.figure import Figure
 import numpy as np
-# import pandas as pd
-import metpy.calc
-import metpy
-from netCDF4 import Dataset
+import pandas as pd
+import param
+import panel as pn
+import intake
+import warnings
+from .data_loaders import _read_from_catalog
+from .selectors import DataSelector, LocSelectorArea
+import intake
+import pkg_resources
+
 
 ## Needs to produce 3 different kinds of TMY
 ## 1: Absolute/unbias corrected raw tmy
 ## 2: Future-minus-historical warming level tmy (see warming_levels)
 ## 3: Severe/extremes tmy based upon historical baseline and a designated threshold/percentile
 
-def _tmy_hourly_heatmap(self):
-    def _get_hist_heatmap_data():
-        """Get historical data from AWS catalog"""
-        heatmap_selections = self.selections
-        heatmap_selections.append_historical = False
-        heatmap_selections.area_average = True
-        heatmap_selections.resolution = "45 km"
-        heatmap_selections.scenario = ["Historical Climate"]
-        heatmap_selections.time_slice = (1981,2010) # to match historical 30-year average
-        heatmap_selections.timescale = "hourly"
-        xr_da = _read_from_catalog(
-            selections=heatmap_selections,
-            location=self.location,
-            cat=self.catalog
-        )
-        return xr_da
 
-    ## hard-coding in for now
-    warming_year_average_range = {
-        1.5 : (2034,2063),
-        2 : (2047,2076),
-        3 : (2061,2090),
-        4 : (2076,2100) ## Need to consider this further
-    }
+class TMYParams(param.Parameterized):
+    """
+    An object that holds the "Data Options" paramters for the
+    explore.tmy panel.
+    """
+    def __init__(self, *args, **params):
+        super().__init__(*args, **params)
 
-    def _get_future_heatmap_data():
-        """Gets data from AWS catalog based upon desired warming level"""
-        heatmap_selections = self.selections
-        heatmap_selections.append_historical = False
-        heatmap_selections.area_average = True
-        heatmap_selections.resolution = "45 km"
-        heatmap_selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
-        heatmap_selections.time_slice = warming_year_average_range[self.warmlevel]
-        heatmap_selections.timescale = "hourly"
-        xr_da2 = _read_from_catalog(
-            selections=heatmap_selections,
-            location=self.location,
-            cat=self.catalog
-        )
-        return xr_da2
+        # Selectors defaults
+        self.selections.append_historical = False
+        self.selections.area_average = True
+        self.selections.resolution = "45 km"
+        self.selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
+        self.selections.time_slice = (1980,2100)
+        self.selections.timescale = "hourly"
+        self.selections.variable = "Air Temperature at 2m"
 
-    def remove_repeats(xr_data):
-        """
-        Remove hours that have repeats.
-        This occurs if two hours have the same absolute difference from the mean.
-        Returns numpy array
-        """
-        unq, unq_idx, unq_cnt = np.unique(xr_data.time.dt.hour.values, return_inverse=True, return_counts=True)
-        cnt_mask = unq_cnt > 1
-        cnt_idx, = np.nonzero(cnt_mask)
-        idx_mask = np.in1d(unq_idx, cnt_idx)
-        idx_idx, = np.nonzero(idx_mask)
-        srt_idx = np.argsort(unq_idx[idx_mask])
-        dup_idx = np.split(idx_idx[srt_idx], np.cumsum(unq_cnt[cnt_mask])[:-1])
-        if len(dup_idx[0]) > 0:
-            dup_idx_keep_first_val = np.concatenate([dup_idx[x][1:] for x in range(len(dup_idx))], axis=0)
-            cleaned_np = np.delete(xr_data.values, dup_idx_keep_first_val)
-            return cleaned_np
-        else:
-            return xr_data.values
+        # Location defaults
+        self.location.area_subset = 'states'
+        self.location.cached_area = 'CA'
 
-    ## Grab data from AWS
-    data_hist = _get_hist_heatmap_data()
-    data_hist = data_hist.mean(dim="simulation").isel(scenario=0).compute()
-    data_future = _get_future_heatmap_data()
-    data_future = data_future.mean(dim="simulation").isel(scenario=0).compute()
-
-    ## Compute hourly TMY for each hour of the year
-    days_in_year = 366
-    def tmy_calc(data, days_in_year=366):
-        """
-        Calculates the typical meteorological year based on a designated period of time.
-        Applicable for both the historical and future periods.
-        Returns: list of tmy
-        """
-        hourly_list = []
-        for x in np.arange(1, days_in_year+1, 1):
-            data_on_day_x = data.where(data.time.dt.dayofyear == x, drop = True)
-            data_grouped = data_on_day_x.groupby("time.hour")
-            mean_by_hour = data_grouped.mean()
-            min_diff = abs(data_grouped - mean_by_hour).groupby("time.hour").min()
-            typical_hourly_data_on_day_x = data_on_day_x.where(abs(data_grouped - mean_by_hour).groupby("time.hour") == min_diff, drop = True).sortby("time.hour")
-            np_typical_hourly_data_on_day_x = remove_repeats(typical_hourly_data_on_day_x)
-            hourly_list.append(np_typical_hourly_data_on_day_x)
-        return hourly_list
-
-    tmy_hist = tmy_calc(data_hist)
-    tmy_future = tmy_calc(data_future)
-
-    # Funnel data into pandas DataFrame object
-    df_hist = pd.DataFrame(tmy_hourly, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
-    df_hist = df_hist.iloc[::-1] # Reverse index
-
-    df_future = pd.DataFrame(tmy_future, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
-    df_future = df_future.iloc[::-1]
-
-    ## Create difference heatmaps based on selected warming level
-    df = df_future - df_hist
-
-    ## Set to PST time -- hardcoded
-    df = df[['8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','1','2','3','4','5','6','7']]
-    col_h=[]
-    for i in np.arange(1,25,1):
-        col_h.append(str(i))
-    df.columns = col_h
-
-    # think about best practices data presentation here
-    if self.variable2 == "Air Temperature at 2m":
-        cm = "YlOrRd"
-        cl = (0,6)  # hardcoding this in, full range of warming level response for 2m air temp
-    elif self.variable2 == "Relative Humidity":
-        cm = "PuOr"
-        cl = (-7,7) # hardcoding this in, full range of warming level response for relhumid
-
-    heatmap = df.hvplot.heatmap(
-        x='columns',
-        y='index',
-        title='Typical Meteorological Year\nDifference between a {}°C-warming level future and the historical baseline'.format(self.warmlevel),
-        cmap="YlOrRd",
-        xaxis='bottom',
-        xlabel="Hour of Day (UTC)",
-        ylabel="Day of Year",clabel="Air Temperature at 2m " + " (°C)",
-        width=800, height=350).opts(
-        clim=(0,6), fontsize={'title': 15, 'xlabel':12, 'ylabel':12} # clim=(0,6) is for air temperature; clim=(-1,1) for relative humidity?
+    variable2 = param.ObjectSelector(default="Air Temperature at 2m",
+        objects=["Air Temperature at 2m"]
     )
-    return heatmap
+
+    cached_area2 = param.ObjectSelector(default="CA",
+        objects=["CA"]
+    )
+
+    area_subset2 = param.ObjectSelector(
+        default="states",
+        objects=["states", "CA counties"],
+    )
+
+    @param.depends("variable2", watch=True)
+    def _update_variable(self):
+        """Update variable in selections object to reflect variable chosen in panel"""
+        self.selections.variable = self.variable2
+
+    @param.depends("area_subset2", watch=True)
+    def _update_cached_area(self):
+        """
+        Makes the dropdown options for 'cached area' reflect the type of area subsetting
+        selected in 'area_subset' (currently state, county, or watershed boundaries).
+        """
+        if self.area_subset2 == "CA counties":
+            # setting this to the dict works for initializing, but not updating an objects list:
+            self.param["cached_area2"].objects = ["Santa Clara County", "Los Angeles County"]
+            self.cached_area2 = "Santa Clara County"
+        elif self.area_subset2 == "states":
+            self.param["cached_area2"].objects = ["CA"]
+            self.cached_area2 = "CA"
+
+    @param.depends("area_subset2","cached_area2",watch=True)
+    def _updated_location(self):
+        """Update locations object to reflect location chosen in panel"""
+        self.location.area_subset = self.area_subset2
+        self.location.cached_area = self.cached_area2
 
 
-## FINAL OBJECT 
-def _display_tmy(selections, location, _cat):
+class TypicalMeteorologicalYear(param.Parameterized):
+    ## --------------- Params used for tmy plot ----------------
+
+    reload_data = param.Action(lambda x: x.param.trigger('reload_data'), label="Reload Data")
+    @param.depends("reload_data", watch=False)
+    def _tmy_hourly_heatmap(self):
+        def _get_hist_heatmap_data():
+            """Get historical data from AWS catalog"""
+            heatmap_selections = self.selections
+            heatmap_selections.append_historical = False
+            heatmap_selections.area_average = True
+            heatmap_selections.resolution = "45 km" ## KEEPING FOR NOW
+            heatmap_selections.scenario = ["Historical Climate"]
+            heatmap_selections.time_slice = (1981,2010) # to match historical 30-year average
+            heatmap_selections.timescale = "hourly"
+            xr_da = _read_from_catalog(
+                selections=heatmap_selections,
+                location=self.location,
+                cat=self.catalog
+            )
+            return xr_da
+
+        ## hard-coding in for now
+        warming_year_average_range = {
+            1.5 : (2034,2063),
+            2 : (2047,2076),
+            3 : (2061,2090),
+            4 : (2076,2100) ## Need to consider this further
+        }
+
+        def _get_future_heatmap_data():
+            """Gets data from AWS catalog based upon desired warming level"""
+            heatmap_selections = self.selections
+            heatmap_selections.append_historical = False
+            heatmap_selections.area_average = True
+            heatmap_selections.resolution = "45 km"
+            heatmap_selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
+            heatmap_selections.time_slice = warming_year_average_range[self.warmlevel]
+            heatmap_selections.timescale = "hourly"
+            xr_da2 = _read_from_catalog(
+                selections=heatmap_selections,
+                location=self.location,
+                cat=self.catalog
+            )
+            return xr_da2
+
+        def remove_repeats(xr_data):
+            """
+            Remove hours that have repeats.
+            This occurs if two hours have the same absolute difference from the mean.
+            Returns numpy array
+            """
+            unq, unq_idx, unq_cnt = np.unique(xr_data.time.dt.hour.values, return_inverse=True, return_counts=True)
+            cnt_mask = unq_cnt > 1
+            cnt_idx, = np.nonzero(cnt_mask)
+            idx_mask = np.in1d(unq_idx, cnt_idx)
+            idx_idx, = np.nonzero(idx_mask)
+            srt_idx = np.argsort(unq_idx[idx_mask])
+            dup_idx = np.split(idx_idx[srt_idx], np.cumsum(unq_cnt[cnt_mask])[:-1])
+            if len(dup_idx[0]) > 0:
+                dup_idx_keep_first_val = np.concatenate([dup_idx[x][1:] for x in range(len(dup_idx))], axis=0)
+                cleaned_np = np.delete(xr_data.values, dup_idx_keep_first_val)
+                return cleaned_np
+            else:
+                return xr_data.values
+
+        ## Grab data from AWS
+        data_hist = _get_hist_heatmap_data()
+        data_hist = data_hist.mean(dim="simulation").isel(scenario=0).compute()
+        # data_future = _get_future_heatmap_data()
+        # data_future = data_future.mean(dim="simulation").isel(scenario=0).compute()
+
+        ## Compute hourly TMY for each hour of the year
+        days_in_year = 366
+        def tmy_calc(data, days_in_year=366):
+            """
+            Calculates the typical meteorological year based on a designated period of time.
+            Applicable for both the historical and future periods.
+            Returns: list of tmy
+            """
+            hourly_list = []
+            for x in np.arange(1, days_in_year+1, 1):
+                data_on_day_x = data.where(data.time.dt.dayofyear == x, drop = True)
+                data_grouped = data_on_day_x.groupby("time.hour")
+                mean_by_hour = data_grouped.mean()
+                min_diff = abs(data_grouped - mean_by_hour).groupby("time.hour").min()
+                typical_hourly_data_on_day_x = data_on_day_x.where(abs(data_grouped - mean_by_hour).groupby("time.hour") == min_diff, drop = True).sortby("time.hour")
+                np_typical_hourly_data_on_day_x = remove_repeats(typical_hourly_data_on_day_x)
+                hourly_list.append(np_typical_hourly_data_on_day_x)
+            return hourly_list
+
+        tmy_hist = tmy_calc(data_hist)
+        # tmy_future = tmy_calc(data_future)
+
+        ## Funnel data into pandas DataFrame object
+        df_hist = pd.DataFrame(tmy_hourly, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
+        df_hist = df_hist.iloc[::-1] # Reverse index
+        # df_future = pd.DataFrame(tmy_future, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
+        # df_future = df_future.iloc[::-1]
+
+        ## Create difference heatmaps based on selected warming level
+        df = df_hist # absolute unbias corrected version
+        # df = df_future - df_hist # future difference version
+        # df = df_extreme - df_hist # extreme version
+
+        ## Set to PST time -- hardcoded
+        df = df[['8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','1','2','3','4','5','6','7']]
+        col_h=[]
+        for i in np.arange(1,25,1):
+            col_h.append(str(i))
+        df.columns = col_h
+
+        # # think about best practices data presentation here
+        # if self.variable2 == "Air Temperature at 2m":
+        #     cm = "YlOrRd"
+        #     cl = (0,6)  # hardcoding this in, full range of warming level response for 2m air temp
+        # elif self.variable2 == "Relative Humidity":
+        #     cm = "PuOr"
+        #     cl = (-7,7) # hardcoding this in, full range of warming level response for relhumid
+
+        heatmap = df.hvplot.heatmap(
+            x='columns',
+            y='index',
+            # title='Typical Meteorological Year\nDifference between a {}°C-warming level future and the historical baseline'.format(self.warmlevel),
+            title='Typical Meteorological Year\nAbsolute value for Historical Baseline\n{}'.format(self.location_subset2),
+            cmap="YlOrRd",
+            xaxis='bottom',
+            xlabel="Hour of Day (UTC)",
+            ylabel="Day of Year",clabel="Air Temperature at 2m " + " (°C)",
+            width=800, height=350).opts(
+            clim=(0,6), fontsize={'title': 15, 'xlabel':12, 'ylabel':12} # clim=(0,6) is for air temperature; clim=(-1,1) for relative humidity?
+        )
+        return heatmap
+
+
+
+def _tmy_visualize():
     """
     Creates a new TMY focus panel object to display user selections
     """
-
-    # App Explore object -- ## THINK ABOUT WHETHER THIS IS THE BEST SET-UP
-    app_explore = AppExplore(selections=selections, location=location)
+    tmy_ob = TMYParams(selections=self.selections, location=self.location, catalog=_cat)
 
     user_options = pn.Card(
             pn.Row(
                 pn.Column(
-                    pn.widgets.StaticText(name="", value='Warming level (°C)'),
-                    pn.widgets.RadioButtonGroup.from_param(warming_levels.param.warmlevel, name=""),
-                    pn.widgets.Select.from_param(warming_levels.param.variable2, name="Data variable"),
-                    pn.widgets.StaticText.from_param(selections.param.variable_description),
-                    pn.widgets.Button.from_param(warming_levels.param.reload_data2, button_type="primary", width=150, height=30),
+                    pn.widgets.StaticText(name="", value='Typical Meteorological Year Options'),
+                    pn.widgets.Select.from_param(tmy_ob.param.variable, name="Data variable"),
+                    pn.widgets.StaticText.from_param(tmy_ob.param.variable_description),
+                    pn.widgets.Button.from_param(tmy_ob.param.reload_data, button_type="primary", width=150, height=30),
                     width = 230),
                 pn.Column(
-                    pn.widgets.Select.from_param(warming_levels.param.area_subset2, name="Area subset"),
-                    pn.widgets.Select.from_param(warming_levels.param.cached_area2, name="Cached area"),
+                    pn.widgets.Select.from_param(tmy_ob.param.area_subset2, name="Area subset"),
                     location.view,
                     width = 230)
                 )
         , title="Data Options", collapsible=False, width=460, height=500
     )
 
-    TMY = pn.Column(
+
+    TMY = pn.Card(
         pn.widgets.StaticText(
-           value="A typical meteorological year is calculated by selecting the 24 hours for every day that best represent multi-model mean conditions during a 30-year period – 1981-2010 for the historical baseline or centered on the year the warming level is reached.",
+           value=" ",
            width = 700
-        ),
-        app_explore._tmy_hourly_heatmap
+           ),
+        tmy_ob._tmy_hourly_heatmap
+    )
+
+    mthd_bx = pn.Card(
+        "A typical meteorological year is calculated by selecting the 24 hours for every day that best represent multi-model mean conditions during a 30-year period – 1981-2010 for the historical baseline or centered on the year the warming level is reached. Alternatively, can put what data was selected here as a visual reminder. ",
+        title="Methodology", collapsible=True, width=1160
     )
 
     tmy_panel = pn.Column(
-        user_options,
-        TMY
+        pn.Row(user_options, TMY),
+        mthd_bx
     )
-
     return tmy_panel
-
-
-
-
-
-
-
-
-
-##### --------------- COPY/PASTE FROM EXPLORE.PY --------------------
-
-# TMY files in climakitae/data
-# tmy_filenames = ['tmy_future-minus-hist_rh_45km_CA_15degC.csv',
-#  'tmy_future-minus-hist_rh_45km_CA_2degC.csv',
-#  'tmy_future-minus-hist_rh_45km_CA_3degC.csv',
-#  'tmy_future-minus-hist_rh_45km_losangeles_15degC.csv',
-#  'tmy_future-minus-hist_rh_45km_losangeles_2degC.csv',
-#  'tmy_future-minus-hist_rh_45km_losangeles_3degC.csv',
-#  'tmy_future-minus-hist_rh_45km_santaclara_15degC.csv',
-#  'tmy_future-minus-hist_rh_45km_santaclara_2degC.csv',
-#  'tmy_future-minus-hist_rh_45km_santaclara_3degC.csv',
-#  'tmy_future-minus-hist_temp_45km_CA_15degC.csv',
-#  'tmy_future-minus-hist_temp_45km_CA_2degC.csv',
-#  'tmy_future-minus-hist_temp_45km_CA_3degC.csv',
-#  'tmy_future-minus-hist_temp_45km_losangeles_15degC.csv',
-#  'tmy_future-minus-hist_temp_45km_losangeles_2degC.csv',
-#  'tmy_future-minus-hist_temp_45km_losangeles_3degC.csv',
-#  'tmy_future-minus-hist_temp_45km_santaclara_15degC.csv',
-#  'tmy_future-minus-hist_temp_45km_santaclara_2degC.csv',
-#  'tmy_future-minus-hist_temp_45km_santaclara_3degC.csv']
-# cached_tmy_files = [pkg_resources.resource_filename('climakitae', 'data/cached_tmy/'+file) for file in tmy_filenames]
-
-# def _read_cached_tmy_df(cached_tmy_files, variable, warmlevel, cached_area):
-#     """Read in cached tmy file corresponding to a given variable, warmlevel, and cached area.
-#     Returns a dataframe"""
-#
-#     # Subset list by variable
-#     if variable == "Relative Humidity":
-#         cached_tmy_var = [file for file in cached_tmy_files if "rh" in file]
-#     elif variable == "Air Temperature at 2m":
-#         cached_tmy_var = [file for file in cached_tmy_files if "temp" in file]
-#
-#     # Subset list by warming level
-#     if warmlevel == 1.5:
-#         cached_tmy_warmlevel = [file for file in cached_tmy_var if "15degC" in file]
-#     elif warmlevel == 2:
-#         cached_tmy_warmlevel = [file for file in cached_tmy_var if "2degC" in file]
-#     elif warmlevel == 3:
-#         cached_tmy_warmlevel = [file for file in cached_tmy_var if "3degC" in file]
-#
-#     # Subset list by location
-#     if cached_area == "CA":
-#         tmy = [file for file in cached_tmy_warmlevel if "CA" in file]
-#     if cached_area == "Santa Clara County":
-#         tmy = [file for file in cached_tmy_warmlevel if "santaclara" in file]
-#     if cached_area == "Los Angeles County" :
-#         tmy = [file for file in cached_tmy_warmlevel if "losangeles" in file]
-#
-#     # Read in file as pandas dataframe
-#     df = pd.read_csv(tmy[0], index_col=0)
-#
-#     # Name columns and index
-#     df.columns.name = "Hour of Day"
-#     df.index.name = "Day of Year"
-#
-#     return df

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -1,7 +1,7 @@
 """
 Calculates the Typical Meterological Year (TMY) for the Cal-Adapt: Analytics Engine using a standard climatological period (1981-2010) for the historical baseline,
 and uses a 30-year window around when a designated warming level is exceeded for the SSP3-7.0 future scenario for 1.5°C, 2°C, and 3°C. Additional functionality for 4°C is forthcoming.
-Working Group 4 (Aug 31, 2022) version focuses on air temperature and relative humidity, with all variables being available at a later date.
+Working Group 4 (Aug 31, 2022) version focuses on air temperature and relative humidity, with all variables being available for Analytics Engine Beta Launch.
 """
 
 ## PROCESS: typical meteorological year
@@ -10,15 +10,16 @@ Working Group 4 (Aug 31, 2022) version focuses on air temperature and relative h
 # process is repeated for each hour in the year
 # hours are added together to provide a full year of hourly samples
 
-# To be developed:
-# app.explore.tmy()
-# absolute tmy of raw data: "preliminary unbiased data corrected data"
-# difference tmys
+# To be developed: will delete these notes once finalized
+# app.explore.tmy -- COMPLETED
+# absolute tmy of raw data: "preliminary unbiased data corrected data" -- IN PROGRESS
+# difference tmys -- IN PROGRESS (FROM OLD EXPLORE )
 # extreme/severe tmys: can think about percentiles above extreme values to represent
 # can also select diurnal cycle
 # download/export functionality
 # watch cluster worker numbers for a target time to complete computations
 # potential recent data transformation data cacheing
+
 
 ## Import libraries
 import numpy as np
@@ -26,6 +27,189 @@ import numpy as np
 import metpy.calc
 import metpy
 from netCDF4 import Dataset
+
+## Needs to produce 3 different kinds of TMY
+## 1: Absolute/unbias corrected raw tmy
+## 2: Future-minus-historical warming level tmy (see warming_levels)
+## 3: Severe/extremes tmy based upon historical baseline and a designated threshold/percentile
+
+def _tmy_hourly_heatmap(self):
+    def _get_hist_heatmap_data():
+        """Get historical data from AWS catalog"""
+        heatmap_selections = self.selections
+        heatmap_selections.append_historical = False
+        heatmap_selections.area_average = True
+        heatmap_selections.resolution = "45 km"
+        heatmap_selections.scenario = ["Historical Climate"]
+        heatmap_selections.time_slice = (1981,2010) # to match historical 30-year average
+        heatmap_selections.timescale = "hourly"
+        xr_da = _read_from_catalog(
+            selections=heatmap_selections,
+            location=self.location,
+            cat=self.catalog
+        )
+        return xr_da
+
+    ## hard-coding in for now
+    warming_year_average_range = {
+        1.5 : (2034,2063),
+        2 : (2047,2076),
+        3 : (2061,2090),
+        4 : (2076,2100) ## Need to consider this further
+    }
+
+    def _get_future_heatmap_data():
+        """Gets data from AWS catalog based upon desired warming level"""
+        heatmap_selections = self.selections
+        heatmap_selections.append_historical = False
+        heatmap_selections.area_average = True
+        heatmap_selections.resolution = "45 km"
+        heatmap_selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
+        heatmap_selections.time_slice = warming_year_average_range[self.warmlevel]
+        heatmap_selections.timescale = "hourly"
+        xr_da2 = _read_from_catalog(
+            selections=heatmap_selections,
+            location=self.location,
+            cat=self.catalog
+        )
+        return xr_da2
+
+    def remove_repeats(xr_data):
+        """
+        Remove hours that have repeats.
+        This occurs if two hours have the same absolute difference from the mean.
+        Returns numpy array
+        """
+        unq, unq_idx, unq_cnt = np.unique(xr_data.time.dt.hour.values, return_inverse=True, return_counts=True)
+        cnt_mask = unq_cnt > 1
+        cnt_idx, = np.nonzero(cnt_mask)
+        idx_mask = np.in1d(unq_idx, cnt_idx)
+        idx_idx, = np.nonzero(idx_mask)
+        srt_idx = np.argsort(unq_idx[idx_mask])
+        dup_idx = np.split(idx_idx[srt_idx], np.cumsum(unq_cnt[cnt_mask])[:-1])
+        if len(dup_idx[0]) > 0:
+            dup_idx_keep_first_val = np.concatenate([dup_idx[x][1:] for x in range(len(dup_idx))], axis=0)
+            cleaned_np = np.delete(xr_data.values, dup_idx_keep_first_val)
+            return cleaned_np
+        else:
+            return xr_data.values
+
+    ## Grab data from AWS
+    data_hist = _get_hist_heatmap_data()
+    data_hist = data_hist.mean(dim="simulation").isel(scenario=0).compute()
+    data_future = _get_future_heatmap_data()
+    data_future = data_future.mean(dim="simulation").isel(scenario=0).compute()
+
+    ## Compute hourly TMY for each hour of the year
+    days_in_year = 366
+    def tmy_calc(data, days_in_year=366):
+        """
+        Calculates the typical meteorological year based on a designated period of time.
+        Applicable for both the historical and future periods.
+        Returns: list of tmy
+        """
+        hourly_list = []
+        for x in np.arange(1, days_in_year+1, 1):
+            data_on_day_x = data.where(data.time.dt.dayofyear == x, drop = True)
+            data_grouped = data_on_day_x.groupby("time.hour")
+            mean_by_hour = data_grouped.mean()
+            min_diff = abs(data_grouped - mean_by_hour).groupby("time.hour").min()
+            typical_hourly_data_on_day_x = data_on_day_x.where(abs(data_grouped - mean_by_hour).groupby("time.hour") == min_diff, drop = True).sortby("time.hour")
+            np_typical_hourly_data_on_day_x = remove_repeats(typical_hourly_data_on_day_x)
+            hourly_list.append(np_typical_hourly_data_on_day_x)
+        return hourly_list
+
+    tmy_hist = tmy_calc(data_hist)
+    tmy_future = tmy_calc(data_future)
+
+    # Funnel data into pandas DataFrame object
+    df_hist = pd.DataFrame(tmy_hourly, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
+    df_hist = df_hist.iloc[::-1] # Reverse index
+
+    df_future = pd.DataFrame(tmy_future, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
+    df_future = df_future.iloc[::-1]
+
+    ## Create difference heatmaps based on selected warming level
+    df = df_future - df_hist
+
+    ## Set to PST time -- hardcoded
+    df = df[['8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','1','2','3','4','5','6','7']]
+    col_h=[]
+    for i in np.arange(1,25,1):
+        col_h.append(str(i))
+    df.columns = col_h
+
+    # think about best practices data presentation here
+    if self.variable2 == "Air Temperature at 2m":
+        cm = "YlOrRd"
+        cl = (0,6)  # hardcoding this in, full range of warming level response for 2m air temp
+    elif self.variable2 == "Relative Humidity":
+        cm = "PuOr"
+        cl = (-7,7) # hardcoding this in, full range of warming level response for relhumid
+
+    heatmap = df.hvplot.heatmap(
+        x='columns',
+        y='index',
+        title='Typical Meteorological Year\nDifference between a {}°C-warming level future and the historical baseline'.format(self.warmlevel),
+        cmap="YlOrRd",
+        xaxis='bottom',
+        xlabel="Hour of Day (UTC)",
+        ylabel="Day of Year",clabel="Air Temperature at 2m " + " (°C)",
+        width=800, height=350).opts(
+        clim=(0,6), fontsize={'title': 15, 'xlabel':12, 'ylabel':12} # clim=(0,6) is for air temperature; clim=(-1,1) for relative humidity?
+    )
+    return heatmap
+
+
+## FINAL OBJECT 
+def _display_tmy(selections, location, _cat):
+    """
+    Creates a new TMY focus panel object to display user selections
+    """
+
+    # App Explore object -- ## THINK ABOUT WHETHER THIS IS THE BEST SET-UP
+    app_explore = AppExplore(selections=selections, location=location)
+
+    user_options = pn.Card(
+            pn.Row(
+                pn.Column(
+                    pn.widgets.StaticText(name="", value='Warming level (°C)'),
+                    pn.widgets.RadioButtonGroup.from_param(warming_levels.param.warmlevel, name=""),
+                    pn.widgets.Select.from_param(warming_levels.param.variable2, name="Data variable"),
+                    pn.widgets.StaticText.from_param(selections.param.variable_description),
+                    pn.widgets.Button.from_param(warming_levels.param.reload_data2, button_type="primary", width=150, height=30),
+                    width = 230),
+                pn.Column(
+                    pn.widgets.Select.from_param(warming_levels.param.area_subset2, name="Area subset"),
+                    pn.widgets.Select.from_param(warming_levels.param.cached_area2, name="Cached area"),
+                    location.view,
+                    width = 230)
+                )
+        , title="Data Options", collapsible=False, width=460, height=500
+    )
+
+    TMY = pn.Column(
+        pn.widgets.StaticText(
+           value="A typical meteorological year is calculated by selecting the 24 hours for every day that best represent multi-model mean conditions during a 30-year period – 1981-2010 for the historical baseline or centered on the year the warming level is reached.",
+           width = 700
+        ),
+        app_explore._tmy_hourly_heatmap
+    )
+
+    tmy_panel = pn.Column(
+        user_options,
+        TMY
+    )
+
+    return tmy_panel
+
+
+
+
+
+
+
+
 
 ##### --------------- COPY/PASTE FROM EXPLORE.PY --------------------
 
@@ -49,7 +233,6 @@ from netCDF4 import Dataset
 #  'tmy_future-minus-hist_temp_45km_santaclara_2degC.csv',
 #  'tmy_future-minus-hist_temp_45km_santaclara_3degC.csv']
 # cached_tmy_files = [pkg_resources.resource_filename('climakitae', 'data/cached_tmy/'+file) for file in tmy_filenames]
-
 
 # def _read_cached_tmy_df(cached_tmy_files, variable, warmlevel, cached_area):
 #     """Read in cached tmy file corresponding to a given variable, warmlevel, and cached area.
@@ -85,110 +268,3 @@ from netCDF4 import Dataset
 #     df.index.name = "Day of Year"
 #
 #     return df
-
-@param.depends("reload_data2", watch=False)
-def _TMY_hourly_heatmap(self):
-    """Generate a TMY hourly heatmap using hourly data"""
-
-    # hard-coding in for now
-    warming_year_average_range = {
-        1.5 : (2034,2063),
-        2 : (2047,2076),
-        3 : (2061,2090),
-        4 : (2076, 2100)
-    }
-
-    def remove_repeats(xr_data):
-        """
-        Remove hours that have repeats.
-        This occurs if two hours have the same absolute difference from the mean.
-        Returns numpy array
-        """
-        unq, unq_idx, unq_cnt = np.unique(xr_data.time.dt.hour.values, return_inverse=True, return_counts=True)
-        cnt_mask = unq_cnt > 1
-        cnt_idx, = np.nonzero(cnt_mask)
-        idx_mask = np.in1d(unq_idx, cnt_idx)
-        idx_idx, = np.nonzero(idx_mask)
-        srt_idx = np.argsort(unq_idx[idx_mask])
-        dup_idx = np.split(idx_idx[srt_idx], np.cumsum(unq_cnt[cnt_mask])[:-1])
-        if len(dup_idx[0]) > 0:
-            dup_idx_keep_first_val = np.concatenate([dup_idx[x][1:] for x in range(len(dup_idx))], axis=0)
-            cleaned_np = np.delete(xr_data.values, dup_idx_keep_first_val)
-            return cleaned_np
-        else:
-            return xr_data.values
-
-    ## NEED TO SET BACK TO AWS CATALOG READING IN FOR ALL VARIABLES
-    # df = _read_cached_tmy_df(
-    #     cached_tmy_files=cached_tmy_files,
-    #     variable=self.variable2,
-    #     warmlevel=self.warmlevel,
-    #     cached_area=self.cached_area2
-    # )
-
-    # Set to PST time -- hardcoded
-    df = df[['8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','1','2','3','4','5','6','7']]
-    col_h=[]
-    for i in np.arange(1,25,1):
-        col_h.append(str(i))
-    df.columns = col_h
-
-    # think about best practices data presentation here
-    if self.variable2 == "Air Temperature at 2m":
-        cm = "YlOrRd"
-        cl = (0,6)  # hardcoding this in, full range of warming level response for 2m air temp
-    elif self.variable2 == "Relative Humidity":
-        cm = "PuOr"
-        cl = (-7,7) # hardcoding this in, full range of warming level response for relhumid
-
-    heatmap = df.hvplot.heatmap(
-        x='columns',
-        y='index',
-        title='Typical Meteorological Year\nDifference between a {}°C future and historical baseline'.format(self.warmlevel),
-        cmap=cm,
-        xaxis='bottom',
-        xlabel="Hour of Day (PST)",
-        ylabel="Day of Year",clabel=self.postage_data.name + " ("+self.postage_data.attrs["units"]+")",
-        width=800, height=350).opts(
-        fontsize={'title': 15, 'xlabel':12, 'ylabel':12},
-        clim=cl
-    )
-    return heatmap
-
-
-
-## ----------------------------------------------- old explore ^ ---------
-
-# think about options here for display
-# absolute/unbias corrected
-# difference for warming levels 
-
-def _display_tmy(selections, location, _cat):
-    """
-    Creates a new TMY focus panel object to display user selections
-    """
-    user_options = pn.Card(
-            pn.Row(
-                pn.Column(
-                    pn.widgets.StaticText(name="", value='Warming level (°C)'),
-                    pn.widgets.RadioButtonGroup.from_param(warming_levels.param.warmlevel, name=""),
-                    pn.widgets.Select.from_param(warming_levels.param.variable2, name="Data variable"),
-                    pn.widgets.StaticText.from_param(selections.param.variable_description),
-                    pn.widgets.Button.from_param(warming_levels.param.reload_data2, button_type="primary", width=150, height=30),
-                    width = 230),
-                pn.Column(
-                    pn.widgets.Select.from_param(warming_levels.param.area_subset2, name="Area subset"),
-                    pn.widgets.Select.from_param(warming_levels.param.cached_area2, name="Cached area"),
-                    location.view,
-                    width = 230)
-                )
-        , title="Data Options", collapsible=False, width=460, height=500
-    )
-
-    TMY = pn.Column(
-        pn.widgets.StaticText(
-           value="A typical meteorological year is calculated by selecting the 24 hours for every day that best represent multi-model mean conditions during a 30-year period – 1981-2010 for the historical baseline or centered on the year the warming level is reached.",
-           width = 700
-        ),
-        warming_levels._TMY_hourly_heatmap
-    )


### PR DESCRIPTION
Similar to Cora's thresholds PR #60, this PR implements the average meteorological year (former typical) panel: 

```
import climakitae as ck
app = ck.Application()
app.explore2.amy()
```

Which presents with the following options:
1. Absolute AMY - can select either historical baseline (1981-2010), or future 30-year period based on selected warming level
2. Difference AMY - can select difference between future warming level period minus historical baseline (the difference plots we saw in the WG4 warming level notebook), or _forthcoming_ the severe future period minus historical baseline
2a. Severe AMY will be based on 90th percentile, but should be able to either have full user selection, or a set of pre-determined selection of percentiles, using climtas (https://climtas.readthedocs.io/en/latest/percentile.html)

![Screen Shot 2022-09-26 at 4 09 57 PM](https://user-images.githubusercontent.com/106171203/192370403-957b3071-3102-4f48-9015-d0cffe1b9100.png)
