### PR TITLE
Cleans up toolbar options for AMY heatmap

### DIFF
--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -231,7 +231,7 @@ class AverageMeteorologicalYear(param.Parameterized):
             catalog=self.catalog,
             warmlevel=1.5
         )
-        
+
         # Selectors defaults
         self.selections.append_historical = False
         self.selections.area_average = True
@@ -250,7 +250,7 @@ class AverageMeteorologicalYear(param.Parameterized):
 
     # For reloading data and plots
     reload_data = param.Action(lambda x: x.param.trigger('reload_data'), label='Reload Data')
-    
+
     @param.depends("tmy_advanced_options","reload_data","warmlevel", watch=True)
     def _update_data_to_be_returned(self):
         """Update self.selections so that the correct data is returned by app.retrieve()"""
@@ -258,7 +258,7 @@ class AverageMeteorologicalYear(param.Parameterized):
             self.selections.scenario = ["Historical Climate"]
             self.selections.time_slice = (1981,2010) # to match historical 30-year average
 
-        elif self.tmy_advanced_options == "Warming Level Future": 
+        elif self.tmy_advanced_options == "Warming Level Future":
             warming_year_average_range = {
                 1.5 : (2034,2063),
                 2 : (2047,2076),
@@ -266,7 +266,7 @@ class AverageMeteorologicalYear(param.Parameterized):
             }
             self.selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
             self.selections.time_slice = warming_year_average_range[self.warmlevel]
-            
+
 
     @param.depends("variable2", watch=True)
     def _update_variable(self):
@@ -366,9 +366,9 @@ class AverageMeteorologicalYear(param.Parameterized):
             xlabel="Hour of Day (PST)",
             ylabel="Day of Year", clabel=clabel, rot=60,
             width=800, height=350).opts(
-            fontsize={'title': 13, 'xlabel':12, 'ylabel':12}
+            fontsize={'title': 13, 'xlabel':12, 'ylabel':12},
+            toolbar="below"
         )
-        heatmap.opts(toolbar="below")
 
         return heatmap
 


### PR DESCRIPTION
Quick fix for Issue https://github.com/cal-adapt/climakitae/issues/109

Just moves the toolbar statement into a single .opts() call with minor whitespace cleaning

To test: 
Just make sure that the AMY heatmap in explore_amy notebook (or by calling app.explore.amy) works as desired. 