### PR TITLE
Downgrade image

### DIFF
--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -651,7 +651,7 @@ def _get_simulation_options(cat, activity_id, table_id, grid_label, experiment_i
 
     # Get all unique simulation options from catalog selection
     try:
-        simulation_options = cat_subset.unique()["source_id"]["values"]
+        simulation_options = list(cat_subset.df["source_id"].unique())
         if "ensmean" in simulation_options:
             simulation_options.remove("ensmean")  # Remove ensemble means
     except:
@@ -769,7 +769,7 @@ class _DataSelector(param.Parameterized):
             table_id=_timescale_to_table_id(self.timescale),
             grid_label=_resolution_to_gridlabel(self.resolution),
         )
-        self.unique_variable_ids = self.cat_subset.unique()["variable_id"]["values"]
+        self.unique_variable_ids = list(self.cat_subset.df["variable_id"].unique())
         self.variable_options_df = _get_variable_options_df(
             var_catalog=var_catalog,
             unique_variable_ids=self.unique_variable_ids,
@@ -780,7 +780,7 @@ class _DataSelector(param.Parameterized):
         # Set scenario param
         scenario_ssp_options = [
             _scenario_to_experiment_id(scen, reverse=True)
-            for scen in self.cat_subset.unique()["experiment_id"]["values"]
+            for scen in list(self.cat_subset.df["experiment_id"].unique())
             if "ssp" in scen
         ]
         for scenario_i in [
@@ -859,7 +859,7 @@ class _DataSelector(param.Parameterized):
             table_id=_timescale_to_table_id(self.timescale),
             grid_label=_resolution_to_gridlabel(self.resolution),
         )
-        self.unique_variable_ids = self.cat_subset.unique()["variable_id"]["values"]
+        self.unique_variable_ids = list(self.cat_subset.df["variable_id"].unique())
         self.variable_options_df = _get_variable_options_df(
             var_catalog=var_catalog,
             unique_variable_ids=self.unique_variable_ids,
@@ -952,7 +952,7 @@ class _DataSelector(param.Parameterized):
         # Get scenario options in catalog format
         scenario_ssp_options = [
             _scenario_to_experiment_id(scen, reverse=True)
-            for scen in self.cat_subset.unique()["experiment_id"]["values"]
+            for scen in list(self.cat_subset.df["experiment_id"].unique())
             if "ssp" in scen
         ]
         for scenario_i in [

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -651,7 +651,7 @@ def _get_simulation_options(cat, activity_id, table_id, grid_label, experiment_i
 
     # Get all unique simulation options from catalog selection
     try:
-        simulation_options = cat_subset.unique()["source_id"]
+        simulation_options = cat_subset.unique()["source_id"]["values"]
         if "ensmean" in simulation_options:
             simulation_options.remove("ensmean")  # Remove ensemble means
     except:
@@ -769,7 +769,7 @@ class _DataSelector(param.Parameterized):
             table_id=_timescale_to_table_id(self.timescale),
             grid_label=_resolution_to_gridlabel(self.resolution),
         )
-        self.unique_variable_ids = self.cat_subset.unique()["variable_id"]
+        self.unique_variable_ids = self.cat_subset.unique()["variable_id"]["values"]
         self.variable_options_df = _get_variable_options_df(
             var_catalog=var_catalog,
             unique_variable_ids=self.unique_variable_ids,
@@ -780,7 +780,7 @@ class _DataSelector(param.Parameterized):
         # Set scenario param
         scenario_ssp_options = [
             _scenario_to_experiment_id(scen, reverse=True)
-            for scen in self.cat_subset.unique()["experiment_id"]
+            for scen in self.cat_subset.unique()["experiment_id"]["values"]
             if "ssp" in scen
         ]
         for scenario_i in [
@@ -859,7 +859,7 @@ class _DataSelector(param.Parameterized):
             table_id=_timescale_to_table_id(self.timescale),
             grid_label=_resolution_to_gridlabel(self.resolution),
         )
-        self.unique_variable_ids = self.cat_subset.unique()["variable_id"]
+        self.unique_variable_ids = self.cat_subset.unique()["variable_id"]["values"]
         self.variable_options_df = _get_variable_options_df(
             var_catalog=var_catalog,
             unique_variable_ids=self.unique_variable_ids,
@@ -952,7 +952,7 @@ class _DataSelector(param.Parameterized):
         # Get scenario options in catalog format
         scenario_ssp_options = [
             _scenario_to_experiment_id(scen, reverse=True)
-            for scen in self.cat_subset.unique()["experiment_id"]
+            for scen in self.cat_subset.unique()["experiment_id"]["values"]
             if "ssp" in scen
         ]
         for scenario_i in [

--- a/climakitae/uncertain_utils.py
+++ b/climakitae/uncertain_utils.py
@@ -7,12 +7,16 @@ import pandas as pd
 import intake
 import warnings
 from .selectors import Boundaries
-from cmip6_preprocessing.preprocessing import rename_cmip6
 from scipy import stats
 import pkg_resources
 from climakitae.data_loaders import _get_area_subset
 import holoviews as hv
 import panel as pn
+
+try:
+    from xmip.preprocessing import rename_cmip6
+except ImportError:
+    from cmip6_preprocessing.preprocessing import rename_cmip6
 
 
 ### Utility functions for uncertainty analyses and notebooks

--- a/climakitae/uncertain_utils.py
+++ b/climakitae/uncertain_utils.py
@@ -7,7 +7,7 @@ import pandas as pd
 import intake
 import warnings
 from .selectors import Boundaries
-from xmip.preprocessing import rename_cmip6
+from cmip6_preprocessing.preprocessing import rename_cmip6
 from scipy import stats
 import pkg_resources
 from climakitae.data_loaders import _get_area_subset

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,11 @@ classifiers =
 packages = find:
 install_requires =
     cartopy
-    dask-geopandas
     geopandas
     geoviews
     holoviews
     hvplot
     intake
-    intake-geopandas
     intake-xarray
     matplotlib
     metpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,11 +17,13 @@ classifiers =
 packages = find:
 install_requires =
     cartopy
+    dask-geopandas
     geopandas
     geoviews
     holoviews
     hvplot
     intake
+    intake-geopandas
     intake-xarray
     matplotlib
     metpy


### PR DESCRIPTION
Necessary climakitae changes to revert to pangeo image tag 2021.10.19. I left environment.yml and requirements.txt as is. 

You'll also need to pip install xclim: ```pip install xclim==0.36.0```

**To test:**
Try running all the panels- app.select, app.expore.amy, app.explore.thresholds, app.explore.warming_levels and perhaps some of the timeseries stuff if you're so inclined. I believe @vicford is working on reverting some of the notebooks to work for this image. 