### PR TITLE
Switch RH colormap for warming_levels

### DIFF
--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -3,6 +3,7 @@ import hvplot.pandas
 import xarray as xr
 import holoviews as hv
 from holoviews import opts
+import bokeh.palettes
 from matplotlib.figure import Figure
 import numpy as np
 import pandas as pd
@@ -14,7 +15,7 @@ import s3fs
 import pkg_resources
 from .utils import _reproject_data, _read_ae_colormap, _read_var_csv
 
-# Silence warnings 
+# Silence warnings
 import logging
 logging.getLogger("param").setLevel(logging.CRITICAL)
 
@@ -41,7 +42,7 @@ ssp370_data = pd.read_csv(ssp370, index_col='Year')
 ssp585_data = pd.read_csv(ssp585, index_col='Year')
 hist_data = pd.read_csv(hist, index_col='Year')
 
-# Variable descriptions csv with colormap info 
+# Variable descriptions csv with colormap info
 var_descrip = _read_var_csv(var_descrip_pkg, index_col="description")
 
 
@@ -68,12 +69,12 @@ def _get_postage_data(area_subset2, cached_area2, variable2, location):
 
     # Select variable from dataset
     postage_data = pkg_data[variable2].compute()
-    
+
     #================= Modified from data_loaders.py =================
-    
+
     def set_subarea(boundary_dataset):
         return boundary_dataset[boundary_dataset.index == shape_index].iloc[0].geometry
-    
+
     shape_index = int(
             location._geography_choose[location.area_subset][location.cached_area]
         )
@@ -85,18 +86,18 @@ def _get_postage_data(area_subset2, cached_area2, variable2, location):
     elif location.area_subset == "CA watersheds":
         shape = set_subarea(location._geographies._ca_watersheds)
     ds_region = [shape]
-    
+
     #==================================
-    
-    # Un-list attributes so rioxarray can find them when it looks for a crs 
+
+    # Un-list attributes so rioxarray can find them when it looks for a crs
     proj = "Lambert_Conformal"
     for attr_np in ["earth_radius","latitude_of_projection_origin","longitude_of_central_meridian"]:
         postage_data[proj].attrs[attr_np] = postage_data[proj].attrs[attr_np].item()
-    
-    # Add grid-mapping attr (missing from Rel Humidity) 
-    if "grid_mapping" not in postage_data.attrs: 
-        postage_data.attrs["grid_mapping"] = proj 
-    
+
+    # Add grid-mapping attr (missing from Rel Humidity)
+    if "grid_mapping" not in postage_data.attrs:
+        postage_data.attrs["grid_mapping"] = proj
+
     # Clip data to geometry
     postage_data = postage_data.rio.clip(geometries=ds_region, crs=4326, drop=True)
     return postage_data
@@ -116,7 +117,7 @@ def get_anomaly_data(data, warmlevel=3.0):
     model_case = {'cesm2':'CESM2', 'cnrm-esm2-1':'CNRM-ESM2-1',
               'ec-earth3-veg':'EC-Earth3-Veg', 'fgoals-g3':'FGOALS-g3',
               'mpi-esm1-2-lr':'MPI-ESM1-2-LR'}
-    ssp = 'ssp370' 
+    ssp = 'ssp370'
     all_sims = xr.Dataset()
     central_year_l, year_start_l, year_end_l = [],[],[]
     for simulation in data.simulation.values:
@@ -128,28 +129,28 @@ def get_anomaly_data(data, warmlevel=3.0):
                 end_year = centered_time+14
                 anom = one_ts.sel(time=slice(str(start_year),str(end_year))).mean('time') - one_ts.sel(time=slice('1981','2010')).mean('time')
                 all_sims[simulation] = anom
-                
-                # Append to list. Used to assign descriptive attributes & coordinates to final dataset 
-                central_year_l.append(centered_time) 
+
+                # Append to list. Used to assign descriptive attributes & coordinates to final dataset
+                central_year_l.append(centered_time)
                 year_start_l.append(start_year)
                 year_end_l.append(end_year)
     anomaly_da = all_sims.to_array('simulation')
