### PR TITLE
Add return function to allow users to observe selection options from AMY panel

### DIFF
--- a/climakitae/explore.py
+++ b/climakitae/explore.py
@@ -11,9 +11,12 @@ from .warming_levels import WarmingLevels, _display_warming_levels
 class AppExplore(object):
     """
     A class for holding the following app explore options:
-        app.explore.amy()
-        app.explore.thresholds()
-        app.explore.warming_levels()
+        app.explore.amy(): AMY panel GUI
+        app.explore.thresholds(): thresholds panel GUI
+        app.explore.warming_levels(): warming levels panel GUI
+        app.explore.amy_selections(): AverageMeteorologicalYear object generated in app.explore.amy(); 
+            only accessible if app.explore.amy() has already been run. 
+    
     """
 
     def __init__(self, selections, location, _cat):
@@ -32,6 +35,7 @@ class AppExplore(object):
 
     def amy(self):
         """Display Average Meteorological Year panel."""
+        global tmy_ob
         tmy_ob = AverageMeteorologicalYear(
             selections = self.selections,
             location = self.location,
@@ -40,6 +44,15 @@ class AppExplore(object):
         return _amy_visualize(
             tmy_ob=tmy_ob, selections=self.selections, location=self.location
         )
+    
+    def amy_selections(self):
+        """Return the Average Meteorological Year panel object such that the user 
+        can pull information from the AMY panel or directly modify the values."""
+        if 'tmy_ob' in globals(): # First, check if amy() has been run and the object has been created 
+            return tmy_ob
+        else: 
+            print("Please first initialize the AMY panel by calling app.explore.amy()") 
+            return None
 
     def thresholds(self, option=1):
         """Display Thresholds panel."""

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -197,11 +197,11 @@ class AverageMeteorologicalYear(param.Parameterized):
     }
 
     # Define TMY params
-    tmy_options = param.ObjectSelector(
+    tmy_type = param.ObjectSelector(
         default="Absolute", objects=["Absolute", "Difference"]
     )
 
-    # Define new advanced options param, that is dependent on the user selection in tmy_options
+    # Define new advanced options param, that is dependent on the user selection in tmy_type
     tmy_advanced_options = param.ObjectSelector(objects=dict())
 
     # Define new computation description param
@@ -233,15 +233,15 @@ class AverageMeteorologicalYear(param.Parameterized):
 
         # Initialze tmy_adanced_options param
         self.param["tmy_advanced_options"].objects = self.tmy_advanced_options_dict[
-            self.tmy_options
+            self.tmy_type
         ]["objects"]
-        self.tmy_advanced_options = self.tmy_advanced_options_dict[self.tmy_options][
+        self.tmy_advanced_options = self.tmy_advanced_options_dict[self.tmy_type][
             "default"
         ]
 
         # Initialize tmy_computation_description param
         self.tmy_computation_description = self.computatation_description_dict[
-            self.tmy_options
+            self.tmy_type
         ][self.tmy_advanced_options]
 
         # Postage data and anomalies defaults
@@ -265,7 +265,7 @@ class AverageMeteorologicalYear(param.Parameterized):
         lambda x: x.param.trigger("reload_data"), label="Reload Data"
     )
 
-    @param.depends("selections.variable", "tmy_options", watch=True)
+    @param.depends("selections.variable", "tmy_type", watch=True)
     def _update_cmap(self):
         """Set colormap depending on variable"""
         cmap_name = var_catalog[
@@ -274,7 +274,7 @@ class AverageMeteorologicalYear(param.Parameterized):
         ].colormap.item()
 
         # Set to diverging colormap if difference is selected
-        if self.tmy_options == "Difference":
+        if self.tmy_type == "Difference":
             cmap_name = "ae_diverging"
 
         # Read colormap hex
@@ -315,27 +315,27 @@ class AverageMeteorologicalYear(param.Parameterized):
             warmlevel = self.warmlevel
         )
 
