### PR TITLE
Timeseries resampling one-liner improve for clarity

### DIFF
--- a/climakitae/timeseriestools.py
+++ b/climakitae/timeseriestools.py
@@ -295,9 +295,7 @@ def _timeseries_visualize(choices):
     an instance of TimeSeriesParams.
     """
     smooth_text = "Smoothing applies a running mean to remove noise from the data."
-    resample_text = (
-        "The resample window and period define the length of time over which to calculate the extreme."
-    )
+    resample_text = "The resample window and period define the length of time over which to calculate the extreme."
 
     return pn.Column(
         pn.Row(

--- a/climakitae/timeseriestools.py
+++ b/climakitae/timeseriestools.py
@@ -296,7 +296,7 @@ def _timeseries_visualize(choices):
     """
     smooth_text = "Smoothing applies a running mean to remove noise from the data."
     resample_text = (
-        "Resampling is required in extremes to determine the frequency of the extreme."
+        "The resample window and period define the length of time over which to calculate the extreme."
     )
 
     return pn.Column(


### PR DESCRIPTION
Minor clarity improvement to the resampling "info one-liner" in the timeseries explore panel to better explain the resampling process. 

<img width="694" alt="Screen Shot 2022-12-20 at 9 46 12 AM" src="https://user-images.githubusercontent.com/106171203/208694525-ebc5d7cf-8dd0-4e36-a946-8abdcd3c3c95.png">
