### PR TITLE
AMY code updates to go with updates to explore_amy() notebook 

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -183,7 +183,7 @@ def _get_area_subset(location):
     return ds_region
 
 
-def _process_and_concat(selections, dsets, cat_subset):
+def _process_and_concat(selections, location, dsets, cat_subset):
     """Process data if append_historical was selected.
     Merge all datasets into one.
 
@@ -270,12 +270,14 @@ def _process_and_concat(selections, dsets, cat_subset):
     da_final.attrs = {  # Add descriptive attributes to DataArray
         "institution": orig_attrs["institution"],
         "source": orig_attrs["source"],
+        "location_subset": location.cached_area,
         "resolution": selections.resolution,
         "frequency": selections.timescale,
         "grid_mapping": da_final.attrs["grid_mapping"],
         "variable_id": selections.variable_id,
         "extended_description": selections.extended_description,
         "units": da_final.attrs["units"],
+        
     }
     return da_final
 
@@ -319,7 +321,7 @@ def _get_data_one_var(selections, location, cat):
     # Process data if append_historical was selected.
     # Merge individual Datasets into one DataArray object.
     da = _process_and_concat(
-        selections=selections, dsets=data_dict, cat_subset=cat_subset
+        selections=selections, location=location, dsets=data_dict, cat_subset=cat_subset
     )
 
     return da

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -217,7 +217,7 @@ def _amy_heatmap(amy_df, title=None, cmap="viridis", cbar_label=None):
     return fig
 
 
-def lineplot_from_amy_data1(amy_data, computation_method=None, location_subset=None, warmlevel=None, variable=None):
+def lineplot_from_amy_data(amy_data, computation_method=None, location_subset=None, warmlevel=None, variable=None):
     """Generate a lineplot of AMY data, with mon-day-hr on the x-axis
     
     Args: 

--- a/climakitae/tmy.py
+++ b/climakitae/tmy.py
@@ -338,15 +338,6 @@ class AverageMeteorologicalYear(param.Parameterized):
         # Location defaults
         self.location.area_subset = "CA counties"
         self.location.cached_area = "Los Angeles County"
-        
-        # Selectors defaults
-        self.selections.append_historical = False
-        self.selections.area_average = True
-        self.selections.resolution = "45 km"
-        self.selections.scenario = ["Historical Climate"]  # setting for historical
-        self.selections.time_slice = (1981, 2010)
-        self.selections.timescale = "hourly"
-        self.selections.variable = "Air Temperature at 2m"
 
         # Initialze tmy_adanced_options param
         self.param["computation_method"].objects = self.tmy_advanced_options_dict[
@@ -376,6 +367,16 @@ class AverageMeteorologicalYear(param.Parameterized):
         
         # Colormap 
         self.cmap = _read_ae_colormap(cmap="ae_orange", cmap_hex=False)
+        
+        # Selectors defaults
+        self.selections.append_historical = False
+        self.selections.area_average = True
+        self.selections.resolution = "45 km"
+        self.selections.scenario = ["Historical Climate"]  # setting for historical
+        self.selections.time_slice = (1981, 2010)
+        self.selections.timescale = "hourly"
+        self.selections.variable = "Air Temperature at 2m"
+        self.selections.simulation = ["ensmean"]
 
     # For reloading data and plots
     reload_data = param.Action(
@@ -400,12 +401,10 @@ class AverageMeteorologicalYear(param.Parameterized):
     @param.depends("computation_method", "reload_data", "warmlevel", watch=True)
     def _update_data_to_be_returned(self):
         """Update self.selections so that the correct data is returned by app.retrieve()"""
+        
         if self.computation_method == "Historical":
             self.selections.scenario = ["Historical Climate"]
-            self.selections.time_slice = (
-                1981,
-                2010,
-            )  # to match historical 30-year average
+            self.selections.time_slice = (1981,2010,) 
 
         elif self.computation_method == "Warming Level Future":
             warming_year_average_range = {
@@ -415,6 +414,11 @@ class AverageMeteorologicalYear(param.Parameterized):
             }
             self.selections.scenario = ["SSP 3-7.0 -- Business as Usual"]
             self.selections.time_slice = warming_year_average_range[self.warmlevel]
+            
+        self.selections.simulation = ["ensmean"]
+        self.selections.append_historical = False
+        self.selections.area_average = True
+        self.selections.timescale = "hourly"
 
     @param.depends("reload_data", watch=True)
     def _update_tmy_data(self):
@@ -550,7 +554,7 @@ def _amy_visualize(tmy_ob, selections, location):
         title=" How do you want to investigate AMY?",
         collapsible=False,
         width=510,
-        height=600,
+        height=615,
     )
 
     mthd_bx = pn.Column(

--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import datetime
 import xarray as xr
 import rioxarray as rio
 import pandas as pd

--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -16,6 +16,26 @@ ae_diverging = pkg_resources.resource_filename(
 ae_blue = pkg_resources.resource_filename("climakitae", "data/cmaps/ae_blue.txt")
 
 
+def julianDay_to_str_date(julday, leap_year=True, str_format="%b-%d"): 
+    """Convert julian day of year to string format 
+    i.e. if str_format = "%b-%d", the output will be Mon-Day ("Jan-01") 
+    
+    Args: 
+        julday (int): Julian day 
+        leap_year (boolean): leap year? (default to True)
+        str_format (str): string format of output date 
+        
+    Return: 
+        date (str): Julian day in the input format month-day (i.e. "Jan-01")  
+    """
+    if leap_year: 
+        year = "2024"
+    else: 
+        year = "2023" 
+    date = datetime.datetime.strptime(year+"."+str(julday), '%Y.%j').strftime(str_format)
+    return date 
+
+
 def _readable_bytes(B):
     """
     Return the given bytes as a human friendly KB, MB, GB, or TB string.


### PR DESCRIPTION
This PR addresses quite a few changes to tmy.py. First, it changes the interactive heatmap generated by app.explore.amy() to a static matplotlib heatmap. This is because the hvplot heatmap was not allowing us control over the axes (see this bug report I raised in the hvplot GitHub [here](https://github.com/holoviz/hvplot/issues/975)). I also added a new function `lineplot_from_amy_data` in tmy.py, which is used in the new version of explore_amy(). Additionally, I added a function into utils.py that converts julian day into whatever string datetime format you want; this is used by `tmy_calc` now to improve readability of the data and plot axes. 

**To test:** Run through the version explore_amy.ipynb stored in the amy_usability_improvements branch of cae-notebooks (linked [here](https://github.com/cal-adapt/cae-notebooks/blob/amy_usability_improvements/explore_amy.ipynb)). Try changing the function arguments to `lineplot_from_amy_data`; it should be able to work with any subset of the arguments fed to it 

i.e. the function should work and produce a nice looking map if you call any of the following: 
```

# Directly from notebook 
amy_selections = app.explore.amy_selections() # Get information about user inputs to AMY panel 
lineplot_from_amy_data(
    one_month, 
    computation_method=amy_selections.computation_method, # Historical or Warming Level Future  
    location_subset=app.location.cached_area, # Location subset information 
    warmlevel=amy_selections.warmlevel, # Warming level selection 
    variable=app.selections.variable+"("+app.selections.units+")" # Variable and units selected. 
)

# Should work if you only input the data 
lineplot_from_amy_data(amy_data) 

# Should work if you input random strings for any subset of arguments 
lineplot_from_amy_data(
    amy_data, 
    variable="Chicken Soup",
    location_subset="Santa's house" 
) 
```