-    
-    # Assign descriptivie coordinates 
+
+    # Assign descriptivie coordinates
     anomaly_da = anomaly_da.assign_coords(
-        {"window_year_center":("simulation",central_year_l), 
-        "window_year_start":("simulation",year_start_l), 
+        {"window_year_center":("simulation",central_year_l),
+        "window_year_start":("simulation",year_start_l),
         "window_year_end":("simulation",year_end_l)}
     )
-    # Assign descriptive attributes to new coordinates 
+    # Assign descriptive attributes to new coordinates
     anomaly_da["window_year_center"].attrs["description"] = "year that defines the center of the 30-year window around which the anomaly was computed"
     anomaly_da["window_year_start"].attrs["description"] = "year that defines the start of the 30-year window around which the anomaly was computed"
     anomaly_da["window_year_end"].attrs["description"] = "year that defines the end of the 30-year window around which the anomaly was computed"
     anomaly_da.attrs["warming_level"] = warmlevel
-    
+
     # Rename
     anomaly_da.name = data.name + " Anomalies"
-    
+
     return anomaly_da
 
 
@@ -166,12 +167,12 @@ def _compute_vmin_vmax(da_min,da_max):
     return vmin, vmax, sopt
 
 
-def _make_hvplot(data, clabel, clim, cmap, sopt, title, width=225, height=210): 
+def _make_hvplot(data, clabel, clim, cmap, sopt, title, width=225, height=210):
     """Make single map"""
     _plot = data.hvplot.image(
-        x="x", y="y", 
+        x="x", y="y",
         grid=True, width=width, height=height, xaxis=None, yaxis=None,
-        clabel=clabel, clim=clim, cmap=cmap, # Colorbar 
+        clabel=clabel, clim=clim, cmap=cmap,
         symmetric=sopt, title=title
     )
     return _plot
@@ -182,7 +183,7 @@ class WarmingLevels(param.Parameterized):
     ## ---------- Reset certain DataSelector and LocSelectorArea options ----------
     def __init__(self, *args, **params):
         super().__init__(*args, **params)
-        
+
         # Selectors defaults
         self.selections.append_historical = True
         self.selections.area_average = False
@@ -210,8 +211,8 @@ class WarmingLevels(param.Parameterized):
     ssp = param.ObjectSelector(default="All",
         objects=[
             "All",
-            "SSP 1-1.9 -- Very Low Emissions Scenario", 
-            "SSP 1-2.6 -- Low Emissions Scenario", 
+            "SSP 1-1.9 -- Very Low Emissions Scenario",
+            "SSP 1-2.6 -- Low Emissions Scenario",
             "SSP 2-4.5 -- Middle of the Road",
             "SSP 3-7.0 -- Business as Usual",
             "SSP 5-8.5 -- Burn it All"
@@ -278,20 +279,20 @@ class WarmingLevels(param.Parameterized):
 
     @param.depends("reload_data2", watch=False)
     def _GCM_PostageStamps_MAIN(self):
-        
-        # Get plot data 
+
+        # Get plot data
         all_plot_data = self._warm_all_anoms
-        if self.variable2 == "Relative Humidity": 
+        if self.variable2 == "Relative Humidity":
             all_plot_data = all_plot_data*100
-            
+
         # Get int number of simulations
         num_simulations = len(all_plot_data.simulation.values)
-            
-        # Set up plotting arguments 
+
+        # Set up plotting arguments
         clabel = self.variable2 + " ("+self.postage_data.attrs["units"]+")"
         cmap_name = var_descrip[self.variable2]["default_cmap"]
         cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
-         
+
         # Compute 1% min and 99% max of all simulations
         vmin_l, vmax_l = [],[]
         for sim in range(num_simulations):
@@ -301,54 +302,64 @@ class WarmingLevels(param.Parameterized):
             vmax_l.append(vmax_i)
         vmin = min(vmin_l)
         vmax = max(vmax_l)
-    
-        # Make each plot 
+
+        # Colormap normalization for hvplot -- only for relative humidity!
+        if self.variable2 == "Relative Humidity":
+            cmap = _read_ae_colormap(cmap="ae_diverging", cmap_hex=True)
+
+        # Make each plot
         all_plots = _make_hvplot( # Need to make the first plot separate from the loop
-            data=all_plot_data.isel(simulation=0), 
+            data=all_plot_data.isel(simulation=0),
             clabel=clabel, clim=(vmin,vmax), cmap=cmap, sopt=sopt,
             title=all_plot_data.isel(simulation=0).simulation.item()
         )
-        for sim_i in range(1,num_simulations): 
+        for sim_i in range(1,num_simulations):
             pl_i = _make_hvplot(
-                data=all_plot_data.isel(simulation=sim_i), 
+                data=all_plot_data.isel(simulation=sim_i),
                 clabel=clabel, clim=(vmin,vmax), cmap=cmap, sopt=sopt,
                 title=all_plot_data.isel(simulation=sim_i).simulation.item()
             )
             all_plots += pl_i
-        
-        try: 
-            all_plots.cols(3) # Organize into 3 columns 
+
+        try:
+            all_plots.cols(3) # Organize into 3 columns
             all_plots.opts(title=self.variable2+ ': Anomalies for '+str(self.warmlevel)+'°C Warming by Simulation') # Add title
-        except: 
+        except:
             all_plots.opts(title=str(self.warmlevel)+'°C Anomalies') # Add shorter title
-        
+
         all_plots.opts(toolbar="below") # Set toolbar location
-        all_plots.opts(hv.opts.Layout(merge_tools=True)) # Merge toolbar 
+        all_plots.opts(hv.opts.Layout(merge_tools=True)) # Merge toolbar
         return all_plots
-        
-        
+
+
     @param.depends("reload_data2", watch=False)
     def _GCM_PostageStamps_STATS(self):
-        
-        # Get plot data 
+
+        # Get plot data
         all_plot_data = self._warm_all_anoms
-        if self.variable2 == "Relative Humidity": 
+        if self.variable2 == "Relative Humidity":
             all_plot_data = all_plot_data*100
-        
+
         # Compute stats
         min_data = all_plot_data.min(dim='simulation')
         max_data = all_plot_data.max(dim='simulation')
         med_data = all_plot_data.median(dim='simulation')
         mean_data = all_plot_data.mean(dim='simulation')
-        
-        # Set up plotting arguments 
+
+        # Set up plotting arguments
         width=210
         height=210
         clabel = self.variable2 + " ("+self.postage_data.attrs["units"]+")"
         cmap_name = var_descrip[self.variable2]["default_cmap"]
         cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
         vmin, vmax, sopt = _compute_vmin_vmax(min_data,max_data)
-        
+
+        if self.variable2 == "Relative Humidity":
+            cmap = _read_ae_colormap(cmap='ae_diverging', cmap_hex=True)
+        else:
+            cmap_name = var_descrip[self.variable2]["default_cmap"]
+            cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
+
         # Make plots
         min_plot = _make_hvplot(data=min_data, clabel=clabel, cmap=cmap, clim=(vmin,vmax), sopt=sopt, title="Minimum", width=width, height=height)
         max_plot = _make_hvplot(data=max_data, clabel=clabel, cmap=cmap,  clim=(vmin,vmax), sopt=sopt, title="Maximum", width=width, height=height)
@@ -358,23 +369,23 @@ class WarmingLevels(param.Parameterized):
         all_plots = (mean_plot+med_plot+min_plot+max_plot)
         all_plots.opts(title=self.variable2+ ': Anomalies for '+str(self.warmlevel)+'°C Warming Across Models') # Add title
         all_plots.opts(toolbar="below") # Set toolbar location
-        all_plots.opts(hv.opts.Layout(merge_tools=True)) # Merge toolbar 
+        all_plots.opts(hv.opts.Layout(merge_tools=True)) # Merge toolbar
         return all_plots
 
-    
+
     @param.depends("reload_data2", watch=False)
-    def _30_yr_window(self): 
+    def _30_yr_window(self):
         """Create a dataframe to give information about the 30-yr anomalies window for each simulation used in the postage stamp maps. """
         anom = self._warm_all_anoms
         df = pd.DataFrame(
             {"simulation":anom.simulation.values,
-            "30-yr window":zip(anom.window_year_start.values,anom.window_year_end.values), 
-            "central year":anom.window_year_center.values, 
-            "warming level":[anom.attrs["warming_level"]]*len(anom.simulation)} 
-        ) 
+            "30-yr window":zip(anom.window_year_start.values,anom.window_year_end.values),
+            "central year":anom.window_year_center.values,
+            "warming level":[anom.attrs["warming_level"]]*len(anom.simulation)}
+        )
         df_pane = pn.pane.DataFrame(
-            df, 
-            width=400, 
+            df,
+            width=400,
             index=False
         )
         return df_pane
@@ -401,7 +412,7 @@ class WarmingLevels(param.Parameterized):
         ipcc_data = (
             hist_data.hvplot(y="Mean", color="k", label="Historical", width=width, height=height) *
             hist_data.hvplot.area(x="Year", y="5%", y2="95%", alpha=0.1, color="k", ylabel="°C", xlabel="", ylim=[-1,5], xlim=[1950,2100])
-        ) 
+        )
         if self.ssp == "All":
             ipcc_data = (
                 ipcc_data *
@@ -411,15 +422,15 @@ class WarmingLevels(param.Parameterized):
                 ssp370_data.hvplot(y="Mean", color=c370, label="SSP3-7.0") *
                 ssp585_data.hvplot(y="Mean", color=c585, label="SSP5-8.5")
             )
