### PR TITLE
Timeseries update

### DIFF
--- a/climakitae/timeseriestools.py
+++ b/climakitae/timeseriestools.py
@@ -25,17 +25,12 @@ class _TimeSeriesParams(param.Parameterized):
         self.data = dataset
 
         _time_resolution = dataset.attrs["frequency"]
-        if _time_resolution == "monthly":
-            self._time_scales = dict([("months", "MS"), ("years", "AS-SEP")])
-        elif _time_resolution == "daily":
-            self._time_scales = dict(
-                [("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
-            )
-        else:
-            self._time_scales = dict(
-                [("hours", "H"), ("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
-            )
-
+        _time_scales = dict([("months", "MS"), ("years", "AS-SEP")])
+        if (_time_resolution == "daily") or (_time_resolution == "hourly"):
+            _time_scales["days"] = "D"
+        if _time_resolution == "hourly":
+            _time_scales["hours"] = "H"
+        self._time_scales = _time_scales
         self.param["resample_period"].objects = self._time_scales
 
     anomaly = param.Boolean(default=True, label="Difference from a historical mean")

--- a/climakitae/timeseriestools.py
+++ b/climakitae/timeseriestools.py
@@ -14,24 +14,25 @@ class _TimeSeriesParams(param.Parameterized):
     draw the GUI, but another UI could in principle be used to update these
     parameters instead.
     """
+
     resample_period = param.Selector(default="AS-SEP", objects=dict())
     _time_scales = dict(
-            [("hours", "H"), ("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
-        )
-    
+        [("hours", "H"), ("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
+    )
+
     def __init__(self, dataset, **params):
         super().__init__(**params)
         self.data = dataset
-        
+
         _time_resolution = dataset.attrs["frequency"]
-        if _time_resolution == 'monthly':
+        if _time_resolution == "monthly":
             del self._time_scales["days"]
             del self._time_scales["hours"]
-        elif _time_resolution == 'daily':
-            del self._time_scales["hours"] 
-    
+        elif _time_resolution == "daily":
+            del self._time_scales["hours"]
+
         self.param["resample_period"].objects = self._time_scales
-        
+
     anomaly = param.Boolean(default=True, label="Difference from a historical mean")
     reference_range = param.CalendarDateRange(
         default=(dt.datetime(1981, 1, 1), dt.datetime(2010, 12, 31)),
@@ -43,10 +44,8 @@ class _TimeSeriesParams(param.Parameterized):
     separate_seasons = param.Boolean(
         default=False, label="Disaggregate into four seasons"
     )
-            
-    extremes = param.ListSelector(
-        default=[], objects=["Min", "Max", "Percentile"]
-    )
+
+    extremes = param.ListSelector(default=[], objects=["Min", "Max", "Percentile"])
     resample_window = param.Integer(default=1, bounds=(1, 30))
     percentile = param.Number(
         default=0,
@@ -134,19 +133,22 @@ class _TimeSeriesParams(param.Parameterized):
         def _extremes_da(y):
             plot_multiple = xr.Dataset()
             if "Max" in self.extremes:
-                plot_multiple["Max"] = to_plot.resample(
-                    time=str(self.resample_window) + self._time_scales[self.resample_period]
+                plot_multiple["max"] = to_plot.resample(
+                    time=str(self.resample_window)
+                    + self._time_scales[self.resample_period]
                 ).max("time")
             if "Min" in self.extremes:
-                plot_multiple["Min"] = to_plot.resample(
-                    time=str(self.resample_window) + self._time_scales[self.resample_period]
+                plot_multiple["min"] = to_plot.resample(
+                    time=str(self.resample_window)
+                    + self._time_scales[self.resample_period]
                 ).min("time")
             if "Percentile" in self.extremes:
-                plot_multiple[str(self.percentile)+" percentile"] = to_plot.resample(
-                    time=str(self.resample_window) + self._time_scales[self.resample_period]
+                plot_multiple[str(self.percentile) + " percentile"] = to_plot.resample(
+                    time=str(self.resample_window)
+                    + self._time_scales[self.resample_period]
                 ).quantile(q=self.percentile)
             return plot_multiple.to_array("extremes")
-                
+
         if self.extremes != []:
             return _extremes_da(to_plot)
         else:
@@ -189,7 +191,7 @@ class _TimeSeriesParams(param.Parameterized):
             "tsnrhtdd"[(n // 10 % 10 != 1) * (n % 10 < 4) * n % 10 :: 4],
         )
         percentrile_str = ordinal(percentile_int)
-        
+
         # Smoothing string user-friendly (used in title)
         if self.smoothing == "Running Mean":
             smoothing_str = "Smoothed "
@@ -242,7 +244,7 @@ class _TimeSeriesParams(param.Parameterized):
                     )
 
         elif self.extremes != []:
-            plot_by = ["simulation","extremes"]
+            plot_by = ["simulation", "extremes"]
             if self.smoothing == "None":
                 if self.extremes == "Percentile":  # Unsmoothed, percentile extremes
                     new_title = (

--- a/climakitae/timeseriestools.py
+++ b/climakitae/timeseriestools.py
@@ -15,7 +15,7 @@ class _TimeSeriesParams(param.Parameterized):
     parameters instead.
     """
 
-    resample_period = param.Selector(default="AS-SEP", objects=dict())
+    resample_period = param.Selector(default="years", objects=dict())
     _time_scales = dict(
         [("hours", "H"), ("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
     )

--- a/climakitae/timeseriestools.py
+++ b/climakitae/timeseriestools.py
@@ -26,11 +26,18 @@ class _TimeSeriesParams(param.Parameterized):
 
         _time_resolution = dataset.attrs["frequency"]
         if _time_resolution == "monthly":
-            del self._time_scales["days"]
-            del self._time_scales["hours"]
+            self._time_scales = dict(
+                [("months", "MS"), ("years", "AS-SEP")]
+            )
         elif _time_resolution == "daily":
-            del self._time_scales["hours"]
-
+            self._time_scales = dict(
+                [("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
+            )
+        else:
+            self._time_scales = dict(
+                [("hours", "H"), ("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
+            )
+                
         self.param["resample_period"].objects = self._time_scales
 
     anomaly = param.Boolean(default=True, label="Difference from a historical mean")

--- a/climakitae/timeseriestools.py
+++ b/climakitae/timeseriestools.py
@@ -26,9 +26,7 @@ class _TimeSeriesParams(param.Parameterized):
 
         _time_resolution = dataset.attrs["frequency"]
         if _time_resolution == "monthly":
-            self._time_scales = dict(
-                [("months", "MS"), ("years", "AS-SEP")]
-            )
+            self._time_scales = dict([("months", "MS"), ("years", "AS-SEP")])
         elif _time_resolution == "daily":
             self._time_scales = dict(
                 [("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
@@ -37,7 +35,7 @@ class _TimeSeriesParams(param.Parameterized):
             self._time_scales = dict(
                 [("hours", "H"), ("days", "D"), ("months", "MS"), ("years", "AS-SEP")]
             )
-                
+
         self.param["resample_period"].objects = self._time_scales
 
     anomaly = param.Boolean(default=True, label="Difference from a historical mean")

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -102,7 +102,7 @@ def test_extremes_smoothing(test_TSP):
     test_TSP.anomaly = False
     test_TSP.smoothing = "Running Mean"
     test_TSP.num_timesteps = 3
-    test_TSP.extremes = "Min"
+    test_TSP.extremes = ["Min"]
     test_TSP.resample_window = 2
 
     # Transform data and test
@@ -113,7 +113,7 @@ def test_extremes_smoothing(test_TSP):
 def test_extremes_min(test_TSP):
     # Specify Params options
     test_TSP.anomaly = False
-    test_TSP.extremes = "Min"
+    test_TSP.extremes = ["Min"]
     test_TSP.resample_window = 2
 
     # Transform data and test

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -124,7 +124,7 @@ def test_extremes_min(test_TSP):
 def test_extremes_percentile(test_TSP):
     # Specify Params options
     test_TSP.anomaly = False
-    test_TSP.extremes = "Percentile"
+    test_TSP.extremes = ["Percentile"]
     test_TSP.resample_window = 2
     test_TSP.percentile = 0.95
 


### PR DESCRIPTION
This PR addressed two outstanding loose ends in timeseriestools.py
https://trello.com/c/g35VOHPb
and
https://trello.com/c/LRwiznwG

- You can no longer select a resampling window smaller than the time resolution the data is starting with
- You can select min, max, and/or percentile all at once instead of only one at a time.
