### PR TITLE
Move xclim install to GitHub testing workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,8 @@ jobs:
 
     - name: Output conda info 
       run: conda info
+    - name: Install xclim
+      run: pip install boltons==21.0.0 bottleneck==1.3.6 cf_xarray==0.7.9 jsonpickle==2.2.0 patsy==0.5.3 statsmodels==0.13.5 xclim==0.41.0 --no-deps
     - name: Install climakitae 
       run: pip install .
 #    - name: Lint with flake8

--- a/environment.yml
+++ b/environment.yml
@@ -31,5 +31,4 @@ dependencies:
   - scipy
   - shapely
   - xarray
-  - xclim
   - xmip


### PR DESCRIPTION
This PR removes xclim from environment.yml and instead pip installs it and its dependencies in the GitHub workflow that runs the test environment.