### PR TITLE
Updates CDD+HDD function and adds degree hours calculation

### DIFF
--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -22,7 +22,8 @@ def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
     """
 
     # Check that temperature data was passed to function, throw error if not
-    assert t2.name == "Air Temperature at 2m", "Invalid input data, please provide air temperature data to CDD/HDD calculation"
+    if t2.name != "Air Temperature at 2m":
+        raise Exception("Invalid input data, please provide Air Temperature at 2m data to CDD/HDD calculation")
 
     # Subtract t2 from the threshold inputs
     hdd_deg_less_than_standard = hdd_threshold - t2
@@ -70,7 +71,8 @@ def compute_hdh_cdh(t2, hdh_threshold=65, cdh_threshold=65):
     """
 
     # Check that temperature data was passed to function, throw error if not
-    assert t2.name == "Air Temperature at 2m", "Invalid input data, please provide air temperature data to CDH/HDH calculation"
+    if t2.name != "Air Temperature at 2m":
+        raise Exception("Invalid input data, please provide Air Temperature at 2m data to CDH/HDH calculation")
 
     # Calculate heating and cooling hours
     cooling_hours = t2.where(

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -42,6 +42,40 @@ def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
     return (hdd, cdd)
 
 
+def compute_hdh_cdh(t2, hdh_threshold=65, cdh_threshold=65):
+    """Compute heating degree hours (HDH) and cooling degree hours (CDH)
+
+    Parameters
+    -----------
+    t2: xr.DataArray
+        Air temperature at 2m gridded data
+    hdh_threshold: int, optional
+        Standard temperature in Fahrenheit. Default to 65 degF
+    cdh_threshold: int, optional
+        Standard temperature in Fahrenheit. Default to 65 degF
+
+    Returns
+    -------
+    tuple of xr.DataArray
+        (hdh, cdh)
+    """
+    
+    # Calculate heating and cooling hours
+    cooling_hours = t2.where(t2 > hdh_threshold)  # temperatures above threshold, require cooling
+    heating_hours = (-1) * t2.where(t2 < cdh_threshold)  # temperatures below threshold, require heating
+
+    # Compute CDH: count number of hours and resample to daily (max 24 value)
+    cdh = cooling_hours.resample(time='1D').count(dim='time').squeeze()
+    cdh.name = "Cooling Degree Hours"
+    cdh.attrs["cdh_threshold"] = str(cdh_threshold) + "degF"
+
+    # Compute HDH: count number of hours and resample to daily (max 24 value)
+    hdh = heating_hours.resample(time='1D').count(dim='time').squeeze()
+    hdh.name = "Heating Degree Hours"
+    hdh.attrs["hdh_threshold"] = str(hdh_threshold) + "degF"
+
+    return(hdh, cdh)
+
 
 def _compute_dewpointtemp(temperature, rel_hum):
     """Calculate dew point temperature

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -58,9 +58,9 @@ def compute_hdh_cdh(t2, hdh_threshold, cdh_threshold):
     t2: xr.DataArray
         Air temperature at 2m gridded data
     hdh_threshold: int, optional
-        Standard temperature in Fahrenheit. 
+        Standard temperature in Fahrenheit.
     cdh_threshold: int, optional
-        Standard temperature in Fahrenheit. 
+        Standard temperature in Fahrenheit.
 
     Returns
     -------

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -30,14 +30,18 @@ def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
         hdd_deg_less_than_standard > 0, 0
     )  # Replace negative values with 0
     hdd.name = "Heating Degree Days"
-    hdd.attrs["hdd_threshold"] = str(hdd_threshold) + "degF" # add attribute of threshold value
+    hdd.attrs["hdd_threshold"] = (
+        str(hdd_threshold) + "degF"
+    )  # add attribute of threshold value
 
     # Compute CDD: Find negative difference (i.e. days > 65 degF)
     cdd = (-1) * cdd_deg_less_than_standard.where(
         cdd_deg_less_than_standard < 0, 0
     )  # Replace positive values with 0
     cdd.name = "Cooling Degree Days"
-    cdd.attrs["cdd_threshold"] = str(cdd_threshold) + "degF" # add attribute of threshold value
+    cdd.attrs["cdd_threshold"] = (
+        str(cdd_threshold) + "degF"
+    )  # add attribute of threshold value
 
     return (hdd, cdd)
 
@@ -59,22 +63,26 @@ def compute_hdh_cdh(t2, hdh_threshold=65, cdh_threshold=65):
     tuple of xr.DataArray
         (hdh, cdh)
     """
-    
+
     # Calculate heating and cooling hours
-    cooling_hours = t2.where(t2 > hdh_threshold)  # temperatures above threshold, require cooling
-    heating_hours = (-1) * t2.where(t2 < cdh_threshold)  # temperatures below threshold, require heating
+    cooling_hours = t2.where(
+        t2 > hdh_threshold
+    )  # temperatures above threshold, require cooling
+    heating_hours = (-1) * t2.where(
+        t2 < cdh_threshold
+    )  # temperatures below threshold, require heating
 
     # Compute CDH: count number of hours and resample to daily (max 24 value)
-    cdh = cooling_hours.resample(time='1D').count(dim='time').squeeze()
+    cdh = cooling_hours.resample(time="1D").count(dim="time").squeeze()
     cdh.name = "Cooling Degree Hours"
     cdh.attrs["cdh_threshold"] = str(cdh_threshold) + "degF"
 
     # Compute HDH: count number of hours and resample to daily (max 24 value)
-    hdh = heating_hours.resample(time='1D').count(dim='time').squeeze()
+    hdh = heating_hours.resample(time="1D").count(dim="time").squeeze()
     hdh.name = "Heating Degree Hours"
     hdh.attrs["hdh_threshold"] = str(hdh_threshold) + "degF"
 
-    return(hdh, cdh)
+    return (hdh, cdh)
 
 
 def _compute_dewpointtemp(temperature, rel_hum):

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -3,14 +3,16 @@
 import numpy as np
 
 
-def compute_hdd_cdd(t2, standard_temp=65):
+def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
     """Compute heating degree days (HDD) and cooling degree days (CDD)
 
     Parameters
     -----------
     t2: xr.DataArray
         Air temperature at 2m gridded data
-    standard_temp: int, optional
+    hdd_threshold: int, optional
+        Standard temperature in Fahrenheit. Default to 65 degF
+    cdd_threshold: int, optional
         Standard temperature in Fahrenheit. Default to 65 degF
 
     Returns
@@ -19,22 +21,26 @@ def compute_hdd_cdd(t2, standard_temp=65):
         (hdd, cdd)
     """
 
-    # Subtract t2 from the standard reference temperature
-    deg_less_than_standard = standard_temp - t2
+    # Subtract t2 from the threshold inputs
+    hdd_deg_less_than_standard = hdd_threshold - t2
+    cdd_deg_less_than_standard = cdd_threshold - t2
 
     # Compute HDD: Find positive difference (i.e. days < 65 degF)
-    hdd = deg_less_than_standard.where(
-        deg_less_than_standard > 0, 0
+    hdd = hdd_deg_less_than_standard.where(
+        hdd_deg_less_than_standard > 0, 0
     )  # Replace negative values with 0
     hdd.name = "Heating Degree Days"
+    hdd.attrs["hdd_threshold"] = str(hdd_threshold) + "degF" # add attribute of threshold value
 
     # Compute CDD: Find negative difference (i.e. days > 65 degF)
-    cdd = (-1) * deg_less_than_standard.where(
-        deg_less_than_standard < 0, 0
+    cdd = (-1) * cdd_deg_less_than_standard.where(
+        cdd_deg_less_than_standard < 0, 0
     )  # Replace positive values with 0
     cdd.name = "Cooling Degree Days"
+    cdd.attrs["cdd_threshold"] = str(cdd_threshold) + "degF" # add attribute of threshold value
 
     return (hdd, cdd)
+
 
 
 def _compute_dewpointtemp(temperature, rel_hum):

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -21,26 +21,31 @@ def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
         (hdd, cdd)
     """
 
+    # Check that temperature data was passed to function, throw error if not
+    assert t2.name == "Air Temperature at 2m", "Invalid input data, please provide air temperature data to CDD/HDD calculation"
+
     # Subtract t2 from the threshold inputs
     hdd_deg_less_than_standard = hdd_threshold - t2
     cdd_deg_less_than_standard = cdd_threshold - t2
 
-    # Compute HDD: Find positive difference (i.e. days < 65 degF)
-    hdd = hdd_deg_less_than_standard.where(
-        hdd_deg_less_than_standard > 0, 0
-    )  # Replace negative values with 0
+    # Compute HDD: Find positive difference (i.e. days < 65 degF) 
+    hdd = hdd_deg_less_than_standard.clip(
+        0, None
+    )
+    # Replace negative values with 0
     hdd.name = "Heating Degree Days"
     hdd.attrs["hdd_threshold"] = (
-        str(hdd_threshold) + "degF"
+        str(hdd_threshold) + " degF"
     )  # add attribute of threshold value
 
-    # Compute CDD: Find negative difference (i.e. days > 65 degF)
-    cdd = (-1) * cdd_deg_less_than_standard.where(
-        cdd_deg_less_than_standard < 0, 0
-    )  # Replace positive values with 0
+    # Compute CDD: Find negative difference (i.e. days > 65 degF) 
+    cdd = (-1) * cdd_deg_less_than_standard.clip(
+        None, 0
+    )
+    # Replace positive values with 0
     cdd.name = "Cooling Degree Days"
     cdd.attrs["cdd_threshold"] = (
-        str(cdd_threshold) + "degF"
+        str(cdd_threshold) + " degF"
     )  # add attribute of threshold value
 
     return (hdd, cdd)
@@ -64,6 +69,9 @@ def compute_hdh_cdh(t2, hdh_threshold=65, cdh_threshold=65):
         (hdh, cdh)
     """
 
+    # Check that temperature data was passed to function, throw error if not
+    assert t2.name == "Air Temperature at 2m", "Invalid input data, please provide air temperature data to CDH/HDH calculation"
+
     # Calculate heating and cooling hours
     cooling_hours = t2.where(
         t2 > hdh_threshold
@@ -75,12 +83,12 @@ def compute_hdh_cdh(t2, hdh_threshold=65, cdh_threshold=65):
     # Compute CDH: count number of hours and resample to daily (max 24 value)
     cdh = cooling_hours.resample(time="1D").count(dim="time").squeeze()
     cdh.name = "Cooling Degree Hours"
-    cdh.attrs["cdh_threshold"] = str(cdh_threshold) + "degF"
+    cdh.attrs["cdh_threshold"] = str(cdh_threshold) + " degF"
 
     # Compute HDH: count number of hours and resample to daily (max 24 value)
     hdh = heating_hours.resample(time="1D").count(dim="time").squeeze()
     hdh.name = "Heating Degree Hours"
-    hdh.attrs["hdh_threshold"] = str(hdh_threshold) + "degF"
+    hdh.attrs["hdh_threshold"] = str(hdh_threshold) + " degF"
 
     return (hdh, cdh)
 

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -23,26 +23,24 @@ def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
 
     # Check that temperature data was passed to function, throw error if not
     if t2.name != "Air Temperature at 2m":
-        raise Exception("Invalid input data, please provide Air Temperature at 2m data to CDD/HDD calculation")
+        raise Exception(
+            "Invalid input data, please provide Air Temperature at 2m data to CDD/HDD calculation"
+        )
 
     # Subtract t2 from the threshold inputs
     hdd_deg_less_than_standard = hdd_threshold - t2
     cdd_deg_less_than_standard = cdd_threshold - t2
 
-    # Compute HDD: Find positive difference (i.e. days < 65 degF) 
-    hdd = hdd_deg_less_than_standard.clip(
-        0, None
-    )
+    # Compute HDD: Find positive difference (i.e. days < 65 degF)
+    hdd = hdd_deg_less_than_standard.clip(0, None)
     # Replace negative values with 0
     hdd.name = "Heating Degree Days"
     hdd.attrs["hdd_threshold"] = (
         str(hdd_threshold) + " degF"
     )  # add attribute of threshold value
 
-    # Compute CDD: Find negative difference (i.e. days > 65 degF) 
-    cdd = (-1) * cdd_deg_less_than_standard.clip(
-        None, 0
-    )
+    # Compute CDD: Find negative difference (i.e. days > 65 degF)
+    cdd = (-1) * cdd_deg_less_than_standard.clip(None, 0)
     # Replace positive values with 0
     cdd.name = "Cooling Degree Days"
     cdd.attrs["cdd_threshold"] = (
@@ -72,7 +70,9 @@ def compute_hdh_cdh(t2, hdh_threshold=65, cdh_threshold=65):
 
     # Check that temperature data was passed to function, throw error if not
     if t2.name != "Air Temperature at 2m":
-        raise Exception("Invalid input data, please provide Air Temperature at 2m data to CDH/HDH calculation")
+        raise Exception(
+            "Invalid input data, please provide Air Temperature at 2m data to CDH/HDH calculation"
+        )
 
     # Calculate heating and cooling hours
     cooling_hours = t2.where(

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 
-def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
+def compute_hdd_cdd(t2, hdd_threshold, cdd_threshold):
     """Compute heating degree days (HDD) and cooling degree days (CDD)
 
     Parameters
@@ -11,9 +11,9 @@ def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
     t2: xr.DataArray
         Air temperature at 2m gridded data
     hdd_threshold: int, optional
-        Standard temperature in Fahrenheit. Default to 65 degF
+        Standard temperature in Fahrenheit.
     cdd_threshold: int, optional
-        Standard temperature in Fahrenheit. Default to 65 degF
+        Standard temperature in Fahrenheit.
 
     Returns
     -------
@@ -50,7 +50,7 @@ def compute_hdd_cdd(t2, hdd_threshold=65, cdd_threshold=65):
     return (hdd, cdd)
 
 
-def compute_hdh_cdh(t2, hdh_threshold=65, cdh_threshold=65):
+def compute_hdh_cdh(t2, hdh_threshold, cdh_threshold):
     """Compute heating degree hours (HDH) and cooling degree hours (CDH)
 
     Parameters
@@ -58,9 +58,9 @@ def compute_hdh_cdh(t2, hdh_threshold=65, cdh_threshold=65):
     t2: xr.DataArray
         Air temperature at 2m gridded data
     hdh_threshold: int, optional
-        Standard temperature in Fahrenheit. Default to 65 degF
+        Standard temperature in Fahrenheit. 
     cdh_threshold: int, optional
-        Standard temperature in Fahrenheit. Default to 65 degF
+        Standard temperature in Fahrenheit. 
 
     Returns
     -------

--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -399,6 +399,15 @@ def _write_gwl_files():
     all_gw_levels2.to_csv("../data/gwl_1981-2010ref.csv")
 
 
+## DFU notebook-specific functions, flexible for all notebooks
+def compute_annual_aggreggate(data, name, num_grid_cells):  
+    """Calculates the annual sum of HDD and CDD"""
+    annual_ag = data.squeeze().groupby('time.year').sum(['time']) # Aggregate annually
+    annual_ag = annual_ag/num_grid_cells # Divide by number of gridcells 
+    annual_ag.name = name # Give new name to dataset
+    return annual_ag
+
+
 def compute_multimodel_stats(data): 
     """Calculates model mean, min, max across simulations"""
     # Compute mean across simulation dimensions and add is as a coordinate
@@ -425,3 +434,24 @@ def trendline(data):
     trendline = m*data_sim_mean.year + b # y = mx + b 
     trendline.name = "trendline" 
     return trendline
+
+## DFU plotting functions
+def hdd_cdd_lineplot(annual_data, trendline, title="title"): 
+    """Plots annual CDD/HDD with trendline provided"""
+    return annual_data.hvplot.line(
+        x="year", by="simulation", 
+        width=800, height=350,
+        title=title,
+        yformatter='%.0f' # Remove scientific notation
+    ) * trendline.hvplot.line(  # Add trendline
+        x="year", 
+        color="black", 
+        line_dash='dashed', 
+        label="trendline"
+    ) 
+
+def hdh_cdh_lineplot(data):    
+    """Plots HDH/CDH"""
+    return data.hvplot.line(x="time", by="simulation",
+                             title=data.name, 
+                             ylabel=data.name + " (degF)")

--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -400,58 +400,71 @@ def _write_gwl_files():
 
 
 ## DFU notebook-specific functions, flexible for all notebooks
-def compute_annual_aggreggate(data, name, num_grid_cells):  
+def compute_annual_aggreggate(data, name, num_grid_cells):
     """Calculates the annual sum of HDD and CDD"""
-    annual_ag = data.squeeze().groupby('time.year').sum(['time']) # Aggregate annually
-    annual_ag = annual_ag/num_grid_cells # Divide by number of gridcells 
-    annual_ag.name = name # Give new name to dataset
+    annual_ag = data.squeeze().groupby("time.year").sum(["time"])  # Aggregate annually
+    annual_ag = annual_ag / num_grid_cells  # Divide by number of gridcells
+    annual_ag.name = name  # Give new name to dataset
     return annual_ag
 
 
-def compute_multimodel_stats(data): 
+def compute_multimodel_stats(data):
     """Calculates model mean, min, max across simulations"""
     # Compute mean across simulation dimensions and add is as a coordinate
-    sim_mean = data.mean(dim="simulation").assign_coords({"simulation":"simulation mean"}).expand_dims("simulation") 
+    sim_mean = (
+        data.mean(dim="simulation")
+        .assign_coords({"simulation": "simulation mean"})
+        .expand_dims("simulation")
+    )
 
-    # Compute multimodel min 
-    sim_min = data.min(dim="simulation").assign_coords({"simulation":"simulation min"}).expand_dims("simulation") 
+    # Compute multimodel min
+    sim_min = (
+        data.min(dim="simulation")
+        .assign_coords({"simulation": "simulation min"})
+        .expand_dims("simulation")
+    )
 
-    # Compute multimodel max 
-    sim_max = data.max(dim="simulation").assign_coords({"simulation":"simulation max"}).expand_dims("simulation") 
+    # Compute multimodel max
+    sim_max = (
+        data.max(dim="simulation")
+        .assign_coords({"simulation": "simulation max"})
+        .expand_dims("simulation")
+    )
 
     # Add to main dataset
     stats_concat = xr.concat([data, sim_mean, sim_min, sim_max], dim="simulation")
     return stats_concat
 
 
-def trendline(data): 
+def trendline(data):
     """Calculates treadline of the multi-model mean"""
     if "simulation mean" not in data.simulation:
         raise Exception("Invalid data provdied, please pass the multimodel mean stats")
 
-    data_sim_mean = data.sel(simulation="simulation mean") 
+    data_sim_mean = data.sel(simulation="simulation mean")
     m, b = data_sim_mean.polyfit(dim="year", deg=1).polyfit_coefficients.values
-    trendline = m*data_sim_mean.year + b # y = mx + b 
-    trendline.name = "trendline" 
+    trendline = m * data_sim_mean.year + b  # y = mx + b
+    trendline.name = "trendline"
     return trendline
 
+
 ## DFU plotting functions
-def hdd_cdd_lineplot(annual_data, trendline, title="title"): 
+def hdd_cdd_lineplot(annual_data, trendline, title="title"):
     """Plots annual CDD/HDD with trendline provided"""
     return annual_data.hvplot.line(
-        x="year", by="simulation", 
-        width=800, height=350,
+        x="year",
+        by="simulation",
+        width=800,
+        height=350,
         title=title,
-        yformatter='%.0f' # Remove scientific notation
+        yformatter="%.0f",  # Remove scientific notation
     ) * trendline.hvplot.line(  # Add trendline
-        x="year", 
-        color="black", 
-        line_dash='dashed', 
-        label="trendline"
-    ) 
+        x="year", color="black", line_dash="dashed", label="trendline"
+    )
 
-def hdh_cdh_lineplot(data):    
+
+def hdh_cdh_lineplot(data):
     """Plots HDH/CDH"""
-    return data.hvplot.line(x="time", by="simulation",
-                             title=data.name, 
-                             ylabel=data.name + " (degF)")
+    return data.hvplot.line(
+        x="time", by="simulation", title=data.name, ylabel=data.name + " (degF)"
+    )

--- a/climakitae/utils.py
+++ b/climakitae/utils.py
@@ -417,7 +417,7 @@ def compute_multimodel_stats(data):
 
 def trendline(data): 
     """Calculates treadline of the multi-model mean"""
-    if "simulation mean" not in data:
+    if "simulation mean" not in data.simulation:
         raise Exception("Invalid data provdied, please pass the multimodel mean stats")
 
     data_sim_mean = data.sel(simulation="simulation mean") 


### PR DESCRIPTION
As requested, multiple changes have occurred for heating/cooling degree days:
1. The order in which CDD/HDD is computed is now flipped, so that CDD and HDD are calculated prior to spatial averaging.
2. CDD/HDD function now has the functionality to accept a different threshold for heating/cooling. 
**Please test that the `compute_hdd_cdd` function works as desired in the INTRO dfu notebook, Section 4**

4. A new heating/cooling degree hours calculation is provided
**Please test that the `compute_hdh_cdh` function works as desired in the INTRO dfu notebook, Section 5**

INTRO DFU notebook is also under review to reflect these changes as well: https://github.com/cal-adapt/cae-notebooks/pull/42