### PR TITLE
Rework code after ensmean data was added to main data catalog

### DIFF
--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -8,7 +8,13 @@ from .selectors import (
     LocSelectorArea,
     UserFileChoices,
     _user_export_select,
-    FileTypeSelector,
+    FileTypeSelector, 
+    _get_simulation_options
+)
+from .catalog_convert import (
+    _resolution_to_gridlabel,
+    _timescale_to_table_id,
+    _scenario_to_experiment_id,
 )
 from .view import _visualize
 
@@ -35,6 +41,16 @@ class Application(object):
         choices for the data available to load. Modifies the 'selections' and
         'location' values according to what the user specifies in that GUI.
         """
+        # Reset simulation options
+        # This will remove ensmean if the use has just called app.explore.amy()
+        self.selections.simulation = _get_simulation_options( 
+            cat=self._cat,
+            activity_id=self.selections.downscaling_method,
+            table_id=_timescale_to_table_id(self.selections.timescale),
+            grid_label=_resolution_to_gridlabel(self.selections.resolution),
+            experiment_id=[_scenario_to_experiment_id(scen) for scen in self.selections.scenario]
+        )
+        # Display panel 
         select_panel = _display_select(self.selections, self.location)
         return select_panel
 

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -347,7 +347,7 @@ def _get_unique_variables(cat, activity_id, table_id, grid_label):
     return variable_id_options, scenario_options
 
 
-def _get_simulation_options(cat, activity_id, table_id, grid_label, experiment_id, variable_id): 
+def _get_simulation_options(cat, activity_id, table_id, grid_label, experiment_id): 
     """Get simulations for user selections. This function is not intended to provide user options, 
     but is rather used to provide information only. It also serves to remove ensmean as an option.
     
@@ -357,7 +357,6 @@ def _get_simulation_options(cat, activity_id, table_id, grid_label, experiment_i
         table_id (str): timescale
         grid_label (str): resolution
         experiment_id (list of str): selected scenario/s
-        variable_id (str): variable
     
     Returns: 
         simulation_options (list of strs): valid simulation (source_id) options for input 
@@ -370,8 +369,7 @@ def _get_simulation_options(cat, activity_id, table_id, grid_label, experiment_i
             activity_id=activity_id, 
             table_id=table_id, 
             grid_label=grid_label, 
-            experiment_id=experiment_id, 
-            variable_id=variable_id
+            experiment_id=experiment_id
         )
     
     # Get all unique simulation options from catalog selection 
@@ -510,8 +508,7 @@ class DataSelector(param.Parameterized):
             activity_id=self.downscaling_method,
             table_id=_timescale_to_table_id(self.timescale),
             grid_label=_resolution_to_gridlabel(self.resolution),
-            experiment_id=[_scenario_to_experiment_id(scen) for scen in self.scenario], 
-            variable_id=self.variable_id
+            experiment_id=[_scenario_to_experiment_id(scen) for scen in self.scenario]
         )
 
     @param.depends("timescale", "resolution", watch=True)
@@ -658,8 +655,7 @@ class DataSelector(param.Parameterized):
             activity_id=self.downscaling_method,
             table_id=_timescale_to_table_id(self.timescale),
             grid_label=_resolution_to_gridlabel(self.resolution),
-            experiment_id=[_scenario_to_experiment_id(scen) for scen in self.scenario], 
-            variable_id=self.variable_id
+            experiment_id=[_scenario_to_experiment_id(scen) for scen in self.scenario]
         )
 
     @param.depends("time_slice", "scenario", "append_historical", watch=False)

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -62,11 +62,11 @@ def _get_historical_tmy_data(cat, selections, location):
     selections.append_historical = False
     selections.area_average = True
     selections.timescale = "hourly"
+    selections.simulation = "ensmean"
     historical_da_mean = _read_from_catalog(
         selections = selections, 
         location = location, 
-        cat = cat, 
-        source_id = "ensmean"
+        cat = cat
     ).isel(scenario = 0, simulation = 0)
     return historical_da_mean.compute()
 
@@ -82,11 +82,11 @@ def _get_future_heatmap_data(cat, selections, location, warmlevel):
     selections.append_historical = False
     selections.area_average = True
     selections.timescale = "hourly"
+    selections.simulation = "ensmean"
     future_da_mean = _read_from_catalog(
         selections = selections, 
         location = location, 
-        cat = cat, 
-        source_id = "ensmean"
+        cat = cat
     ).isel(scenario = 0, simulation = 0)
     return future_da_mean.compute()
 

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -62,7 +62,7 @@ def _get_historical_tmy_data(cat, selections, location):
     selections.append_historical = False
     selections.area_average = True
     selections.timescale = "hourly"
-    selections.simulation = "ensmean"
+    selections.simulation = ["ensmean"]
     historical_da_mean = _read_from_catalog(
         selections = selections, 
         location = location, 
@@ -82,7 +82,7 @@ def _get_future_heatmap_data(cat, selections, location, warmlevel):
     selections.append_historical = False
     selections.area_average = True
     selections.timescale = "hourly"
-    selections.simulation = "ensmean"
+    selections.simulation = ["ensmean"]
     future_da_mean = _read_from_catalog(
         selections = selections, 
         location = location, 


### PR DESCRIPTION
Just had to modify the code a bit to account for the ensemble mean data now being available in our main data catalog. This required me to add simulation as a parameter to app.select, such that app.explore.tmy could select for just the ensmean data, and app.select could ignore the ensmean data (and not return it as an additional simulation). 

I realize the explanation is a bit confusing. Feel free to add questions here for additional clarity and I will respond and try to clear up any confusion. 

**Once this PR is approved, I will merge it as the same time as the amy_cached_data branch**

**To test:** Just try running app.retrieve() for different datasets. Also try running app.explore.amy(). Thanks! 

_Note to self: Need to confirm that this doesn't cause any issues with the notebooks in cae-notebooks before merging as well._