### PR TITLE
Move meteorological year data retrieval function to core.py

### DIFF
--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -2,11 +2,7 @@ import intake
 from .data_export import _export_to_user
 from .explore import AppExplore
 from .view import _visualize
-from .data_loaders import (
-    _read_from_catalog, 
-    _compute, 
-    _read_data_from_csv
-) 
+from .data_loaders import _read_from_catalog, _compute, _read_data_from_csv
 from .selectors import (
     DataSelector,
     _display_select,
@@ -107,13 +103,13 @@ class Application(object):
         return _read_data_from_csv(
             self.selections, self.location, self._cat, csv, merge
         )
-    
-    def retrieve_meteo_yr_data(self, ssp=None, year_start=2015, year_end=None): 
+
+    def retrieve_meteo_yr_data(self, ssp=None, year_start=2015, year_end=None):
         """User-facing function for retrieving data needed for computing a meteorological year.
 
-        Reads in the hourly ensemble means instead of the hourly data. 
-        Reads in future SSP data, historical climate data, or a combination 
-        of both, depending on year_start and year_end 
+        Reads in the hourly ensemble means instead of the hourly data.
+        Reads in future SSP data, historical climate data, or a combination
+        of both, depending on year_start and year_end
 
         Parameters
         ----------
@@ -129,7 +125,9 @@ class Application(object):
         xr.DataArray
             Hourly ensemble means from year_start-year_end for the ssp specified.
         """
-        return _retrieve_meteo_yr_data(self.selections, self.location, self._cat, ssp, year_start, year_end)
+        return _retrieve_meteo_yr_data(
+            self.selections, self.location, self._cat, ssp, year_start, year_end
+        )
 
     # === View =======================================
     def view(self, data, lat_lon=True, width=None, height=None, cmap=None):

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -2,7 +2,11 @@ import intake
 from .data_export import _export_to_user
 from .explore import AppExplore
 from .view import _visualize
-from .data_loaders import _read_from_catalog, _compute, _read_data_from_csv
+from .data_loaders import (
+    _read_from_catalog, 
+    _compute, 
+    _read_data_from_csv
+) 
 from .selectors import (
     DataSelector,
     _display_select,
@@ -17,6 +21,7 @@ from .catalog_convert import (
     _timescale_to_table_id,
     _scenario_to_experiment_id,
 )
+from .meteo_yr import _retrieve_meteo_yr_data
 
 
 class Application(object):
@@ -102,6 +107,29 @@ class Application(object):
         return _read_data_from_csv(
             self.selections, self.location, self._cat, csv, merge
         )
+    
+    def retrieve_meteo_yr_data(self, ssp=None, year_start=2015, year_end=None): 
+        """User-facing function for retrieving data needed for computing a meteorological year.
+
+        Reads in the hourly ensemble means instead of the hourly data. 
+        Reads in future SSP data, historical climate data, or a combination 
+        of both, depending on year_start and year_end 
+
+        Parameters
+        ----------
+        ssp: str, one of "SSP 2-4.5 -- Middle of the Road", "SSP 2-4.5 -- Middle of the Road", "SSP 3-7.0 -- Business as Usual", "SSP 5-8.5 -- Burn it All"
+            Shared Socioeconomic Pathway. Defaults to SSP 3-7.0 -- Business as Usual
+        year_start: int, optional
+            Year between 1980-2095. Default to 2015
+        year_end: int, optional
+            Year between 1985-2100. Default to year_start+30
+
+        Returns
+        -------
+        xr.DataArray
+            Hourly ensemble means from year_start-year_end for the ssp specified.
+        """
+        return _retrieve_meteo_yr_data(self.selections, self.location, self._cat, ssp, year_start, year_end)
 
     # === View =======================================
     def view(self, data, lat_lon=True, width=None, height=None, cmap=None):

--- a/climakitae/meteo_yr.py
+++ b/climakitae/meteo_yr.py
@@ -92,10 +92,10 @@ def _retrieve_meteo_yr_data(
     year_end=None,
 ):
     """Backend function for retrieving data needed for computing a meteorological year.
-    
-    Reads in the hourly ensemble means instead of the hourly data. 
-    Reads in future SSP data, historical climate data, or a combination 
-    of both, depending on year_start and year_end 
+
+    Reads in the hourly ensemble means instead of the hourly data.
+    Reads in future SSP data, historical climate data, or a combination
+    of both, depending on year_start and year_end
 
     Parameters
     ----------


### PR DESCRIPTION
I had written a function a while back-- `retrieve_meteo_yr_data`-- that retrieves the necessary data for computing an average or severe meteorological year. But, for some reason, I put it in the meteo_yr module and had it accept `app` as an argument, which is pretty weird and unintuitive. 

In this PR, I just moved that function into core.py. This changed how the function can be used in a notebook. Because of that, I also had to change the DFU meteorological year notebook (see the related [cae-notebooks PR](https://github.com/cal-adapt/cae-notebooks/pull/33))

Current functionality: 
```
from climakitae.meteo_yr import retrieve_meteo_yr_data
data = retrieve_meteo_yr_data(app)
```

Desired functionality (this PR): 
```
data = app.retrieve_meteo_yr_data()
```

**How to review**: Try running the [DFU notebook on meteorological years](https://github.com/cal-adapt/cae-notebooks/blob/retrieve_meteo_yr/specific_use_cases/demand_forecast_office/meteorological_year.ipynb), as well as the [explore amy notebook](https://github.com/cal-adapt/cae-notebooks/blob/retrieve_meteo_yr/explore_amy.ipynb) from within this branch, and make sure everything runs smoothly. 