### PR TITLE
Fine-tuning on AMY for diurnal cycles + export

### DIFF
--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -23,7 +23,6 @@ import cartopy.crs as ccrs
 import hvplot.xarray
 import hvplot.pandas
 import xarray as xr
-# import climtas
 import holoviews as hv
 from holoviews import opts
 from matplotlib.figure import Figure
@@ -118,7 +117,7 @@ def tmy_calc(data, days_in_year=366):
     """
     Calculates the average meteorological year based on a designated period of time.
     Applicable for both the historical and future periods.
-    Returns: list of tmy
+    Returns: dataframe of amy
     """
     hourly_list = []
     for x in np.arange(1, days_in_year+1, 1):
@@ -130,7 +129,18 @@ def tmy_calc(data, days_in_year=366):
             drop = True).sortby("time.hour")
         np_typical_hourly_data_on_day_x = remove_repeats(typical_hourly_data_on_day_x)
         hourly_list.append(np_typical_hourly_data_on_day_x)
-    return hourly_list
+
+    ## Funnel data into pandas DataFrame object
+    df_amy = pd.DataFrame(hourly_list, columns=np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
+    df_amy = df_amy.iloc[::-1]
+
+    ## Re-order columns for PST, with easy to read time labels
+    df_amy = df_amy[[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,1,2,3,4,5,6,7]]
+    df_amy.columns = [
+        '12am','1am','2am','3am','4am','5am','6am','7am','8am','9am','10am','11am',
+        '12pm','1pm','2pm','3pm','4pm','5pm','6pm','7pm','8pm','9pm','10pm','11pm'
+    ]
+    return df_amy
 
 
 class AverageMeteorologicalYear(param.Parameterized):
@@ -289,23 +299,24 @@ class AverageMeteorologicalYear(param.Parameterized):
     @param.depends("reload_data", watch=False)
     def _tmy_hourly_heatmap(self):
 
-        tmy_hist = tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
-        tmy_future = tmy_calc(self.future_tmy_data, days_in_year=days_in_year)
+        # tmy_hist = tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
+        # tmy_future = tmy_calc(self.future_tmy_data, days_in_year=days_in_year)
 
-        ## Funnel data into pandas DataFrame object
-        df_hist = pd.DataFrame(tmy_hist, columns=np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
-        df_hist = df_hist.iloc[::-1]
-        df_future = pd.DataFrame(tmy_future, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
-        df_future = df_future.iloc[::-1]
+        # ## Funnel data into pandas DataFrame object
+        # df_hist = pd.DataFrame(tmy_hist, columns=np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
+        # df_hist = df_hist.iloc[::-1]
+        # df_future = pd.DataFrame(tmy_future, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
+        # df_future = df_future.iloc[::-1]
 
         # update heatmap df and title with selections
+        days_in_year = 366
         if self.tmy_options == "Absolute":
             if self.tmy_advanced_options == "Historical":
-                df = df_hist
+                df = tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nAbsolute {} Baseline".format(self.cached_area2, self.tmy_advanced_options)
                 clabel = self.variable2 + " (" +self.historical_tmy_data.attrs["units"]+")"
             else:
-                df = df_future
+                df = tmy_calc(self.future_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nAbsolute {} at {}°C".format(
                     self.cached_area2,
                     self.tmy_advanced_options,
@@ -314,14 +325,14 @@ class AverageMeteorologicalYear(param.Parameterized):
         elif self.tmy_options == "Difference":
             cmap = _read_ae_colormap("ae_diverging", cmap_hex = True)
             if self.tmy_advanced_options == "Warming Level Future":
-                df = df_future - df_hist
+                df = tmy_calc(self.future_tmy_data, days_in_year=days_in_year) - tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nDifference between {} at {}°C and Historical Baseline".format(
                     self.cached_area2,
                     self.tmy_advanced_options,
                     self.warmlevel)
                 clabel = self.variable2 + " (" +self.historical_tmy_data.attrs["units"]+")"
             else:
-                df = df_future - df_hist # placeholder for now for severe amy
+                df = tmy_calc(self.future_tmy_data, days_in_year=days_in_year) - tmy_calc(self.historical_tmy_data, days_in_year=days_in_year) # placeholder for now for severe amy
                 title = "Average Meteorological Year: {}\nDifference between {} at 90th percentile and Historical Baseline".format(
                     self.cached_area2,
                     self.tmy_advanced_options)
@@ -329,16 +340,15 @@ class AverageMeteorologicalYear(param.Parameterized):
         else:
             title = "Average Meteorological Year\n{}".format(self.cached_area2)
 
-        # Manual re-ordering for PST time from UTC and easy-to-understand labels
-        df = df[[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,1,2,3,4,5,6,7]]
-        df.columns = [
-            '12am','1am','2am','3am','4am','5am','6am','7am','8am','9am','10am','11am',
-            '12pm','1pm','2pm','3pm','4pm','5pm','6pm','7pm','8pm','9pm','10pm','11pm'
-        ]
+        # # Manual re-ordering for PST time from UTC and easy-to-understand labels
+        # df = df[[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,1,2,3,4,5,6,7]]
+        # df.columns = [
+        #     '12am','1am','2am','3am','4am','5am','6am','7am','8am','9am','10am','11am',
+        #     '12pm','1pm','2pm','3pm','4pm','5pm','6pm','7pm','8pm','9pm','10pm','11pm'
+        # ]
 
         cmap_name = var_descrip[self.variable2]["default_cmap"]
         cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
-
 
         heatmap = df.hvplot.heatmap(
             x='columns',

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -132,7 +132,6 @@ def tmy_calc(data, days_in_year=366):
 
     ## Funnel data into pandas DataFrame object
     df_amy = pd.DataFrame(hourly_list, columns=np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
-    df_amy = df_amy.iloc[::-1]
 
     ## Re-order columns for PST, with easy to read time labels
     df_amy = df_amy[[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,1,2,3,4,5,6,7]]
@@ -298,16 +297,6 @@ class AverageMeteorologicalYear(param.Parameterized):
 
     @param.depends("reload_data", watch=False)
     def _tmy_hourly_heatmap(self):
-
-        # tmy_hist = tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
-        # tmy_future = tmy_calc(self.future_tmy_data, days_in_year=days_in_year)
-
-        # ## Funnel data into pandas DataFrame object
-        # df_hist = pd.DataFrame(tmy_hist, columns=np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
-        # df_hist = df_hist.iloc[::-1]
-        # df_future = pd.DataFrame(tmy_future, columns = np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
-        # df_future = df_future.iloc[::-1]
-
         # update heatmap df and title with selections
         days_in_year = 366
         if self.tmy_options == "Absolute":
@@ -331,21 +320,14 @@ class AverageMeteorologicalYear(param.Parameterized):
                     self.tmy_advanced_options,
                     self.warmlevel)
                 clabel = self.variable2 + " (" +self.historical_tmy_data.attrs["units"]+")"
-            else:
-                df = tmy_calc(self.future_tmy_data, days_in_year=days_in_year) - tmy_calc(self.historical_tmy_data, days_in_year=days_in_year) # placeholder for now for severe amy
+            else:   # placeholder for now for severe amy
+                df = tmy_calc(self.future_tmy_data, days_in_year=days_in_year) - tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nDifference between {} at 90th percentile and Historical Baseline".format(
                     self.cached_area2,
                     self.tmy_advanced_options)
                 clabel = self.variable2 + " (" +self.historical_tmy_data.attrs["units"]+")"
         else:
             title = "Average Meteorological Year\n{}".format(self.cached_area2)
-
-        # # Manual re-ordering for PST time from UTC and easy-to-understand labels
-        # df = df[[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,1,2,3,4,5,6,7]]
-        # df.columns = [
-        #     '12am','1am','2am','3am','4am','5am','6am','7am','8am','9am','10am','11am',
-        #     '12pm','1pm','2pm','3pm','4pm','5pm','6pm','7pm','8pm','9pm','10pm','11pm'
-        # ]
 
         cmap_name = var_descrip[self.variable2]["default_cmap"]
         cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -111,7 +111,7 @@ def remove_repeats(xr_data):
         return xr_data.values
 
 
-## Compute hourly TMY for each hour of the year
+## Compute hourly AMY for each hour of the year
 days_in_year = 366
 def tmy_calc(data, days_in_year=366):
     """
@@ -134,11 +134,19 @@ def tmy_calc(data, days_in_year=366):
     df_amy = pd.DataFrame(hourly_list, columns=np.arange(1,25,1), index=np.arange(1,days_in_year+1,1))
 
     ## Re-order columns for PST, with easy to read time labels
-    df_amy = df_amy[[8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,1,2,3,4,5,6,7]]
-    df_amy.columns = [
-        '12am','1am','2am','3am','4am','5am','6am','7am','8am','9am','10am','11am',
-        '12pm','1pm','2pm','3pm','4pm','5pm','6pm','7pm','8pm','9pm','10pm','11pm'
-    ]
+    cols = df_amy.columns.tolist()
+    cols = cols[7:] + cols[:7]
+    df_amy = df_amy[cols]
+
+    n_col_lst = []
+    for ampm in ['am', 'pm']:
+        hr_lst = []
+        for hr in range(1, 13, 1):
+            hr_lst.append(str(hr)+ampm)
+        hr_lst = hr_lst[-1:] + hr_lst[:-1]
+        n_col_lst = n_col_lst + hr_lst
+    df_amy.columns = n_col_lst
+
     return df_amy
 
 


### PR DESCRIPTION
This PR works explicitly for in-notebook features for the Average Meteorological year notebook: https://github.com/cal-adapt/cae-examples/blob/typical_meteorological_year/explore_amy.ipynb

Effectively: the two critical AMY functions **tmy_calc** and **remove_repeats** were pulled out of the class so that they could be calleable in-notebook for analyzing/plotting a diurnal cycle, an annual cycle, and export functionality of the AMY dataframe itself. Some of the dataframe transforms were therefore included and cleaned up in the larger script. 

**Note**: Exporting the AMY dataframe _currently_ does not conform to our existing export functionality, so there is a separate in line call for that. Exporting the relevant catalog data works as desired. 

To test this: please run through the explore_amy notebook over in cae-examples branch `typical_meteorological_year`