### PR TITLE
Update variable descriptions for min/max daily and hourly air temperature 

### DIFF
--- a/climakitae/data/variable_descriptions.csv
+++ b/climakitae/data/variable_descriptions.csv
@@ -34,8 +34,8 @@ wspd10max,maximum 10-meter wind speed,Dynamical,daily/monthly,m/s,Maximum wind s
 psfc,surface pressure,Dynamical,daily/monthly,hPa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE
 q2,2-meter specific humidity,Dynamical,daily/monthly,g/kg,Specific humidity at 2m,"The ratio of the mass of water vapor over the mass of total (moist) air, measured 2m above Earth's surface.",ae_blue,TRUE
 tskin,surface skin temperature ,Dynamical,daily/monthly,K,Surface skin temperature,Temperature of the Earth's surface (ground surface).,ae_orange,TRUE
-t2min,daily minimum 2-m temperature ,Dynamical,daily/monthly,K,Daily minimum air temperature at 2m,The minimum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
-t2max,daily maximum 2-m temperature ,Dynamical,daily/monthly,K,Daily maximum air temperature at 2m,The maximum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
+t2min,daily minimum 2-m temperature ,Dynamical,daily/monthly,K,Minimum Air Temperature at 2m,The minimum air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
+t2max,daily maximum 2-m temperature ,Dynamical,daily/monthly,K,Maximum Air Temperature at 2m,The maximum air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
 lw_dwn,downwelling longwave flux at bottom,Dynamical,daily/monthly,W/m2,Instantaneous downwelling longwave flux at bottom,Longwave radiation emitted by Earth's surface that is reflected back downwards by clouds. ,ae_orange,TRUE
 sw_dwn,downwelling shortwave flux at bottom,Dynamical,daily/monthly,W/m2,Instantaneous downwelling shortwave flux at bottom,"Shortwave radiation from the sun that reaches Earth's surface, minus radiation reflected back to space by clouds or absorbed by the atmosphere.",ae_orange,TRUE
 sw_sfc,shortwave flux at the surface,Dynamical,daily/monthly,W/m2,Shortwave flux at the surface,Shortwave radiation from the sun that reaches Earth's surface. ,ae_orange,TRUE


### PR DESCRIPTION
The variable description for the minimum and maximum air temperature used to be "Daily min/max..." whether it was daily or monthly. This PR fixes that! Now it just reades "Min air temp...."

This will change the name of the dataset that is returned as well. 