### PR TITLE
Small catalog fixes 

### DIFF
--- a/climakitae/catalog_convert.py
+++ b/climakitae/catalog_convert.py
@@ -1,16 +1,16 @@
 """Helper functions for working with ESM catalog and user data selections"""
 
-def _convert_resolution(resolution, reverse = False):
+def _resolution_to_gridlabel(resolution, reverse = False):
     """Convert resolution format to grid_label format matching catalog names.
     Set reverse=True to get resolution format from input grid_label.
     """
-    res_dict = {"45km":"d01", "9km":"d02", "3km":"d03"}
+    res_dict = {"45 km":"d01", "9 km":"d02", "3 km":"d03"}
 
     if reverse == True:
         res_dict = {v: k for k, v in res_dict.items()}
     return res_dict[resolution]
 
-def _convert_timescale(timescale, reverse = False):
+def _timescale_to_table_id(timescale, reverse = False):
     """Convert resolution format to table_id format matching catalog names.
     Set reverse=True to get resolution format from input table_id.
     """
@@ -20,7 +20,7 @@ def _convert_timescale(timescale, reverse = False):
         timescale_dict = {v: k for k, v in timescale_dict.items()}
     return timescale_dict[timescale]
 
-def _convert_scenario(scenario, reverse = False):
+def _scenario_to_experiment_id(scenario, reverse = False):
     """
     Convert scenario format to experiment_id format matching catalog names.
     Set reverse=True to get scenario format from input experiement_id.

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -1,4 +1,5 @@
 import xarray as xr
+import dask 
 import rioxarray
 import intake
 import numpy as np
@@ -10,8 +11,9 @@ from .catalog_convert import (
 )
 from .unit_conversions import _convert_units
 
-# support methods for core.Application.generate
+# Set options 
 xr.set_options(keep_attrs = True)
+dask.config.set({"array.slicing.split_large_chunks": True})
 
 # ============================ Helper functions ================================
 

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -3,10 +3,10 @@ import rioxarray
 import intake
 import numpy as np
 from shapely.geometry import box
-from .catalog_utils import (
-    _convert_resolution,
-    _convert_timescale,
-    _convert_scenario
+from .catalog_convert import (
+    _resolution_to_gridlabel,
+    _timescale_to_table_id,
+    _scenario_to_experiment_id
 )
 from .unit_conversions import _convert_units
 
@@ -67,10 +67,10 @@ def _get_cat_subset(selections, cat):
 
     # Get catalog keys
     # Convert user-friendly names to catalog names (i.e. "45km" to "d01")
-    activity_id = selections.dataset
-    table_id = _convert_timescale(selections.timescale)
-    grid_label = _convert_resolution(selections.resolution)
-    experiment_id = [_convert_scenario(x) for x in scenario_selections]
+    activity_id = selections.downscaling_method
+    table_id = _timescale_to_table_id(selections.timescale)
+    grid_label = _resolution_to_gridlabel(selections.resolution)
+    experiment_id = [_scenario_to_experiment_id(x) for x in scenario_selections]
     variable_id = selections.variable_id
 
     # Get catalog subset
@@ -161,12 +161,12 @@ def _process_and_concat(selections, dsets, cat_subset):
 
     for scenario in scenario_list:
         sim_list = []
-        da_name = _convert_scenario(scenario, reverse = True)
+        da_name = _scenario_to_experiment_id(scenario, reverse = True)
         for simulation in cat_subset.unique()["source_id"]["values"]:
             if selections.append_historical and "ssp" in scenario:
 
                 # Reset name
-                da_name = "Historical + " + _convert_scenario(scenario, reverse = True)
+                da_name = "Historical + " + _scenario_to_experiment_id(scenario, reverse = True)
 
                 # Get filenames
                 try:
@@ -250,6 +250,12 @@ def _read_from_catalog(selections, location, cat):
     """
     # Raise error if no scenarios are selected
     assert not selections.scenario == [], "Please select as least one scenario."
