### PR TITLE
Fix historical + SSP data retrieval bug

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -215,14 +215,14 @@ def _process_and_concat(selections, location, dsets, cat_subset):
 
     if True in ["SSP" in one for one in selections.scenario_ssp]:
         if "Historical Climate" in selections.scenario_historical:
-            # Historical climate will be appended to the SSP data
-            append_historical = True
+            if selections.time_slice[0] > 2015:
+                # Historical climate will be appended to the SSP data
+                append_historical = True
             scenario_list.remove("Historical Climate")
         if "Historical Reconstruction (ERA5-WRF)" in selections.scenario_historical:
             # We are not allowing users to select historical reconstruction data and SSP data at the same time,
             # due to the memory restrictions at the moment
             scenario_list.remove("Historical Reconstruction (ERA5-WRF)")
-
     for scenario in scenario_list:
         scen_name = _scenario_to_experiment_id(scenario)
         sim_list = []


### PR DESCRIPTION
This PR fixes a bug that was raised when the user tries to retrieve historical + SSP data for a time slice that is out of the bounds of the historical time range. For example, ```app.retrieve()``` would raise an error if you had selected "Historical Climate" and one of the SSPs, but only had selected a time range of 2090-2100 (which doesn't include any data in the historical climate range of 1980-2015). 

**To test**: Make sure you can retrieve the data when you have selected both "Historical Climate" and an SSP for a time slice that is completely in the future (i.e 2030-2035).