-        elif self.ssp == "SSP 1-1.9 -- Very Low Emissions Scenario": 
+        elif self.ssp == "SSP 1-1.9 -- Very Low Emissions Scenario":
             ipcc_data = (ipcc_data * ssp119_data.hvplot(y="Mean", color=c119, label="SSP1-1.9"))
-        elif self.ssp == "SSP 1-2.6 -- Low Emissions Scenario": 
+        elif self.ssp == "SSP 1-2.6 -- Low Emissions Scenario":
             ipcc_data = (ipcc_data * ssp126_data.hvplot(y="Mean", color=c126, label="SSP1-2.6"))
-        elif self.ssp == "SSP 2-4.5 -- Middle of the Road": 
+        elif self.ssp == "SSP 2-4.5 -- Middle of the Road":
             ipcc_data = (ipcc_data * ssp245_data.hvplot(y="Mean", color=c245, label="SSP2-4.5"))
-        elif self.ssp == "SSP 3-7.0 -- Business as Usual": 
+        elif self.ssp == "SSP 3-7.0 -- Business as Usual":
             ipcc_data = (ipcc_data * ssp370_data.hvplot(y="Mean", color=c370, label="SSP3-7.0"))
-        elif self.ssp == "SSP 5-8.5 -- Burn it All": 
+        elif self.ssp == "SSP 5-8.5 -- Burn it All":
             ipcc_data = (ipcc_data * ssp585_data.hvplot(y="Mean", color=c585, label="SSP5-8.5"))
 
 
