### PR TITLE
Fix data retrieval bug for derived hourly variables

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -582,7 +582,7 @@ def _read_catalog_from_select(selections, location, cat, loop=False):
                         "You've encountered a bug. No data available for selected derived variable."
                     )
 
-        selections.variable_id = orig_var_id_selection
+        selections.variable_id = [orig_var_id_selection]
         da.attrs["variable_id"] = orig_var_id_selection  # Reset variable ID attribute
         da.name = orig_variable_selection  # Set name of DataArray
 


### PR DESCRIPTION
When working on a different feature, I noticed a bug in the data retrieval of the derived variables. The data retrieval was not working for derived variables if you tried to call `app.retrieve` more than once, because the backend code was setting `selections.variable_id` to a string instead of a list. This fixes that! 

**To test**: Try retrieving a derived variable, which could be one of the following: 
1) Hourly relative humidity
2) Hourly, daily, or monthly dew point temperature 
3) Hourly specific humidity 
4) Hourly wind speed