+    
+    # Raise error if no simulation is selected and append_historical == True
+    if selections.append_historical:
+        if not any(['SSP' in s for s in selections.scenario]):
+            raise ValueError('Please also select at least one SSP to '
+                     'which the historical simulation should be appended.')
 
     # Get catalog subset for a set of user selections
     cat_subset = _get_cat_subset(selections = selections, cat = cat)

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -11,10 +11,10 @@ import geopandas as gpd
 import pandas as pd
 import pkg_resources
 from .unit_conversions import _get_unit_conversion_options
-from .catalog_utils import (
-    _convert_resolution,
-    _convert_timescale,
-    _convert_scenario
+from .catalog_convert import (
+    _resolution_to_gridlabel,
+    _timescale_to_table_id,
+    _scenario_to_experiment_id
 )
 
 # Import package data 
@@ -375,8 +375,8 @@ class DataSelector(param.Parameterized):
     area_average = param.Boolean(default = False)
 
     resolution = param.ObjectSelector(
-        default = "45km",
-        objects = ["45km", "9km", "3km"]
+        default = "45 km",
+        objects = ["45 km", "9 km", "3 km"]
     )
     timescale = param.ObjectSelector(
         default = "monthly",
@@ -384,7 +384,7 @@ class DataSelector(param.Parameterized):
     )
 
     # Empty params, initialized in __init__
-    dataset = param.ObjectSelector(objects = dict())
+    downscaling_method = param.ObjectSelector(objects = dict())
     scenario = param.ListSelector(objects = dict())
     variable = param.ObjectSelector(objects = dict())
     units = param.ObjectSelector(objects = dict())
@@ -395,15 +395,15 @@ class DataSelector(param.Parameterized):
         # Set default values
         super().__init__(**params)
 
-        # Dataset selection
-        self.dataset = "WRF"
+        # Downscaling method selection
+        self.downscaling_method = "WRF"
 
         # Variable catalog info
         self.unique_variable_ids, self.scenario_options = _get_unique_variables( # Get a list of unique variable ids for that catalog subset
             cat = self.cat,
-            activity_id = self.dataset,
-            table_id = _convert_timescale(self.timescale),
-            grid_label = _convert_resolution(self.resolution)
+            activity_id = self.downscaling_method,
+            table_id = _timescale_to_table_id(self.timescale),
+            grid_label = _resolution_to_gridlabel(self.resolution)
         )
 
         self.variable_options_df = _get_variable_options_df( # Get more info about that subset of unique variable ids 
@@ -413,7 +413,7 @@ class DataSelector(param.Parameterized):
         )
 
         # Set scenario param
-        scenario_options = [_convert_scenario(x, reverse = True) for x in self.scenario_options]
+        scenario_options = [_scenario_to_experiment_id(x, reverse = True) for x in self.scenario_options]
 
         # Reorder list
         for scenario_i in [
@@ -448,9 +448,9 @@ class DataSelector(param.Parameterized):
         # Get a list of unique variable ids for that catalog subset
         self.unique_variable_ids, self.scenario_options = _get_unique_variables(
             cat = self.cat,
-            activity_id = self.dataset,
-            table_id = _convert_timescale(self.timescale),
-            grid_label = _convert_resolution(self.resolution)
+            activity_id = self.downscaling_method,
+            table_id = _timescale_to_table_id(self.timescale),
+            grid_label = _resolution_to_gridlabel(self.resolution)
         )
 
         # Get more info about that subset of unique variable ids
@@ -469,7 +469,7 @@ class DataSelector(param.Parameterized):
     @param.depends("resolution", "location.area_subset", watch = True)
     def _update_states_3km(self):
         if self.location.area_subset == "states":
-            if self.resolution == "3km":
+            if self.resolution == "3 km":
                 self.location.param["cached_area"].objects = ["CA", "NV", "OR", "UT", "AZ"]
                 self.location.cached_area = "CA"
             else:
@@ -502,7 +502,7 @@ class DataSelector(param.Parameterized):
         "Append historical" is also selected.
         """ 
         # Get scenario options in catalog format
-        scenario_options = [_convert_scenario(x, reverse = True) for x in self.scenario_options]
+        scenario_options = [_scenario_to_experiment_id(x, reverse = True) for x in self.scenario_options]
         
         # Reorder list
         for scenario_i in [

--- a/climakitae/threshold_panel.py
+++ b/climakitae/threshold_panel.py
@@ -90,7 +90,7 @@ class ThresholdDataParams(param.Parameterized):
         # Selectors defaults
         self.selections.append_historical = False
         self.selections.area_average = True
-        self.selections.resolution = "45km"
+        self.selections.resolution = "45 km"
         self.selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
         self.selections.time_slice = (2020, 2100)
         self.selections.timescale = "hourly"

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -54,7 +54,7 @@ def _get_historical_tmy_data(selections, location, catalog):
     """Get historical data from AWS catalog"""
     selections.append_historical = False
     selections.area_average = True
-    selections.resolution = "45km" ## KEEPING FOR NOW
+    selections.resolution = "45 km" ## KEEPING FOR NOW
     selections.scenario = ["Historical Climate"]
     selections.time_slice = (1981, 2010) # to match historical 30-year average
     selections.timescale = "hourly"
@@ -80,7 +80,7 @@ def _get_future_heatmap_data(selections, location, catalog, warmlevel):
 
     selections.append_historical = False
     selections.area_average = True
-    selections.resolution = "45km"
+    selections.resolution = "45 km"
     selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
     selections.time_slice = warming_year_average_range[warmlevel]
     selections.timescale = "hourly"
@@ -243,7 +243,7 @@ class AverageMeteorologicalYear(param.Parameterized):
         # Selectors defaults
         self.selections.append_historical = False
         self.selections.area_average = True
-        self.selections.resolution = "45km"
+        self.selections.resolution = "45 km"
         self.selections.scenario = ["Historical Climate"]  # setting for historical
         self.selections.time_slice = (1981, 2010)
         self.selections.timescale = "hourly"

--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -8,6 +8,11 @@ import matplotlib.colors as mcolors
 import matplotlib
 import pkg_resources
 
+# Read colormap text files 
+ae_orange = pkg_resources.resource_filename('climakitae', 'data/cmaps/ae_orange.txt')
+ae_diverging = pkg_resources.resource_filename('climakitae', 'data/cmaps/ae_diverging.txt')
+ae_blue = pkg_resources.resource_filename('climakitae', 'data/cmaps/ae_blue.txt')
+
 def _read_ae_colormap(cmap = "ae_orange", cmap_hex = False):
     """Read in AE colormap by name
 
@@ -21,10 +26,16 @@ def _read_ae_colormap(cmap = "ae_orange", cmap_hex = False):
         cmap_data (list): used for hvplot maps (if cmap_hex == True)
 
     """
-
-    cmap_filename = cmap + ".txt" # Filename of colormap
-    cmap_pkg_data = pkg_resources.resource_filename("climakitae", "data/cmaps/" + cmap_filename) # Read package data
-    cmap_np = np.loadtxt(cmap_pkg_data, dtype = float)
+    
+    if cmap == "ae_orange": 
+        cmap_data = ae_orange
+    elif cmap == "ae_diverging": 
+        cmap_data = ae_diverging
+    elif cmap == "ae_blue":
+        cmap_data = ae_blue
+    
+    # Load text file
+    cmap_np = np.loadtxt(cmap_data, dtype = float)
 
     # RBG to hex
     if cmap_hex:

--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -136,41 +136,6 @@ def _reproject_data(xr_da, proj = "EPSG:4326", fill_value = np.nan):
     data_reprojected.attrs["grid_mapping"] = proj
     return data_reprojected
 
-# Read csv file containing variable information as dictionary
-def _read_var_csv(
-    csv_file,
-    index_col = "name",
-    usecols = [
-        "name",
-        "description",
-        "extended_description",
-        "native_unit",
-        "alt_unit_options",
-        "default_cmap"
-    ]
-):
-    """Read in variable descriptions csv file as a dictionary
-
-    Args:
-        csv_file (str): Local path to variable csv file
-        index_col (str): Column in csv to use as keys in dictionary
-
-    Returns:
-        descrip_dict (dictionary): Dictionary containing index_col as keys and additional columns as values
-
-    """
-    # Print warning if user inputs invalid index column
-    if index_col in ["native_unit", "alt_unit_options", "default_cmap"]:
-        print("Index column must have unique values. Cannot set index_col to "
-              + index_col
-              + ". Setting index to 'name'.")
-        index_col = "name"
-
-    # Read in csv and return as dictionary
-    csv = pd.read_csv(csv_file, index_col = index_col, usecols = usecols)
-    descrip_dict = csv.to_dict(orient = "index")
-    return descrip_dict
-
 ### some utils for generating warming level reference data in ../data/ ###
 def write_gwl_files():
     """Call everything needed to write the global warming level reference files

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -5,7 +5,7 @@ import pandas as pd
 import hvplot.xarray
 import matplotlib.pyplot as plt
 import pkg_resources
-from .utils import _reproject_data, _read_ae_colormap, _read_var_csv
+from .utils import _reproject_data, _read_ae_colormap
 
 # Import package data
 var_catalog_resource = pkg_resources.resource_filename('climakitae', 'data/variable_catalog.csv')

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -45,7 +45,7 @@ def _visualize(data, lat_lon = True, width = None, height = None, cmap = None):
 
         # Must have more than one grid cell to generate a map
         if (len(data["x"]) <= 1) or (len(data["y"]) <= 1):
-            print("Your data contains only one grid cell. A plot will be created using a default method that may or may not have spatial coordinates as the x and y axes.") # Warn user that plot may be weird
+            print("Your data contains only one grid cell in height and/or width. A plot will be created using a default method that may or may not have spatial coordinates as the x and y axes.") # Warn user that plot may be weird
 
             # Set default cmap if no user input
             # Different if using matplotlib (no "hex")
@@ -58,7 +58,10 @@ def _visualize(data, lat_lon = True, width = None, height = None, cmap = None):
                 warnings.simplefilter("ignore")
 
                 # Use generic static xarray plot
-                _matplotlib_plot = data.isel(time = 0).plot(cmap = cmap)
+                try: 
+                    _matplotlib_plot = data.isel(time = 0).plot(cmap = cmap)
+                except: 
+                    _matplotlib_plot = data.isel(time = 0).plot() # Make histogram for data the plotting function doesn't know how to handle
                 _plot = plt.gcf() # Add plot to figure
                 plt.close() # Close to prevent annoying matplotlib collections object line from showing in notebook
          # If there's more than one grid cell, generate a pretty map

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,5 +46,5 @@ docs =
 
 [options.package_data]
 * =
-    data/*.txt
+    data/cmaps/*.txt
     data/*.csv

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,4 @@ docs =
     sphinx-book-theme
 
 [options.package_data]
-* =
-    data/cmaps/*.txt
-    data/*.csv
+* = data/*.csv, data/cmaps/*.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,4 +45,6 @@ docs =
     sphinx-book-theme
 
 [options.package_data]
-* = data/*.csv
+* =
+    data/*.txt
+    data/*.csv


### PR DESCRIPTION
This PR addresses some small comments from reviewers on the main catalog restructure PR. 

1. Rename `catalog_utils.py` to `catalog_convert.py` 
2. Add a space between the resolution options; i.e. "45km" --> "45 km" 
3. Rename the functions within `catalog_convert.py` to be more descriptive 
4. Add back in an error statement if the user has selected "Append Historical" but no SSP 
5. Rename `selections.dataset` to `selections.downscaling_method`
6. Avoid creating large dask chunks and silence warning. This is done by setting the following config at the top of `data_loaders.py`:  ```dask.config.set({"array.slicing.split_large_chunks": True})```
7. Fix a small bug in `app.view` 