### PR TITLE
Remove redundant return line in threshold_panel.py

### DIFF
--- a/climakitae/threshold_panel.py
+++ b/climakitae/threshold_panel.py
@@ -177,7 +177,6 @@ class ThresholdDataParams(param.Parameterized):
             _exceedance_plot_subtitle(to_plot),
             obj
         )
-        return obj
 
     @param.depends("smoothing")
     def smoothing_card(self):


### PR DESCRIPTION
This PR addresses an [issue that Eric raised](https://github.com/cal-adapt/climakitae/issues/107) that there are two return lines in one of the functions in threshold_panels.py. I just deleted the redundant one. 