### PR TITLE
Geopandas spatial join warning update

### DIFF
--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -390,7 +390,7 @@ def _get_overlapping_stations(stations, polygon):
         stations gpd subsetted to include only points contained within polygon
 
     """
-    return gpd.sjoin(stations, polygon, op="within")
+    return gpd.sjoin(stations, polygon, predicate="within")
 
 
 def _get_subarea(


### PR DESCRIPTION
Quick fix as getting a warning about geopandas.sjoin "op" parameter has been replaced by "predicate", and will start barking at us eventually/soon (https://geopandas.org/en/stable/docs/reference/api/geopandas.sjoin.html)

**To test**: grab station data and make sure it returns data. This barked at me for the "Burbank-Glendale-Pasadena Airport" selection in the temperature_distributions notebook (cae-notebooks/dfu_pdfs branch), but not in app.select, but should be done if that's going to break selectors in the future