### PR TITLE
get version; add metadata

### DIFF
--- a/climakitae/__init__.py
+++ b/climakitae/__init__.py
@@ -1,1 +1,14 @@
+try:
+    from importlib.metadata import version as _version
+except ImportError:
+    # if the fallback library is missing, we are doomed.
+    from importlib_metadata import version as _version  # type: ignore[no-redef]
+
+try:
+    __version__ = _version("climakitae")
+except Exception:
+    # Local copy or not installed with setuptools.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "999"
+
 from .core import Application

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -6,6 +6,7 @@ import warnings
 import datetime
 import numpy as np
 import os
+import rasterio
 from . import __version__
 xr.set_options(keep_attrs=True)
 

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -5,8 +5,8 @@ import dask
 import warnings
 import datetime
 import numpy as np
-import rasterio
 import os
+from . import __version__
 xr.set_options(keep_attrs=True)
 
 
@@ -20,13 +20,8 @@ def export_to_netcdf(data_to_export,save_name,**kwargs):
     save_name: string corresponding to desired output file name + file extension
     kwargs: reserved for future use
     '''    
-    print("Alright, exporting specified data to NetCDF. This might take a while - "+
-         "hang tight!")
-    # set coordinate encoding to follow CF conventions
-    comp = dict(_FillValue=None)
-    encoding = {coord: comp for coord in data_to_export.coords}
-    # and export
-    data_to_export.to_netcdf(save_name,encoding=encoding)
+    print("Alright, exporting specified data to NetCDF.")
+    data_to_export.to_netcdf(save_name)
     
     
 def export_to_csv(data_to_export,save_name,**kwargs):
@@ -40,16 +35,19 @@ def export_to_csv(data_to_export,save_name,**kwargs):
     kwargs: reserved for future use
     '''
     
+    print("WARNING: Exporting to CSV can take a long time,"+
+                 " and is not recommended for data with more than 2 dimensions."+
+                  " Please note that the data will be compressed via gzip. Even so,"+
+         " inherent inefficiencies may result in a file which is too large to save here.")
+    print("Converting data...")
     excel_row_limit = 1048576
     to_save = data_to_export.to_dataframe()        
     csv_nrows = len(to_save.index)        
     if (csv_nrows > excel_row_limit):
-        warnings.warn("Dataset exceeds Excel limit of "+
-                      str(excel_row_limit)+" rows.") 
-           
-    metadata_to_file(data_to_export,save_name)    
+        print("WARNING: Dataset exceeds Excel limit of "+
+                      str(excel_row_limit)+" rows.")        
+    print("Compressing data... This can take a bit...")
     to_save.to_csv(save_name,compression='gzip')   
-    
 
 def export_to_geotiff(data_to_export,save_name,**kwargs):    
     '''
@@ -61,104 +59,20 @@ def export_to_geotiff(data_to_export,save_name,**kwargs):
     save_name: string corresponding to desired output file name + file extension
     kwargs: reserved for future use
     '''
-    ds_attrs = data_to_export.attrs
-        
-    # if x and/or y exist as coordinates
-    # but have been squeezed out as dimensions
-    # (eg we have point data), add them back in as dimensions.
-    # rasters require both x and y dimensions
-    if ('x' not in data_to_export.dims):
-        if ('x' in data_to_export.coords):
-            the_sel = data_to_export.expand_dims('x')
-        else:
-            raise ValueError("No x dimension or coordinate exists;"+
-                             " cannot export to GeoTIFF. Please provide"+
-                            " a data array with both x and y"+
-                             " spatial coordinates.")
-    if ('y' not in data_to_export.dims):
-        if ('y' in data_to_export.coords):
-            data_to_export = data_to_export.expand_dims('y')
-        else:
-            raise ValueError("No y dimension or coordinate exists;"+
-                             " cannot export to GeoTIFF. Please provide"+
-                            " a data array with both x and y"+
-                             " spatial coordinates.")
 
