### PR TITLE
Add uncertainty utils functions/classes to climakitae API in readthedocs

### DIFF
--- a/climakitae/uncertain_utils.py
+++ b/climakitae/uncertain_utils.py
@@ -238,8 +238,8 @@ def grab_temp_data(copt):
 
     Attributes
     ----------
-    copt: object
-        Selections: variable, area_subset, location, area_average, timescale
+    copt: CmipOpt
+        Selections for variable, area_subset, location, area_average, timescale
 
     Returns
     -------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,21 +50,33 @@ Functions help with data retrieval, comutation of the meteorological year, and p
 
 Warming Levels  
 -------------------
-
+Helper functions for performing analyses using climate warming levels. 
 .. autosummary::
    :toctree: generated/
 
    warming_levels.get_anomaly_data
 
-Threshold tools 
+Threshold Tools 
 ----------------
 Helper functions for thresholds-related analyses. Documentation in progress.
 
-Timeseries tools
+Timeseries Tools
 -----------------
 Helper functions for working with timeseries data. Documentation in progess. 
 
+Model Uncertainty
+-------------------
+Helper functions for performing analyses related to assessing uncertainty quantification in climate models.
 
+.. autosummary::
+   :toctree: generated/
+
+   uncertain_utils.CmipOpt
+   uncertain_utils.grab_temp_data
+   uncertain_utils.cmip_annual
+   uncertain_utils.cmip_annual
+   uncertain_utils.compute_vmin_vmax
+   
 Misc
 -----
 Other uncatecorized functions that may be useful to users. 

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - pandas=1.3.4
   - panel=0.12.4
   - param=1.11.1
+  - pint-xarray
   - proj=8.1.1
   - psutil=5.8.0
   - pyproj=3.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3.9.7
   - cartopy=0.20.1
+  - cmip6_preprocessing
   - dask-gateway=0.9.0
   - geopandas=0.10.2
   - geoviews=1.9.2

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.9.7
   - cartopy=0.20.1
-  - cmip6_preprocessing
+  - cmip6_preprocessing=0.5.0
   - dask-gateway=0.9.0
   - geopandas=0.10.2
   - geoviews=1.9.2
@@ -20,7 +20,6 @@ dependencies:
   - pandas=1.3.4
   - panel=0.12.4
   - param=1.11.1
-  - pint-xarray
   - proj=8.1.1
   - psutil=5.8.0
   - pyproj=3.2.1


### PR DESCRIPTION
I added the uncertainy utils to the climakitae API. I also added cmip6_preprocessing (a dependency of uncertain_utils) to our environment.yml file. 

If you want to test locally and build the docs, follow the instructions [here](https://github.com/cal-adapt/climakitae/blob/main/docs/README.md). **You'll also need to install cmip6_preprocessing into your local climakitae-tests conda environment:** ``pip install cmip6_preprocessing``