### PR TITLE
Fix mistake from previous PR

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -215,7 +215,7 @@ def _process_and_concat(selections, location, dsets, cat_subset):
 
     if True in ["SSP" in one for one in selections.scenario_ssp]:
         if "Historical Climate" in selections.scenario_historical:
-            if selections.time_slice[0] > 2015:
+            if selections.time_slice[0] <= 2015:
                 # Historical climate will be appended to the SSP data
                 append_historical = True
             scenario_list.remove("Historical Climate")


### PR DESCRIPTION
I made a mistake when trying to fix a bug in [a PR I pushed yesterday](https://github.com/cal-adapt/climakitae/pull/204), and didn't actually solve the bug. Oops. This PR actually fixes the bug. I think we all missed it because it's kind of a tricky bug to find.

**To test:** Make sure you can retrieve the data when you have selected both "Historical Climate" and an SSP for a time slice that is completely in the future (i.e 2030-2035).