@@ -429,72 +440,72 @@ class WarmingLevels(param.Parameterized):
         # Warming level connection lines & additional labeling
         warmlevel_line = hv.HLine(self.warmlevel).opts(color="black", line_width=1.0) * hv.Text(x=1964, y=self.warmlevel+0.25, text=".    " + str(self.warmlevel) + "°C warming level").opts(style=dict(text_font_size='8pt'))
 
-        # Create plot 
+        # Create plot
         to_plot = ipcc_data * warmlevel_line
 
-        if self.ssp != "All": 
-            # Label to give addional plot info 
+        if self.ssp != "All":
+            # Label to give addional plot info
             info_label = "Intersection information"
-            
-            # Add interval line and shading around selected SSP 
+
+            # Add interval line and shading around selected SSP
             ssp_dict = {
-                "SSP 1-1.9 -- Very Low Emissions Scenario":(ssp119_data, c119), 
-                "SSP 1-2.6 -- Low Emissions Scenario":(ssp126_data, c126), 
+                "SSP 1-1.9 -- Very Low Emissions Scenario":(ssp119_data, c119),
+                "SSP 1-2.6 -- Low Emissions Scenario":(ssp126_data, c126),
                 "SSP 2-4.5 -- Middle of the Road":(ssp245_data,c245),
                 "SSP 3-7.0 -- Business as Usual":(ssp370_data,c370),
                 "SSP 5-8.5 -- Burn it All":(ssp585_data,c585)
             }
