### PR TITLE
Remove assert statements from main code and replace with raise error

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -323,8 +323,9 @@ def _read_from_catalog(selections, location, cat):
     scenario_selections = selections.scenario_ssp + selections.scenario_historical
     
     # Raise error if no scenarios are selected
-    assert not scenario_selections == [], "Please select as least one dataset."
-    
+    if scenario_selections == []:
+        raise ValueError("Please select as least one dataset.")
+
     # Deal with derived variables 
     if selections.variable_id == "precip_tot_derived":
 

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -721,10 +721,8 @@ def _display_select(selections, location, location_type = "area average"):
     for location_type -- 'area average' is the only choice, until station-based
     data are available.
     """
-    assert location_type in [
-        "area average",
-        "station",
-    ], "Please enter either 'area average' or 'station'."
+    if location_type not in ["area average", "station"]:
+        raise ValueError("Please enter either 'area average' or 'station'.")
 
     # _which_loc_input = {'area average': LocSelectorArea, 'station': LocSelectorPoint}
     location_chooser = pn.Row(location.param, location.view)

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -710,21 +710,14 @@ class DataSelector(param.Parameterized):
     
 # ================ DISPLAY LOCATION/DATA SELECTIONS IN PANEL ===================
 
-def _display_select(selections, location, location_type = "area average"):
+def _display_select(selections, location):
     """
     Called by 'select' at the beginning of the workflow, to capture user
     selections. Displays panel of widgets from which to make selections.
-    Location selection widgets depend on location_type argument, which can
-    have only one of two values: 'area average' or 'station'. Modifies
-    'selections' object, which is used by generate() to build an appropriate
-    xarray Dataset. Currently, core.Application.select does not pass an argument
-    for location_type -- 'area average' is the only choice, until station-based
-    data are available.
+    Modifies 'selections' object, which is used by generate() to build an 
+    appropriate xarray Dataset. 
     """
-    if location_type not in ["area average", "station"]:
-        raise ValueError("Please enter either 'area average' or 'station'.")
 
-    # _which_loc_input = {'area average': LocSelectorArea, 'station': LocSelectorPoint}
     location_chooser = pn.Row(location.param, location.view)
 
     first_row = pn.Row(


### PR DESCRIPTION
This simple PR replaces `assert` statements used in main code and replaces them with `raise` statements. The test logic is reversed to do this.

I left the `assert` statements in the test files as it seem appropriate there.