### PR TITLE
Add config argument to retrieve

### DIFF
--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -134,22 +134,22 @@ class Application(object):
     # === Retrieve ===================================
     def retrieve(self, config=None, merge=True):
         """Retrieve data from catalog
-        
-        By default, Application.selections and Application.location determines the data retrieved. 
-        To retrieve data using the settings in a configuration csv file, set config to the local 
+
+        By default, Application.selections and Application.location determines the data retrieved.
+        To retrieve data using the settings in a configuration csv file, set config to the local
         filepath of the csv.
         Grabs the data from the AWS S3 bucket, returns lazily loaded dask array.
-        User-facing function that provides a wrapper for _read_from_catalog and _read_data_from_csv. 
-        
+        User-facing function that provides a wrapper for _read_from_catalog and _read_data_from_csv.
+
         Parameters
         ----------
-        config: str, optional. 
+        config: str, optional.
             Local filepath to configuration csv file
             Default to None-- retrieve settings in app.selections and app.location
         merge: bool, optional
             If config is TRUE and multiple datasets desired, merge to form a single object?
             Defaults to True.
-        
+
         Returns
         -------
         xr.DataArray

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -132,19 +132,35 @@ class Application(object):
         return _compute(data)
 
     # === Retrieve ===================================
-    def retrieve(self):
+    def retrieve(self, config=None, merge=True):
         """Retrieve data from catalog
-
-        Applications.selections and Applications.location determine data retrieves
-        Grabs the data from the AWS S3 bucket, returns lazily loaded dask array
-        User-facing function that provides a wrapper for _read_from_catalog
-
+        
+        By default, Application.selections and Application.location determines the data retrieved. 
+        To retrieve data using the settings in a configuration csv file, set config to the local 
+        filepath of the csv.
+        Grabs the data from the AWS S3 bucket, returns lazily loaded dask array.
+        User-facing function that provides a wrapper for _read_from_catalog and _read_data_from_csv. 
+        
+        Parameters
+        ----------
+        config: str, optional. 
+            Local filepath to configuration csv file
+            Default to None-- retrieve settings in app.selections and app.location
+        merge: bool, optional
+            If config is TRUE and multiple datasets desired, merge to form a single object?
+            Defaults to True.
+        
         Returns
         -------
         xr.DataArray
             Lazily loaded dask array
 
         """
+        if config is not None: 
+            if type(config) == str: 
+                return _read_data_from_csv(self.selections, self.location, self._cat, config, merge)
+            else: 
+                raise ValueError("To retrieve data from a configuration file, please input the path to your local configuration csv as a string") 
         return _read_from_catalog(self.selections, self.location, self._cat)
 
     def retrieve_from_csv(self, csv, merge=True):

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -2,7 +2,7 @@ import intake
 from .data_export import _export_to_user
 from .explore import AppExplore
 from .view import _visualize
-from .data_loaders import _read_from_catalog, _compute, _read_data_from_csv
+from .data_loaders import _read_catalog_from_select, _read_catalog_from_csv, _compute
 from .selectors import (
     DataSelector,
     _display_select,
@@ -139,7 +139,7 @@ class Application(object):
         To retrieve data using the settings in a configuration csv file, set config to the local
         filepath of the csv.
         Grabs the data from the AWS S3 bucket, returns lazily loaded dask array.
-        User-facing function that provides a wrapper for _read_from_catalog and _read_data_from_csv.
+        User-facing function that provides a wrapper for _read_catalog_from_csv and _read_catalog_from_select.
 
         Parameters
         ----------
@@ -154,18 +154,26 @@ class Application(object):
         -------
         xr.DataArray
             Lazily loaded dask array
+            Default if no config file provided
+        xr.Dataset
+            If multiple rows are in the csv, each row is a data_variable
+            Only an option if a config file is provided
+        list of xr.DataArray
+            If multiple rows are in the csv and merge=True,
+            multiple DataArrays are returned in a single list.
+            Only an option if a config file is provided.
 
         """
         if config is not None:
             if type(config) == str:
