### PR TITLE
Clean up package dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,5 +28,4 @@ dependencies:
   - xarray=0.19.0
   - pip
   - pip: 
-    - lmoments3
-    - git+https://github.com/OpenHydrology/lmoments3.git@7e19f97c23019ca68cbd526b8bd417c412438f1c#egg=lmoments3
+    - git+https://github.com/OpenHydrology/lmoments3.git@7e19f97c23019ca68cbd526b8bd417c412438f1c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 xarray==0.19.0
--e git+https://github.com/OpenHydrology/lmoments3.git@7e19f97c23019ca68cbd526b8bd417c412438f1c#egg=lmoments3
+git+https://github.com/OpenHydrology/lmoments3.git@7e19f97c23019ca68cbd526b8bd417c412438f1c
 cartopy==0.20.1
 geopandas==0.10.2
 geoviews==1.9.2
@@ -8,7 +8,6 @@ hvplot==0.7.3
 intake==0.6.4
 intake-xarray==0.5.0
 jinja2==3.0.2
-lmoments3
 matplotlib==3.4.3
 metpy==1.1.0
 numpy==1.21.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ panel==0.12.4
 param==1.11.1
 pyproj==3.2.1
 pytest==7.1.3
-proj==8.1.1
 rioxarray==0.7.1
 s3fs==2021.10.1
 scipy==1.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,17 +31,18 @@ install_requires =
     panel
     param
     pyproj
-    pytest
     rioxarray
     s3fs
     scipy
     shapely
     xarray
-
-[options.package_data]
-* = data/*.csv
+tests_require =
+    pytest
 
 [options.extras_require]
 docs =
     Sphinx
     sphinx-book-theme
+
+[options.package_data]
+* = data/*.csv


### PR DESCRIPTION
Here are some minor packaging and dependency changes that remove a duplicate `lmoments3`, a non-existent `proj`, and separate testing from runtime deps.