### PR TITLE
Limit users to a single cluster

### DIFF
--- a/climakitae/cluster.py
+++ b/climakitae/cluster.py
@@ -1,0 +1,19 @@
+from dask_gateway import Gateway, GatewayCluster
+
+
+class Cluster(GatewayCluster):
+    """A dask-gateway cluster allowing one cluster per user.
+
+    Instead of always creating new clusters, connect to a previously running
+    user cluster, and attempt to limit users to a single cluster.
+    """
+
+    def get_client(self, set_as_default=True):
+        clusters = self.gateway.list_clusters()
+        if clusters:
+            cluster = self.gateway.connect(
+                clusters.pop().name, shutdown_on_close=True)
+            for c in clusters:
+                self.gateway.stop_cluster(c.name)
+            return cluster.get_client()
+        return super().get_client(set_as_default)


### PR DESCRIPTION
The idea is to limit users to a single cluster instead of the default behavior of the `GatewayCluster` which always creates new clusters allowing a user to have multiple clusters running. This will attempt to reconnect to a cluster if one is available, and only create one if not.

Usage is the same as a `GatewayCluster`:
``` python
cluster = Cluster()
client = cluster.get_client()
cluster.shutdown()
```