### PR TITLE
Small change to closest gridcell function

### DIFF
--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -68,7 +68,7 @@ def get_closest_gridcell(data, lat, lon):
     print(
         "Input coordinates: (%.2f, %.2f)" % (lat, lon)
         + "\nNearest grid cell coordinates: (%.2f, %.2f)"
-        % (closest_gridcell.lat.item(), closest_gridcell.lon.item())
+        % (closest_gridcell.lat.values.item(), closest_gridcell.lon.values.item())
     )
     return closest_gridcell
 

--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -31,7 +31,7 @@ def get_closest_gridcell(data, lat, lon):
 
     Parameters
     -----------
-    data: xr.DataArray
+    data: xr.DataArray or xr.Dataset
         Gridded data
     lat: float
         Latitude of coordinate pair


### PR DESCRIPTION
I identified a small error, in which the get_closest_gridcell function fails if given a lazily loaded dask array. I fixed this, and also slightly updated the documentation. 

**To test**: Just review the code here in GitHub. Nothing involved required unless you're feeling ambitious.