### PR TITLE
Retrieve LOCA2 data using new catalog link

### DIFF
--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -62,7 +62,7 @@ class Application(object):
 
     def __init__(self):
         self.catalog = intake.open_esm_datastore(
-            "https://cadcat.s3.amazonaws.com/cae-collection.json"
+            "https://cadcat.s3.amazonaws.com/tmp/cae-collection.json"
         )
         self.location = _LocSelectorArea(name="Location Selections")
         self.selections = _DataSelector(cat=self.catalog, location=self.location)

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -311,9 +311,6 @@ def _process_and_concat(selections, location, dsets, cat_subset):
                 # Get the name of the variable id
                 var_id = list(ds_sim.data_vars)[0]
 
-                # Rename simulation coordinate to include the downscaling method
-                ds_sim["simulation"] = "{0}_{1}".format(simulation, activity_id)
-
                 # Convert units
                 da_sim = ds_sim[var_id]
                 if var_id == "huss":
@@ -321,7 +318,12 @@ def _process_and_concat(selections, location, dsets, cat_subset):
                     # Reset to kg/kg so they can be converted if neccessary to g/kg
                     da_sim.attrs["units"] = "kg/kg"
                 da_sim = _convert_units(da=da_sim, selected_units=selections.units)
-                sim_list.append(da_sim)
+                for member_id in da_sim.member_id.values:
+                    da_sim_member_id = da_sim.sel(member_id=member_id).drop("member_id")
+                    da_sim_member_id["simulation"] = "{0}_{1}_{2}".format(
+                        activity_id, simulation, member_id
+                    )
+                    sim_list.append(da_sim_member_id)
 
         # Concatenate along simulation dimension
         da = xr.concat(

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -1436,6 +1436,11 @@ def _display_select(selections, location, map_view):
                 widgets["historical_selection"],
                 widgets["ssp_selection_text"],
                 widgets["ssp_selection"],
+                pn.Column(
+                    selections.view,
+                    widgets["time_slice"],
+                    width=220,
+                ),
                 width=250,
             ),
             pn.Column(


### PR DESCRIPTION
This PR modifies how the data is retrieved to account for the addition of the member_id (i.e. ensemble) dimension to the zarrs in the catalog. You'll notice the simulation coordinate now shows the downscaling method, simulation name, and ensemble. 

**Note:** I'll replace the catalog link in the code with a link to the permanent location after I communicate with Brian. 