-                return _read_data_from_csv(
+                return _read_catalog_from_csv(
                     self.selections, self.location, self._cat, config, merge
                 )
             else:
                 raise ValueError(
-                    "To retrieve data from a configuration file, please input the path to your local configuration csv as a string"
+                    "To retrieve data specified in a configuration file, please input the path to your local configuration csv as a string"
                 )
-        return _read_from_catalog(self.selections, self.location, self._cat)
+        return _read_catalog_from_select(self.selections, self.location, self._cat)
 
     def retrieve_from_csv(self, csv, merge=True):
         """Retrieve data from csv input. Return type will depend on how many rows exist in the input csv file and the argument merge.

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -156,11 +156,15 @@ class Application(object):
             Lazily loaded dask array
 
         """
-        if config is not None: 
-            if type(config) == str: 
-                return _read_data_from_csv(self.selections, self.location, self._cat, config, merge)
-            else: 
-                raise ValueError("To retrieve data from a configuration file, please input the path to your local configuration csv as a string") 
+        if config is not None:
+            if type(config) == str:
+                return _read_data_from_csv(
+                    self.selections, self.location, self._cat, config, merge
+                )
+            else:
+                raise ValueError(
+                    "To retrieve data from a configuration file, please input the path to your local configuration csv as a string"
+                )
         return _read_from_catalog(self.selections, self.location, self._cat)
 
     def retrieve_from_csv(self, csv, merge=True):

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -371,7 +371,7 @@ def _get_data_one_var(selections, location, cat):
     return da
 
 
-def _read_from_catalog(selections, location, cat):
+def _read_catalog_from_select(selections, location, cat):
     """The primary and first data loading method, called by
     core.Application.retrieve, it returns a DataArray (which can be quite large)
     containing everything requested by the user (which is stored in 'selections'
@@ -447,7 +447,7 @@ def _read_from_catalog(selections, location, cat):
 # ============ Retrieve data from a csv input ===============
 
 
-def _read_data_from_csv(selections, location, cat, csv, merge=True):
+def _read_catalog_from_csv(selections, location, cat, csv, merge=True):
     """Retrieve data from csv input.
 
     Allows user to bypass app.select GUI and allows developers to

--- a/climakitae/meteo_yr.py
+++ b/climakitae/meteo_yr.py
@@ -40,7 +40,7 @@ from .catalog_convert import (
     _timescale_to_table_id,
     _scenario_to_experiment_id,
 )
-from .data_loaders import _read_from_catalog
+from .data_loaders import _read_catalog_from_select
 from tqdm.auto import tqdm  # Progress bar
 import logging  # Silence warnings
 
@@ -145,7 +145,7 @@ def _retrieve_meteo_yr_data(
     selections.units = units
 
     # Grab data from the catalog
-    amy_data = _read_from_catalog(
+    amy_data = _read_catalog_from_select(
         selections=selections, location=location, cat=_cat
     ).isel(scenario=0, simulation=0)
     return amy_data

--- a/climakitae/threshold_panel.py
+++ b/climakitae/threshold_panel.py
@@ -2,7 +2,7 @@ import math
 import pandas as pd
 import panel as pn
 import param
-from .data_loaders import _read_from_catalog
+from .data_loaders import _read_catalog_from_select
 from .unit_conversions import _convert_units
 from .threshold_tools import (
     get_exceedance_count,
@@ -28,7 +28,7 @@ def _get_threshold_data(selections, location, cat):
 
     """
     # Read data from catalog
-    data = _read_from_catalog(selections=selections, location=location, cat=cat)
+    data = _read_catalog_from_select(selections=selections, location=location, cat=cat)
     data = data.compute()  # Read into memory
     return data
 

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -9,7 +9,7 @@ import param
 import panel as pn
 import pkg_resources
 from .utils import _read_ae_colormap
-from .data_loaders import _read_from_catalog
+from .data_loaders import _read_catalog_from_select
 from .catalog_convert import _scenario_to_experiment_id
 
 
@@ -61,7 +61,7 @@ def _get_postage_data(selections, location, cat):
 
     """
     # Read data from catalog
-    data = _read_from_catalog(selections=selections, location=location, cat=cat)
+    data = _read_catalog_from_select(selections=selections, location=location, cat=cat)
     data = data.compute()  # Read into memory
     return data
 


### PR DESCRIPTION
This PR combines app.retrieve() and app.retrieve_from_csv(). It allows the user to retrieve the data from a configuration csv file using app.retrieve() by setting the argument `config` to the filepath of a file, i.e. "config.csv". For example: 

This will work to retrieve the data as normal: whatever settings are contained in app.location and app.selections (as set in app.select() ) 
```
app.select() # Make your selections 
data = app.retrieve() 
```

This will also work, duplicating the behavior of app.retrieve_from_csv()
```
app.retrieve(config="config.csv")
```

This will also work, **but eventually I will delete this function**. I need to replace it in the existing notebooks though, first. 
```
app.retrieve_from_csv(config="config.csv") 
```

**To test**: Just try running the example code above. I've included an example csv file here: 
[config.csv](https://github.com/cal-adapt/climakitae/files/10583248/config.csv)