-    # squeeze singleton dimensions as long as they are 
-    # simulation and/or scenario dimensions;
-    # retain simulation and/or scenario metadata
-    if (('scenario' in data_to_export.coords) and 
-        ('scenario' not in data_to_export.dims)):
-        scen_attrs = {'scenario' : str(data_to_export.coords['scenario'].values)}
-        ds_attrs = dict(ds_attrs, **scen_attrs)    
-    if (('scenario' in data_to_export.dims) and 
-          (len(data_to_export.scenario)==1)):
-        scen_attr = {'scenario' : str(data_to_export.scenario.values[0])}
-        ds_attrs = dict(ds_attrs, **scen_attr)
-        data_to_export = data_to_export.squeeze(dim='scenario')
-    elif (('scenario' not in data_to_export.dims) and 
-          ('scenario' not in data_to_export.coords)):
-        warnings.warn("'scenario' not in data array as"+
-                      " dimension or coordinate; this information"+
-                      " will be lost on export to raster."+
-                      " Either provide a data array"+
-                      " which contains a single scenario"+
-                      " as a dimension and/or coordinate,"+
-                      " or record the scenario sampled"+
-                      " for your records.")
-
-    if (('simulation' in data_to_export.coords) and 
-        ('simulation' not in data_to_export.dims)):
-        sim_attrs = {'simulation' : str(data_to_export.coords['simulation'].values)}
-        ds_attrs = dict(ds_attrs, **sim_attrs)
-    if ((str('simulation') in data_to_export.dims) and 
-    (len(data_to_export.simulation)==1)):
-        sim_attrs = {'simulation' : str(data_to_export.simulation.values)}
-        ds_attrs = dict(ds_attrs, **sim_attrs)
-        data_to_export = data_to_export.squeeze(dim='simulation')
-    elif (('simulation' not in data_to_export.dims) and 
-          ('simulation' not in data_to_export.coords)):
-        warnings.warn("'simulation' not in data array as"+
-                      " dimension or coordinate; this information"+
-                      " will be lost on export to raster."+
-                      " Either provide a data array"+
-                      " which contains a single simulation"+
-                      " as a dimension and/or coordinate,"+
-                      " or record the simulation sampled"+
-                      " for your records.")
-        
-    ndim = len(data_to_export.dims)
-    if (ndim == 3):
-        if ('time' in data_to_export.dims):
-            data_to_export = data_to_export.transpose('time', 'y', 'x')
-            if (len(data_to_export.time) > 1):
-                print("Saving as multiband raster in which"+
-                 " each band corresponds to a time step.")
-        elif ('simulation' in data_to_export.dims):
-            data_to_export = data_to_export.transpose('simulation', 'y', 'x')
-            if (len(data_to_export.simulation) > 1):
-                print("Saving as multiband raster in which"+
-                 " each band corresponds to a simulation.")
-        elif ('scenario' in data_to_export.dims):
-            data_to_export = data_to_export.transpose('scenario', 'y', 'x')
-            if (len(data_to_export.scenario) > 1):
-                print("Saving as multiband raster in which"+
-                 " each band corresponds to a climate scenario.")
-                    
+    if ('time' in data_to_export.dims):
+        print("NOTE: Saving as multiband raster in which "+
+             "each band corresponds to a time step.")
+        print("See metadata file for more information.")
     print("Saving as GeoTIFF...")
     data_to_export.rio.to_raster(save_name)