-            
+
             ssp_selected = ssp_dict[self.ssp][0] # data selected
             ssp_color = ssp_dict[self.ssp][1] # color corresponding to ssp selected
 
             # Shading around selected SSP
             ci_label = "90% interval"
             ssp_shading = ssp_selected.hvplot.area(
-                x="Year", 
-                y="5%", 
-                y2="95%", 
-                alpha=0.28, 
-                color=ssp_color, 
+                x="Year",
+                y="5%",
+                y2="95%",
+                alpha=0.28,
+                color=ssp_color,
                 label=ci_label
-            ) 
-            to_plot = to_plot*ssp_shading 
+            )
+            to_plot = to_plot*ssp_shading
 
             # If the mean/upperbound/lowerbound does not cross threshold, set to 2100 (not visible)
             if (np.argmax(ssp_selected["Mean"] > self.warmlevel)) > 0:
-                
-                # Add dashed line 
+
+                # Add dashed line
                 label1 = "Warming level reached"
                 year_warmlevel_reached = ssp_selected.where(ssp_selected["Mean"] > self.warmlevel).dropna().index[0]
                 ssp_int = hv.Curve(
-                    [[year_warmlevel_reached,-2],[year_warmlevel_reached,10]], 
+                    [[year_warmlevel_reached,-2],[year_warmlevel_reached,10]],
                     label=label1
-                ).opts(color=ssp_color, line_dash="dashed", line_width=1) 
+                ).opts(color=ssp_color, line_dash="dashed", line_width=1)
                 ssp_int = ssp_int * hv.Text(
-                    x=year_warmlevel_reached-2, y=4.5, 
-                    text=str(int(year_warmlevel_reached)), 
-                    rotation=90, 
+                    x=year_warmlevel_reached-2, y=4.5,
+                    text=str(int(year_warmlevel_reached)),
+                    rotation=90,
                     label=label1
                 ).opts(style=dict(text_font_size='8pt',color=ssp_color))
-                to_plot *= ssp_int # Add to plot 
-                
+                to_plot *= ssp_int # Add to plot
+
             if ((np.argmax(ssp_selected["95%"] > self.warmlevel)) > 0) and ((np.argmax(ssp_selected["5%"] > self.warmlevel)) > 0):
                 # Make 95% CI line
                 x_95 = cmip_t[0] + np.argmax(ssp_selected["95%"] > self.warmlevel)
                 ssp_firstdate = hv.Curve(
-                    [[x_95,-2],[x_95,10]], 
+                    [[x_95,-2],[x_95,10]],
                     label=ci_label
                 ).opts(color=ssp_color, line_width=1)
                 to_plot *= ssp_firstdate
-                
+
                 # Make 5% CI line
                 x_5 = cmip_t[0] + np.argmax(ssp_selected["5%"] > self.warmlevel)
                 ssp_lastdate = hv.Curve(
-                    [[x_5,-2],[x_5,10]], 
+                    [[x_5,-2],[x_5,10]],
                     label=ci_label
                 ).opts(color=ssp_color, line_width=1)
-                to_plot *= ssp_lastdate 
-                
+                to_plot *= ssp_lastdate
+
                 ## Bar to connect firstdate and lastdate of threshold cross
                 bar_y = -0.5
                 yr_len = [(x_95, bar_y), (x_5, bar_y)]