-    # Create a function that will update tmy_advanced_options when tmy_options is modified
-    @param.depends("tmy_options", watch=True)
+    # Create a function that will update tmy_advanced_options when tmy_type is modified
+    @param.depends("tmy_type", watch=True)
     def _update_tmy_advanced_options(self):
         self.param["tmy_advanced_options"].objects = self.tmy_advanced_options_dict[
-            self.tmy_options
+            self.tmy_type
         ]["objects"]
-        self.tmy_advanced_options = self.tmy_advanced_options_dict[self.tmy_options][
+        self.tmy_advanced_options = self.tmy_advanced_options_dict[self.tmy_type][
             "default"
         ]
 
-    @param.depends("tmy_options", "tmy_advanced_options", watch=True)
+    @param.depends("tmy_type", "tmy_advanced_options", watch=True)
     def _update_tmy_computatation_description(self):
         self.tmy_computation_description = self.computatation_description_dict[
-            self.tmy_options
+            self.tmy_type
         ][self.tmy_advanced_options]
 
     @param.depends("reload_data", watch=False)
     def _tmy_hourly_heatmap(self):
         # update heatmap df and title with selections
         days_in_year = 366
-        if self.tmy_options == "Absolute":
+        if self.tmy_type == "Absolute":
             if self.tmy_advanced_options == "Historical":
                 df = tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nAbsolute {} Baseline".format(
@@ -353,7 +353,7 @@ class AverageMeteorologicalYear(param.Parameterized):
                     self.location.cached_area, self.tmy_advanced_options, self.warmlevel
                 )
                 clabel = self.selections.variable + " (" + self.selections.units + ")"
-        elif self.tmy_options == "Difference":
+        elif self.tmy_type == "Difference":
             cmap = _read_ae_colormap("ae_diverging", cmap_hex=True)
             if self.tmy_advanced_options == "Warming Level Future":
                 df = tmy_calc(
@@ -400,7 +400,7 @@ def _amy_visualize(tmy_ob, selections, location):
                 pn.widgets.StaticText(
                     name="", value="Average Meteorological Year Type"
                 ),
-                pn.widgets.RadioButtonGroup.from_param(tmy_ob.param.tmy_options),
+                pn.widgets.RadioButtonGroup.from_param(tmy_ob.param.tmy_type),
                 pn.widgets.Select.from_param(
                     tmy_ob.param.tmy_advanced_options, name="Computation Options"
                 ),

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -62,11 +62,11 @@ def _get_historical_tmy_data(cat, selections, location):
     selections.append_historical = False
     selections.area_average = True
     selections.timescale = "hourly"
+    selections.simulation = "ensmean"
     historical_da_mean = _read_from_catalog(
         selections = selections, 
         location = location, 
-        cat = cat, 
-        source_id = "ensmean"
+        cat = cat
     ).isel(scenario = 0, simulation = 0)
     return historical_da_mean.compute()
 
@@ -82,11 +82,11 @@ def _get_future_heatmap_data(cat, selections, location, warmlevel):
     selections.append_historical = False
     selections.area_average = True
     selections.timescale = "hourly"
+    selections.simulation = "ensmean"
     future_da_mean = _read_from_catalog(
         selections = selections, 
         location = location, 
-        cat = cat, 
-        source_id = "ensmean"
+        cat = cat
     ).isel(scenario = 0, simulation = 0)
     return future_da_mean.compute()
 

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -197,12 +197,12 @@ class AverageMeteorologicalYear(param.Parameterized):
     }
 
     # Define TMY params