-    meta_data_dict = ds_attrs
-    
-    with rasterio.open(save_name, 'r+') as raster:
-        raster.update_tags(**meta_data_dict)
-        raster.close()
     
 def _export_to_user(user_export_format,data_to_export,
                     file_name,**kwargs):
     """
     The data export method, called by core.Application.export_dataset. Saves
-    a dataset to the current working directory in the output 
-    format requested by the user (which is stored in 'user_export_format').
+    a dataset to the current working directory in the output format requested by the user 
+    (which is stored in 'user_export_format').
     
     user_export_format: pulled from dropdown called by app.export_as()
     data_to_export: xarray ds or da to export
@@ -178,7 +92,7 @@ def _export_to_user(user_export_format,data_to_export,
         raise AssertionError("Please select a file format from the dropdown menu.")
     
     extension_dict = {'NetCDF' : '.nc',
-                      'CSV' : '.csv.gz',
+                      'CSV' : '.gz',
                       'GeoTIFF' : '.tif'}
     
     f_extension = extension_dict[req_format]
@@ -192,18 +106,27 @@ def _export_to_user(user_export_format,data_to_export,
    
     ds_attrs = data_to_export.attrs
     ct = datetime.datetime.now()
-    ct_str = ct.strftime("%d-%b-%Y (%H:%M:%S)")    
-    ck_attrs = {'data_exported_from' : 'Cal-Adapt Analytics Engine v 0.0.1',
-               'data_export_timestamp' : ct_str}       
+    ct_str = ct.strftime("%d-%b-%Y (%H:%M)")    
+    
+    ck_attrs = {'Data_exported_from' : 'Cal-Adapt Analytics Engine',
+                'Data_export_timestamp' : ct_str,
+                'Analysis_package_name' : 'climakitae',
+                'Version' : __version__,
+                'Author' : 'Cal-Adapt Analytics Engine Team',
+                'Author_email' : 'analytics@cal-adapt.org',
+                'Home_page' : 'https://github.com/cal-adapt/climakitae',
+                'License' : 'BSD 3-Clause License'}
         
     assert "xarray" in str(
             type(data_to_export)
-            ),("Please pass an xarray dataset (NetCDF only)"+
-               " or data array (any format).")
+            ), "Please pass an xarray dataset or data array (e.g., as output by generate)."
        
     # metadata stuff
     ds_attrs.update(ck_attrs)
     data_to_export.attrs = ds_attrs
+    
+    # squeeze out singleton dims
+    data_to_export = data_to_export.squeeze(drop=True)
     
     # now check file size and avail workspace disk space
     # raise error for not enough space
@@ -213,13 +136,13 @@ def _export_to_user(user_export_format,data_to_export,
     disk_space = shutil.disk_usage('./')[2]/bytes_per_gigabyte
     data_size = data_to_export.nbytes/bytes_per_gigabyte
     
-    if (disk_space <= data_size):
+    if (disk_space < data_size):
         raise ValueError("Not enough disk space to export data!"+
                         " You need at least "+str(data_size)+ " GB free"+
                         " in the hub directory, which has 10 GB total space."+
                          " Try smaller subsets of space, time,"+
-                        " scenario, and/or simulation; pick a coarser"+
-                        " spatial or temporal scale; or clean any exported datasets"+
+                        " scenario, and/or simulation, pick a coarser"+
+                        " spatial or temporal scale, or clean any exported datasets"+
                         " which you have already downloaded or do not want.")
     
     if (data_size > file_size_threshold):
@@ -232,72 +155,22 @@ def _export_to_user(user_export_format,data_to_export,
     if ("NetCDF" in req_format):
         export_to_netcdf(data_to_export,save_name,**kwargs) 
     else:
-        assert "DataArray" in str(type(data_to_export)),("We are only"+
-                             " converting data arrays to this format"+
-                             " at this time, please pass a data array"+
-                             " (not a dataset). HINT:" ) 
-        if ("CSV" in req_format):
-            export_to_csv(data_to_export,save_name,**kwargs)
-        elif ("GeoTIFF" in req_format):
-            dim_check = data_to_export.isel(x=0,y=0).squeeze().shape
-            shape_str = str(dim_check).strip('(').strip(')').replace(", "," x ")
-            if sum([int(dim>1) for dim in dim_check]) > 1:
-                raise AssertionError("Too many non-spatial dimensions"+
-                                     " with length > 1 -- cannot convert"+
-                                     " to GeoTIFF. Current data shape"+
-                                     " excluding x and y coordinates is: "+
-                                     shape_str+". Please subset your"+
-                                     " selection accordingly.")
-                
-            export_to_geotiff(data_to_export,save_name,**kwargs)    
+        if "Dataset" in str(type(data_to_export)):
+            raise ValueError("We are only converting"+
+                             " data arrays to this format at this time,"+
+                             " please pass a data array"+
+                             " (not a dataset).") 
+        else:
+            if ("CSV" in req_format):
+                export_to_csv(data_to_export,save_name,**kwargs)
+            elif ("GeoTIFF" in req_format):
+                assert ndims <= 3,("Cannot export data with more than 3"+
+                       " dimensions as GeoTIFF, please subset data"+
+                       " appropriately to fewer dimensions.")
+                export_to_geotiff(data_to_export,save_name,**kwargs)    
                   
     return(print("Saved! You can find your file(s) in the panel to the left "+
                 "and download to your local machine from there." ))
-
-
-def metadata_to_file(ds,output_name):
-    """
-    Writes NetCDF metadata to a txt file so users can still access it 
-    after exporting to a CSV.
-    """
-    output_name = output_name.strip('.csv.gz')
-    if os.path.exists(output_name+"_metadata.txt"):
-        os.remove(output_name+"_metadata.txt")
-        
-    print("NOTE: File metadata will be written in "+
-          output_name+"_metadata.txt. "+
-         "We recommend you download this along with "+
-         "the CSV for your records.")
-        
-    with open('.'+output_name+"_metadata.txt", 'w') as f:
-        f.write('======== Metadata for CSV file '+output_name+' ========')
-        f.write('\n')
-        f.write('\n')
-        f.write('\n')
-        f.write('===== Global file attributes =====')
-        f.write('\n')
-        f.write('Name: '+ds.name)
-        f.write('\n')
-        for att_keys,att_values in list(zip(ds.attrs.keys(),ds.attrs.values())):    
-            f.write(str(att_keys)+" : "+str(att_values))
-            f.write('\n')                       
-
-        f.write('\n')
-        f.write('\n')
-        f.write('===== Coordinate descriptions =====')
-        f.write('\n')
-        f.write('Note: coordinate values are in the CSV')
-        f.write('\n')
-
-        for coord in ds.coords:
-            f.write('\n')
-            f.write("== "+str(coord)+" ==")
-            f.write('\n')
-            for att_keys,att_values in list(zip(ds[coord].attrs.keys(),
-                                            ds[coord].attrs.values())):    
-                f.write(str(att_keys)+" : "+str(att_values))
-                f.write('\n')
-                
                 
 
             


### PR DESCRIPTION
### About this pull request
With lots of help from @bkg and @elehmer, the export code now automatically pulls the climakitae version number from the config file. It also now appends other metadata from the config file (hard-coded, because I don't expect it to change).

To test: export any file format from almost any notebook (not the timeseries one, as the metadata changes needed to export that are not yet committed to main) and examine the variable attributes. It should be something like:
_FillValue : nan
warming_level : 3.0
Data_exported_from : Cal-Adapt Analytics Engine
Data_export_timestamp : 29-Sep-2022 (23:30)
Analysis_package_name : climakitae
Version : 0.0.1
Author : Cal-Adapt Analytics Engine Team
Author_email : analytics@cal-adapt.org
Home_page : https://github.com/cal-adapt/climakitae
License : BSD 3-Clause License