### PR TITLE
Fix wildcard matching for zarr retrieval

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -237,7 +237,7 @@ def _process_and_concat(selections, location, dsets, cat_subset):
                     try:
                         historical_filename = fnmatch.filter(
                             list(dsets.keys()),
-                            "*{0}*{1}*historical*".format(activity_id, simulation),
+                            "*{0}.*{1}.*historical*".format(activity_id, simulation),
                         )[0]
                         if (  # Need to get CESM2 data if ensmean is selected for ssp2-4.5 or ssp5-8.5
                             simulation == "ensmean"
@@ -250,14 +250,14 @@ def _process_and_concat(selections, location, dsets, cat_subset):
                         ):
                             ssp_filename = fnmatch.filter(
                                 list(dsets.keys()),
-                                "*{0}*CESM2*{1}*".format(
+                                "*{0}.*CESM2.*{1}*".format(
                                     activity_id, _scenario_to_experiment_id(scenario)
                                 ),
                             )[0]
                         else:
                             ssp_filename = fnmatch.filter(
                                 list(dsets.keys()),
-                                "*{0}*{1}*{2}*".format(
+                                "*{0}.*{1}.*{2}*".format(
                                     activity_id,
                                     simulation,
                                     _scenario_to_experiment_id(scenario),
@@ -292,14 +292,14 @@ def _process_and_concat(selections, location, dsets, cat_subset):
                         ):
                             filename = fnmatch.filter(
                                 list(dsets.keys()),
-                                "*{0}*CESM2*{1}*".format(
+                                "*{0}.*CESM2.*{1}*".format(
                                     activity_id, _scenario_to_experiment_id(scenario)
                                 ),
                             )[0]
                         else:
                             filename = fnmatch.filter(
                                 list(dsets.keys()),
-                                "*{0}*{1}*{2}*".format(
+                                "*{0}.*{1}.*{2}*".format(
                                     activity_id,
                                     simulation,
                                     _scenario_to_experiment_id(scenario),


### PR DESCRIPTION
This PR fixes a bug in the file retrieval that uses wildcard matching to deduce the filename for a given simulation and scenario. Previously, it incorrectly would pull "EC-Earth3-Veg" data instead of "EC-Earth3" data, because the substring "EC-Earth3" is in both simulation names. In the code, I added a "." to indicate the the wildcard shouldn't continue after the simulation (maybe that makes no sense...)

**To test**: Not sure how to test this, since no error was ever raised. Just look over the code. 