@@ -504,12 +515,12 @@ class WarmingLevels(param.Parameterized):
                         [[x_95,bar_y],[x_5,bar_y]],
                         label=ci_label
                     ).opts(color=ssp_color, line_width=1) * hv.Text(
-                        x=x_95+5, 
-                        y=bar_y+0.25, 
-                        text=str(yr_rng) + "yrs", 
+                        x=x_95+5,
+                        y=bar_y+0.25,
+                        text=str(yr_rng) + "yrs",
                         label=ci_label
                     ).opts(style=dict(text_font_size='8pt', color=ssp_color))
-                    
+
                     to_plot *= interval
 
         to_plot.opts(opts.Overlay(title='Global mean surface temperature change relative to 1850-1900', fontsize=12))
@@ -558,14 +569,14 @@ def _display_warming_levels(warming_data, selections, location):
             warming_data._GCM_PostageStamps_MAIN,
             pn.Column(
                 pn.widgets.StaticText(
-                    value="<br><br><br>", 
+                    value="<br><br><br>",
                     width=150
                 ),
                 pn.widgets.StaticText(
                     value="<b>Tip</b>: There's a toolbar below the maps. \
         Try clicking the magnifying glass to zoom in on a particular region. \
-        You can also click the save button to save a copy of the figure to your computer.", 
-                    width=150, 
+        You can also click the save button to save a copy of the figure to your computer.",
+                    width=150,
                     style={"border":"1.2px red solid","padding":"5px","border-radius":"4px","font-size":"13px"})
             )
         )
@@ -578,7 +589,7 @@ def _display_warming_levels(warming_data, selections, location):
         ),
         warming_data._GCM_PostageStamps_STATS
     )
-    
+
     window_df = pn.Column(
         pn.widgets.StaticText(
             value="This panel displays start and end years that define the 30-year window for which the anomalies were computed for each model. It also displays the year at which each model crosses the selected warming level, defined in the table below as the central year. This information corresponds to the anomalies shown in the maps on the previous two tabs.",

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -290,7 +290,6 @@ class WarmingLevels(param.Parameterized):
         # Set up plotting arguments
         clabel = self.variable2 + " ("+self.postage_data.attrs["units"]+")"
         cmap_name = var_descrip[self.variable2]["default_cmap"]
-        cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
 
         # Compute 1% min and 99% max of all simulations
         vmin_l, vmax_l = [],[]
@@ -305,6 +304,8 @@ class WarmingLevels(param.Parameterized):
         # Colormap normalization for hvplot -- only for relative humidity!
         if self.variable2 == "Relative Humidity":
             cmap = _read_ae_colormap(cmap="ae_diverging", cmap_hex=True)
+        else:
+            cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
 
         # Make each plot
         all_plots = _make_hvplot( # Need to make the first plot separate from the loop
@@ -350,13 +351,11 @@ class WarmingLevels(param.Parameterized):
         height=210
         clabel = self.variable2 + " ("+self.postage_data.attrs["units"]+")"
         cmap_name = var_descrip[self.variable2]["default_cmap"]
-        cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
         vmin, vmax, sopt = _compute_vmin_vmax(min_data,max_data)
 
         if self.variable2 == "Relative Humidity":
             cmap = _read_ae_colormap(cmap='ae_diverging', cmap_hex=True)
         else:
-            cmap_name = var_descrip[self.variable2]["default_cmap"]
             cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
 
         # Make plots

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -3,7 +3,6 @@ import hvplot.pandas
 import xarray as xr
 import holoviews as hv
 from holoviews import opts
-import bokeh.palettes
 from matplotlib.figure import Figure
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Simple PR to switch the colormap for relative humidity **only*** in warming_levels, because it has both positive and negative values. 

**Caveat**: If/when the warming_levels introduces more variables than just air temperature and relative humidity, a more extensive anomaly colormap setting will need to be in place. All variables have a default colormap in the descriptions csv, however this _should_ be overridden when an anomaly is calculated to display a diverging colormap instead. Midpoint normalizing may need to occur then: https://discourse.holoviz.org/t/diverging-colorbar-around-asymetric-data/3339

To test this, just look at relative humidity in app.explore.warming_levels() and make sure that its the diverging colormap instead of its preset blues. 