### PR TITLE
Fix NoModule numba Error in test environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/cache@v2
       env:
           # Increase this value to reset cache if environment.yml has not changed
-          CACHE_NUMBER: 1
+          CACHE_NUMBER: 2
       with:
         path: ${{ matrix.prefix }}
         key:

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - jinja2
   - matplotlib
   - metpy
+  - numba
   - numpy
   - pandas
   - panel


### PR DESCRIPTION
This PR fixes the missing `numba` package in the testing environment by breaking the cache by incrementing `CACHE_NUMBER` and by adding `numba` to `environment.yml` as it is needed by `xclim` tests.