### PR TITLE
Bug fix in app.retrieve_from_csv

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -468,7 +468,7 @@ def _read_data_from_csv(selections, location, cat, csv, merge=True):
     """
 
     df = pd.read_csv(csv)
-    df = df.fillna('') # Replace empty cells (set to NaN by read_csv) with empty string 
+    df = df.fillna("")  # Replace empty cells (set to NaN by read_csv) with empty string
     df = df.apply(
         lambda x: x.str.strip()
     )  # Strip any accidental white space before or after each input

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -468,6 +468,7 @@ def _read_data_from_csv(selections, location, cat, csv, merge=True):
     """
 
     df = pd.read_csv(csv)
+    df = df.fillna('') # Replace empty cells (set to NaN by read_csv) with empty string 
     df = df.apply(
         lambda x: x.str.strip()
     )  # Strip any accidental white space before or after each input


### PR DESCRIPTION
This fixes a bug I found in `app.retrieve_from_csv()`, where a mysterious pandas error was being raised if any of the cells in a csv were unfilled. `pd.read_csv` was automatically setting these empty cells to NaN, which was causing issues down the line. Here, I set the empty cells to an empty string instead of NaN, which solves the issue! 

**How to review**: Just review the code change. No need to test anything out I think. 