### PR TITLE
Add Black lint checking to workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,11 @@ name: ci
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
After reviewing the GitHub workflow documentation this looks like the best way to implement lint checking on the repo. With this workflow it didn't seem necessary for the other tests to be dependent on the lint. Also, this just checks the code and fails if not compliant. This would require the coder to run `black` before committing and pushing to pass the test. Or would we rather have the workflow reformat the code automatically? I'm not super sure how that would be done, but can look into it.