### PR TITLE
Remove reprojection from app.explore() to avoid overloading memory

### DIFF
--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -100,15 +100,15 @@ def _get_postage_data(area_subset2, cached_area2, variable2, location):
     # Clip data to geometry
     postage_data = postage_data.rio.clip(geometries=ds_region, crs=4326, drop=True)
     
-    # Reproject data to lat/lon
-    try: 
-        postage_data = _reproject_data(
-            xr_da = postage_data, 
-            proj="EPSG:4326", 
-            fill_value=np.nan
-        ) 
-    except: # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error)
-        pass 
+    # # Reproject data to lat/lon
+    # try: 
+    #     postage_data = _reproject_data(
+    #         xr_da = postage_data, 
+    #         proj="EPSG:4326", 
+    #         fill_value=np.nan
+    #     ) 
+    # except: # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error)
+    #     pass 
 
     return postage_data
 

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -99,17 +99,6 @@ def _get_postage_data(area_subset2, cached_area2, variable2, location):
     
     # Clip data to geometry
     postage_data = postage_data.rio.clip(geometries=ds_region, crs=4326, drop=True)
-    
-    # # Reproject data to lat/lon
-    # try: 
-    #     postage_data = _reproject_data(
-    #         xr_da = postage_data, 
-    #         proj="EPSG:4326", 
-    #         fill_value=np.nan
-    #     ) 
-    # except: # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error)
-    #     pass 
-
     return postage_data
 
 


### PR DESCRIPTION
The reprojection code chunk in app.explore.warming_levels() uses a ton of memory, causing the kernel to fail when you play with `app.explore.warming_levels()` (no bueno!!). 

I've commented out this reprojection code. This seems to solve this issue. The explore.warming_levels panel now uses ~1.6GB of memory, instead of ~3.5GB before removing the reprojection code. 

**To test:** Just call app.explore.warming_levels(). Play around with it. Make sure it doesn't crash your kernel. Try running the entire warming_levels notebook from cae-notebooks, **making sure you replace app.explore() with app.explore.warming_levels()** 