### PR TITLE
Simplify repeated code in threshold_tools

### DIFF
--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -241,7 +241,7 @@ def _calculate_return(fitted_distr, data_variable, arg_value):
     float
     """
 
-    try: 
+    try:
         if data_variable == "return_value":
             return_event = 1.0 - (1.0 / arg_value)
             return_value = fitted_distr.ppf(return_event)
@@ -295,9 +295,7 @@ def _bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     try:
         parameters, fitted_distr = _get_fitted_distr(new_ams, distr, distr_func)
         result = _calculate_return(
-            fitted_distr=fitted_distr,
-            data_variable=data_variable,
-            arg_value=arg_value,
+            fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value,
         )
     except (ValueError, ZeroDivisionError):
         result = np.nan
@@ -337,12 +335,7 @@ def _conf_int(
     bootstrap_values = []
 
     for _ in range(bootstrap_runs):
-        result = _bootstrap(
-            ams,
-            distr,
-            data_variable,
-            arg_value,
-        )
+        result = _bootstrap(ams, distr, data_variable, arg_value,)
         bootstrap_values.append(result)
 
     conf_int_array = np.percentile(
@@ -352,6 +345,7 @@ def _conf_int(
     conf_int_lower_limit = conf_int_array[0]
     conf_int_upper_limit = conf_int_array[1]
     return conf_int_lower_limit, conf_int_upper_limit
+
 
 def _get_return_variable(
     ams,
@@ -389,11 +383,9 @@ def _get_return_variable(
     xarray.Dataset
     """
 
-    data_variables = ['return_value', 'return_period', 'return_prob']
+    data_variables = ["return_value", "return_period", "return_prob"]
     if data_variable not in data_variables:
-        raise ValueError(
-            f"Invalid `data_variable`. Must be one of: {data_variables}"
-        )
+        raise ValueError(f"Invalid `data_variable`. Must be one of: {data_variables}")
 
     distr_func = _get_distr_func(distr)
     ams_attributes = ams.attrs
