### PR TITLE
Add in LOCA2 precip with correct units and unit conversions

### DIFF
--- a/climakitae/data/variable_descriptions.csv
+++ b/climakitae/data/variable_descriptions.csv
@@ -53,9 +53,9 @@ sfc_runoff,Dynamical,daily/monthly,mm/d,Surface runoff,"The rate at which water 
 subsfc_runoff,Dynamical,daily/monthly,mm/d,Subsurface runoff,"The rate at which  water that has infiltrated the ground surface travels underground until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE
 prec_max,Dynamical,daily/monthly,mm/h,Maximum precipitation,The maximum precipitation rate in a single hour. ,ae_blue,TRUE
 snow,Dynamical,daily/monthly,mm,Snow water equivalent,The amount of water that would be present if all snow melted. ,ae_blue,FALSE
-pr,Statistical,daily/monthly,mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,FALSE
-tasmax,Statistical,daily/monthly,K,Daily maximum air temperature at 2m,The maximum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
-tasmin,Statistical,daily/monthly,K,Daily minimum air temperature at 2m,The minimum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
-uas,Statistical,daily/monthly,m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE
-vas,Statistical,daily/monthly,m s-1,North-South component of Wind at 10m,"Wind coming from the north, measured at 10m above Earth's surface. By convention, wind coming from the south is negative.",ae_diverging,TRUE
-huss,Statistical,daily/monthly,kg/kg,Specific humidity at 2m,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
+pr,Statistical,daily,kg m-2 s-1,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE
+tasmax,Statistical,daily,K,Daily maximum air temperature at 2m,The maximum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
+tasmin,Statistical,daily,K,Daily minimum air temperature at 2m,The minimum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
+uas,Statistical,daily,m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE
+vas,Statistical,daily,m s-1,North-South component of Wind at 10m,"Wind coming from the north, measured at 10m above Earth's surface. By convention, wind coming from the south is negative.",ae_diverging,TRUE
+huss,Statistical,daily,kg/kg,Specific humidity at 2m,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -997,6 +997,9 @@ class _DataSelector(param.Parameterized):
             self.variable_options_df["display_name"] == self.variable
         ]
         native_unit = var_info.unit.item()
+        if native_unit in ["mm/d", "mm/h"]:
+            # Show same unit options for all mm
+            native_unit = "mm"
         if (
             native_unit in unit_options_dict.keys()
         ):  # See if there's unit conversion options for native variable

--- a/climakitae/unit_conversions.py
+++ b/climakitae/unit_conversions.py
@@ -17,7 +17,7 @@ def _get_unit_conversion_options():
         "kg/kg": ["kg/kg", "g/kg"],
         "g/kg": ["g/kg", "kg/kg"],
         "kg kg-1": ["kg kg-1", "g kg-1"],
-        "1 kg m-2 s-1": ["1 kg m-2 s-1", "mm", "inches"],
+        "kg m-2 s-1": ["kg m-2 s-1", "mm", "inches"],
         "g/kg": ["g/kg", "kg/kg"],
     }
     return options
@@ -51,11 +51,6 @@ def _convert_units(da, selected_units):
             )
         )
 
-    # Convert daily precip mm/d to mm
-    if native_units == "mm/d":
-        da.attrs["units"] = "mm"
-        native_units = "mm"
-
     # Convert hPa to Pa to make conversions easier
     # Monthly data native unit is hPa, hourly is Pa
     if native_units == "hPa" and selected_units != "hPa":
@@ -68,10 +63,12 @@ def _convert_units(da, selected_units):
         return da
 
     # Precipitation units
-    elif native_units == "mm":
+    elif native_units in ["mm", "mm/d", "mm/h"]:
         if selected_units == "inches":
             da = da / 25.4
-    elif native_units == "1 kg m-2 s-1":
+        elif selected_units == "kg m-2 s-1":
+            da = da / 86400
+    elif native_units == "kg m-2 s-1":
         if selected_units == "mm":
             da = da * 86400
         elif selected_units == "inches":
@@ -119,5 +116,6 @@ def _convert_units(da, selected_units):
         if selected_units == "fraction":
             da = da / 100.0
 
+    # Update unit attribute to reflect converted unit
     da.attrs["units"] = selected_units
     return da


### PR DESCRIPTION
ON HOLD FOR NOW: do not review.

This PR adds in the LOCA2 precipitation data with its correct units and unit conversion options. It also modifies how related unit conversions for other precip variables (which have units of mm) are coded in. 

**To test**: Try pulling the precip variables, for LOCA, WRF, and a combination of the two, with different units. Make sure the units and data all look as expected. **TIP**: When testing with the LOCA data, just retrieve and load a year or two of data for a small spatial region to avoid blowing out the memory.