-    tmy_type = param.ObjectSelector(
+    data_type = param.ObjectSelector(
         default="Absolute", objects=["Absolute", "Difference"]
     )
 
-    # Define new advanced options param, that is dependent on the user selection in tmy_type
-    tmy_advanced_options = param.ObjectSelector(objects=dict())
+    # Define new advanced options param, that is dependent on the user selection in data_type
+    computation_method = param.ObjectSelector(objects=dict())
 
     # Define new computation description param
     # This will provide a string description of the computation option selected
@@ -232,17 +232,17 @@ class AverageMeteorologicalYear(param.Parameterized):
         self.selections.variable = "Air Temperature at 2m"
 
         # Initialze tmy_adanced_options param
-        self.param["tmy_advanced_options"].objects = self.tmy_advanced_options_dict[
-            self.tmy_type
+        self.param["computation_method"].objects = self.tmy_advanced_options_dict[
+            self.data_type
         ]["objects"]
-        self.tmy_advanced_options = self.tmy_advanced_options_dict[self.tmy_type][
+        self.computation_method = self.tmy_advanced_options_dict[self.data_type][
             "default"
         ]
 
         # Initialize tmy_computation_description param
         self.tmy_computation_description = self.computatation_description_dict[
-            self.tmy_type
-        ][self.tmy_advanced_options]
+            self.data_type
+        ][self.computation_method]
 
         # Postage data and anomalies defaults
         self.historical_tmy_data = _get_historical_tmy_data(
@@ -265,7 +265,7 @@ class AverageMeteorologicalYear(param.Parameterized):
         lambda x: x.param.trigger("reload_data"), label="Reload Data"
     )
 
-    @param.depends("selections.variable", "tmy_type", watch=True)
+    @param.depends("selections.variable", "data_type", watch=True)
     def _update_cmap(self):
         """Set colormap depending on variable"""
         cmap_name = var_catalog[
@@ -274,23 +274,23 @@ class AverageMeteorologicalYear(param.Parameterized):
         ].colormap.item()
 
         # Set to diverging colormap if difference is selected
-        if self.tmy_type == "Difference":
+        if self.data_type == "Difference":
             cmap_name = "ae_diverging"
 
         # Read colormap hex
         self.cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
 
-    @param.depends("tmy_advanced_options", "reload_data", "warmlevel", watch=True)
+    @param.depends("computation_method", "reload_data", "warmlevel", watch=True)
     def _update_data_to_be_returned(self):
         """Update self.selections so that the correct data is returned by app.retrieve()"""
-        if self.tmy_advanced_options == "Historical":
+        if self.computation_method == "Historical":
             self.selections.scenario = ["Historical Climate"]
             self.selections.time_slice = (
                 1981,
                 2010,
             )  # to match historical 30-year average
 
-        elif self.tmy_advanced_options == "Warming Level Future":
+        elif self.computation_method == "Warming Level Future":
             warming_year_average_range = {
                 1.5: (2034, 2063),
                 2: (2047, 2076),
@@ -315,31 +315,31 @@ class AverageMeteorologicalYear(param.Parameterized):
             warmlevel = self.warmlevel
         )
 
-    # Create a function that will update tmy_advanced_options when tmy_type is modified
-    @param.depends("tmy_type", watch=True)
-    def _update_tmy_advanced_options(self):
-        self.param["tmy_advanced_options"].objects = self.tmy_advanced_options_dict[
-            self.tmy_type
+    # Create a function that will update computation_method when data_type is modified
+    @param.depends("data_type", watch=True)
+    def _update_computation_method(self):
+        self.param["computation_method"].objects = self.tmy_advanced_options_dict[
+            self.data_type
         ]["objects"]
-        self.tmy_advanced_options = self.tmy_advanced_options_dict[self.tmy_type][
+        self.computation_method = self.tmy_advanced_options_dict[self.data_type][
             "default"
         ]
 
-    @param.depends("tmy_type", "tmy_advanced_options", watch=True)
+    @param.depends("data_type", "computation_method", watch=True)
     def _update_tmy_computatation_description(self):
         self.tmy_computation_description = self.computatation_description_dict[
-            self.tmy_type
-        ][self.tmy_advanced_options]
+            self.data_type
+        ][self.computation_method]
 
     @param.depends("reload_data", watch=False)
     def _tmy_hourly_heatmap(self):
         # update heatmap df and title with selections
         days_in_year = 366
-        if self.tmy_type == "Absolute":
-            if self.tmy_advanced_options == "Historical":
+        if self.data_type == "Absolute":
+            if self.computation_method == "Historical":
                 df = tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nAbsolute {} Baseline".format(
-                    self.location.cached_area, self.tmy_advanced_options
+                    self.location.cached_area, self.computation_method
                 )
                 clabel = (
                     self.selections.variable
@@ -350,17 +350,17 @@ class AverageMeteorologicalYear(param.Parameterized):
             else:
                 df = tmy_calc(self.future_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nAbsolute {} at {}°C".format(
-                    self.location.cached_area, self.tmy_advanced_options, self.warmlevel
+                    self.location.cached_area, self.computation_method, self.warmlevel
                 )
                 clabel = self.selections.variable + " (" + self.selections.units + ")"
-        elif self.tmy_type == "Difference":
+        elif self.data_type == "Difference":
             cmap = _read_ae_colormap("ae_diverging", cmap_hex=True)
-            if self.tmy_advanced_options == "Warming Level Future":
+            if self.computation_method == "Warming Level Future":
                 df = tmy_calc(
                     self.future_tmy_data, days_in_year=days_in_year
                 ) - tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nDifference between {} at {}°C and Historical Baseline".format(
-                    self.location.cached_area, self.tmy_advanced_options, self.warmlevel
+                    self.location.cached_area, self.computation_method, self.warmlevel
                 )
                 clabel = self.selections.variable + " (" + self.selections.units + ")"
             else:  # placeholder for now for severe amy
@@ -368,7 +368,7 @@ class AverageMeteorologicalYear(param.Parameterized):
                     self.future_tmy_data, days_in_year=days_in_year
                 ) - tmy_calc(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nDifference between {} at 90th percentile and Historical Baseline".format(
-                    self.location.cached_area, self.tmy_advanced_options
+                    self.location.cached_area, self.computation_method
                 )
                 clabel = self.selections.variable + " (" + self.selections.units + ")"
         else:
@@ -400,9 +400,9 @@ def _amy_visualize(tmy_ob, selections, location):
                 pn.widgets.StaticText(
                     name="", value="Average Meteorological Year Type"
                 ),
-                pn.widgets.RadioButtonGroup.from_param(tmy_ob.param.tmy_type),
+                pn.widgets.RadioButtonGroup.from_param(tmy_ob.param.data_type),
                 pn.widgets.Select.from_param(
-                    tmy_ob.param.tmy_advanced_options, name="Computation Options"
+                    tmy_ob.param.computation_method, name="Computation Options"
                 ),
                 pn.widgets.StaticText.from_param(
                     tmy_ob.param.tmy_computation_description, name=""


### PR DESCRIPTION
This PR adds a new function `app.explore.amy_selections()` that allows users to observe the settings in the AMY panel. Specifically, it returns the AverageMeteorologicalYear object generated in `app.explore.amy()`. I also renamed a few of the params in `tmy.py` to be more descriptive for the users' benefit. 

Workflow I recommend to get info from the amy panel: 
```
app.explore.amy()                                          # Pull up the panel
amy_selections = app.explore.amy_selections()              # Get AverageMeteorologicalYear object generated by amy panel
data_type = amy_selections.data_type                       # Absolute or Difference
computation_method = amy_selections.computation_method     # Warming Level Future or Historical
warmlevel = amy_selections.warmlevel                       # Get warming level selection
```

If you call `app.explore.amy_selections()` **before** calling `app.explore.amy()`, *None* is returned by the function and the following warning is printed: 
<img width="500" alt="AMY error" src="https://user-images.githubusercontent.com/66140951/202286715-8a2f5444-f98f-4d27-9374-c8099f6669d7.png">