@@ -451,11 +443,15 @@ def _get_return_variable(
         new_ds["return_value"].attrs["return period"] = f"1-in-{arg_value}-year event"
     elif data_variable == "return_prob":
         threshold_unit = ams_attributes["units"]
-        new_ds["return_prob"].attrs["threshold"] = f"exceedance of {arg_value} {threshold_unit} event"
+        new_ds["return_prob"].attrs[
+            "threshold"
+        ] = f"exceedance of {arg_value} {threshold_unit} event"
         new_ds["return_prob"].attrs["units"] = None
     elif data_variable == "return_period":
         return_value_unit = ams_attributes["units"]
-        new_ds["return_period"].attrs["return value"] = f"{arg_value} {return_value_unit} event"
+        new_ds["return_period"].attrs[
+            "return value"
+        ] = f"{arg_value} {return_value_unit} event"
         new_ds["return_period"].attrs["units"] = "years"
 
     new_ds["conf_int_lower_limit"].attrs[
@@ -467,6 +463,7 @@ def _get_return_variable(
 
     new_ds.attrs["distribution"] = f"{distr}"
     return new_ds
+
 
 def get_return_value(
     ams,
@@ -496,8 +493,14 @@ def get_return_value(
     xarray.Dataset
     """
     return _get_return_variable(
-        ams, "return_value", return_period, distr, bootstrap_runs, 
-        conf_int_lower_bound, conf_int_upper_bound, multiple_points
+        ams,
+        "return_value",
+        return_period,
+        distr,
+        bootstrap_runs,
+        conf_int_lower_bound,
+        conf_int_upper_bound,
+        multiple_points,
     )
 
 
@@ -529,8 +532,14 @@ def get_return_prob(
     xarray.Dataset
     """
     return _get_return_variable(
-        ams, "return_prob", threshold, distr, bootstrap_runs, 
-        conf_int_lower_bound, conf_int_upper_bound, multiple_points
+        ams,
+        "return_prob",
+        threshold,
+        distr,
+        bootstrap_runs,
+        conf_int_lower_bound,
+        conf_int_upper_bound,
+        multiple_points,
     )
 
 
@@ -562,8 +571,14 @@ def get_return_period(
     xarray.Dataset
     """
     return _get_return_variable(
-        ams, "return_period", return_value, distr, bootstrap_runs, 
-        conf_int_lower_bound, conf_int_upper_bound, multiple_points
+        ams,
+        "return_period",
+        return_value,
+        distr,
+        bootstrap_runs,
+        conf_int_lower_bound,
+        conf_int_upper_bound,
+        multiple_points,
     )
 
 

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -295,9 +295,7 @@ def _bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     try:
         parameters, fitted_distr = _get_fitted_distr(new_ams, distr, distr_func)
         result = _calculate_return(
-            fitted_distr=fitted_distr,
-            data_variable=data_variable,
-            arg_value=arg_value,
+            fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value,
         )
     except (ValueError, ZeroDivisionError):
         result = np.nan
@@ -337,12 +335,7 @@ def _conf_int(
     bootstrap_values = []
 
     for _ in range(bootstrap_runs):
-        result = _bootstrap(
-            ams,
-            distr,
-            data_variable,
-            arg_value,
-        )
+        result = _bootstrap(ams, distr, data_variable, arg_value,)
         bootstrap_values.append(result)
 
     conf_int_array = np.percentile(

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -295,7 +295,9 @@ def _bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     try:
         parameters, fitted_distr = _get_fitted_distr(new_ams, distr, distr_func)
         result = _calculate_return(
-            fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value,
+            fitted_distr=fitted_distr, 
+            data_variable=data_variable, 
+            arg_value=arg_value,
         )
     except (ValueError, ZeroDivisionError):
         result = np.nan
@@ -335,7 +337,12 @@ def _conf_int(
     bootstrap_values = []
 
     for _ in range(bootstrap_runs):
-        result = _bootstrap(ams, distr, data_variable, arg_value,)
+        result = _bootstrap(
+            ams, 
+            distr, 
+            data_variable, 
+            arg_value,
+        )
         bootstrap_values.append(result)
 
     conf_int_array = np.percentile(

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -295,8 +295,8 @@ def _bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     try:
         parameters, fitted_distr = _get_fitted_distr(new_ams, distr, distr_func)
         result = _calculate_return(
-            fitted_distr=fitted_distr, 
-            data_variable=data_variable, 
+            fitted_distr=fitted_distr,
+            data_variable=data_variable,
             arg_value=arg_value,
         )
     except (ValueError, ZeroDivisionError):
@@ -338,9 +338,9 @@ def _conf_int(
 
     for _ in range(bootstrap_runs):
         result = _bootstrap(
-            ams, 
-            distr, 
-            data_variable, 
+            ams,
+            distr,
+            data_variable,
             arg_value,
         )
         bootstrap_values.append(result)

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -295,7 +295,9 @@ def _bootstrap(ams, distr="gev", data_variable="return_value", arg_value=10):
     try:
         parameters, fitted_distr = _get_fitted_distr(new_ams, distr, distr_func)
         result = _calculate_return(
-            fitted_distr=fitted_distr, data_variable=data_variable, arg_value=arg_value,
+            fitted_distr=fitted_distr,
+            data_variable=data_variable,
+            arg_value=arg_value,
         )
     except (ValueError, ZeroDivisionError):
         result = np.nan
@@ -335,7 +337,12 @@ def _conf_int(
     bootstrap_values = []
 
     for _ in range(bootstrap_runs):
-        result = _bootstrap(ams, distr, data_variable, arg_value,)
+        result = _bootstrap(
+            ams,
+            distr,
+            data_variable,
+            arg_value,
+        )
         bootstrap_values.append(result)
 
     conf_int_array = np.percentile(
@@ -485,7 +492,7 @@ def get_return_value(
     distr: str
         The type of extreme value distribution to fit
     bootstrap_runs: int
-        Number of bootstrap samples 
+        Number of bootstrap samples
     conf_int_lower_bound: float
         Confidence interval lower bound
     conf_int_upper_bound: float
@@ -530,7 +537,7 @@ def get_return_prob(
     distr: str
         The type of extreme value distribution to fit
     bootstrap_runs: int
-        Number of bootstrap samples 
+        Number of bootstrap samples
     conf_int_lower_bound: float
         Confidence interval lower bound
     conf_int_upper_bound: float
@@ -575,7 +582,7 @@ def get_return_period(
     distr: str
         The type of extreme value distribution to fit
     bootstrap_runs: int
-        Number of bootstrap samples 
+        Number of bootstrap samples
     conf_int_lower_bound: float
         Confidence interval lower bound
     conf_int_upper_bound: float

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -377,7 +377,7 @@ def _get_return_variable(
     Parameters
     ----------
     ams: xarray.DataArray
-    return_variable: str
+    data_variable: str
     arg_value: float
     distr: str
     bootstrap_runs: int

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -481,23 +481,29 @@ def get_return_value(
     conf_int_upper_bound=97.5,
     multiple_points=True,
 ):
-    """Creates xarray Dataset with return values and confidence intervals from maximum series
-
-    Returns dataset with return values and confidence intervals from maximum series.
+    """Creates xarray Dataset with return values and confidence intervals from maximum series.
 
     Parameters
     ----------
     ams: xarray.DataArray
+        Annual maximum data, can be output from the function get_ams()
     return_period: float
+        The recurrence interval (in years) for which to calculate the return value
     distr: str
+        The type of extreme value distribution to fit
     bootstrap_runs: int
+        Number of bootstrap samples 
     conf_int_lower_bound: float
+        Confidence interval lower bound
     conf_int_upper_bound: float
+        Confidence interval upper bound
     multiple_points: boolean
+        Whether or not the data contains multiple points (has x, y dimensions)
 
     Returns
     -------
     xarray.Dataset
+        Dataset with return values and confidence intervals
     """
     return _get_return_variable(
         ams,
@@ -520,23 +526,29 @@ def get_return_prob(
     conf_int_upper_bound=97.5,
     multiple_points=True,
 ):
-    """Creates xarray Dataset with return probabilities and confidence intervals from maximum series
-
-    Returns dataset with return probabilities and confidence intervals from maximum series.
+    """Creates xarray Dataset with return probabilities and confidence intervals from maximum series.
 
     Parameters
     ----------
     ams: xarray.DataArray
+        Annual maximum data, can be output from the function get_ams()
     threshold: float
+        The threshold value for which to calculate the probability of exceedance
     distr: str
+        The type of extreme value distribution to fit
     bootstrap_runs: int
+        Number of bootstrap samples 
     conf_int_lower_bound: float
+        Confidence interval lower bound
     conf_int_upper_bound: float
+        Confidence interval upper bound
     multiple_points: boolean
+        Whether or not the data contains multiple points (has x, y dimensions)
 
     Returns
     -------
     xarray.Dataset
+        Dataset with return probabilities and confidence intervals
     """
     return _get_return_variable(
         ams,
@@ -559,23 +571,29 @@ def get_return_period(
     conf_int_upper_bound=97.5,
     multiple_points=True,
 ):
-    """Creates xarray Dataset with return periods and confidence intervals from maximum series
-
-    Returns dataset with return periods and confidence intervals from maximum series.
+    """Creates xarray Dataset with return periods and confidence intervals from maximum series.
 
     Parameters
     ----------
     ams: xarray.DataArray
+        Annual maximum data, can be output from the function get_ams()
     return_value: float
+        The threshold value for which to calculate the return period of occurance
     distr: str
+        The type of extreme value distribution to fit
     bootstrap_runs: int
+        Number of bootstrap samples 
     conf_int_lower_bound: float
+        Confidence interval lower bound
     conf_int_upper_bound: float
+        Confidence interval upper bound
     multiple_points: boolean
+        Whether or not the data contains multiple points (has x, y dimensions)
 
     Returns
     -------
     xarray.Dataset
+        Dataset with return periods and confidence intervals
     """
     return _get_return_variable(
         ams,

--- a/climakitae/threshold_tools.py
+++ b/climakitae/threshold_tools.py
@@ -349,7 +349,7 @@ def _conf_int(
 
 def _get_return_variable(
     ams,
-    return_variable,
+    data_variable,
     arg_value,
     distr="gev",
     bootstrap_runs=100,
@@ -401,7 +401,7 @@ def _get_return_variable(
     def _return_variable(ams):
         try:
             parameters, fitted_distr = _get_fitted_distr(ams, distr, distr_func)
-            return_value = _calculate_return(
+            return_variable = _calculate_return(
                 fitted_distr=fitted_distr,
                 data_variable=data_variable,
                 arg_value=arg_value,


### PR DESCRIPTION
This PR creates a new function `_get_return_variable` that consolidates code that was repeated between the `get_return_value`, `get_return_prob`, and `get_return_period` functions (I think this will make things clearer/easier to keep track of as we change things that affect all three user-facing functions!)