### PR TITLE
Rewrite map_view to be an attribute of DataSelectors

### DIFF
--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -77,7 +77,7 @@ class Application(object):
             cat=self.catalog, location=self.location, var_config=self.var_config
         )
         self.map_view = _ViewLocationSelections(
-            location=self.location, selections=self.selections
+            selections=self.selections
         )
         self.user_export_format = _FileTypeSelector()
         self.explore = _AppExplore(

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -11,7 +11,6 @@ from .view import _visualize
 from .data_loaders import _read_catalog_from_select, _read_catalog_from_csv, _compute
 from .selectors import (
     _DataSelector,
-    _ViewLocationSelections,
     _display_select,
     _get_user_options,
     _user_export_select,
@@ -41,8 +40,6 @@ class Application(object):
     explore: _AppExplore
         Explore panel options
         explore.amy(), explore.thresholds(), explore.warming_levels()
-    map_view: _ViewLocationSelections
-        Visualization of the selected data on a map
     var_config: pd.DataFrame
         Variable descriptions, units, etc in table format
 
@@ -70,11 +67,8 @@ class Application(object):
             "https://cadcat.s3.amazonaws.com/tmp/cae-collection.json"
         )
         self.selections = _DataSelector(cat=self.catalog, var_config=self.var_config)
-        self.map_view = _ViewLocationSelections(selections=self.selections)
         self.user_export_format = _FileTypeSelector()
-        self.explore = _AppExplore(
-            self.selections, self.catalog, self.map_view, self.var_config
-        )
+        self.explore = _AppExplore(self.selections, self.catalog, self.var_config)
 
     # === Select =====================================
     def select(self):
@@ -101,7 +95,7 @@ class Application(object):
         )
         self.selections.simulation = simulation_options
         # Display panel
-        select_panel = _display_select(self.selections, self.map_view)
+        select_panel = _display_select(self.selections)
         return select_panel
 
     # === Read data into memory =====================================

--- a/climakitae/core.py
+++ b/climakitae/core.py
@@ -3,6 +3,8 @@ Holds the Application object, which provides access to easy data retrieval, visu
 """
 
 import intake
+import pkg_resources
+import pandas as pd
 from .data_export import _export_to_user
 from .explore import _AppExplore
 from .view import _visualize
@@ -44,6 +46,8 @@ class Application(object):
         explore.amy(), explore.thresholds(), explore.warming_levels()
     map_view: _ViewLocationSelections
         Visualization of the selected data on a map
+    var_config: pd.DataFrame
+        Variable descriptions, units, etc in table format
 
     Examples
     --------
@@ -61,17 +65,23 @@ class Application(object):
     """
 
     def __init__(self):
+        var_catalog_resource = pkg_resources.resource_filename(
+            "climakitae", "data/variable_descriptions.csv"
+        )
+        self.var_config = pd.read_csv(var_catalog_resource, index_col=None)
         self.catalog = intake.open_esm_datastore(
             "https://cadcat.s3.amazonaws.com/tmp/cae-collection.json"
         )
         self.location = _LocSelectorArea(name="Location Selections")
-        self.selections = _DataSelector(cat=self.catalog, location=self.location)
+        self.selections = _DataSelector(
+            cat=self.catalog, location=self.location, var_config=self.var_config
+        )
         self.map_view = _ViewLocationSelections(
             location=self.location, selections=self.selections
         )
         self.user_export_format = _FileTypeSelector()
         self.explore = _AppExplore(
-            self.selections, self.location, self.catalog, self.map_view
+            self.selections, self.location, self.catalog, self.map_view, self.var_config
         )
 
     # === Select =====================================

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -75,14 +75,14 @@ def _compute(xr_da):
 # ============================ Helper functions ================================
 
 
-def _get_as_shapely(location):
+def _get_as_shapely(selections):
     """
-    Takes the location data in the 'location' parameter, and turns it into a
+    Takes the location data, and turns it into a
     shapely object. Just doing polygons for now. Later other point/station data
     will be available too.
 
     Args:
-        location (climakitae.selectors.LocSelectorArea): location selection
+        selections (_DataSelector): Data settings (variable, unit, timescale, etc)
 
     Returns:
         shapely_geom (shapely.geometry)
@@ -91,10 +91,10 @@ def _get_as_shapely(location):
     # Box is formed using the following shape:
     #   shapely.geometry.box(minx, miny, maxx, maxy)
     shapely_geom = box(
-        location.longitude[0],  # minx
-        location.latitude[0],  # miny
-        location.longitude[1],  # maxx
-        location.latitude[1],  # maxy
+        selections.longitude[0],  # minx
+        selections.latitude[0],  # miny
+        selections.longitude[1],  # maxx
+        selections.latitude[1],  # maxy
     )
     return shapely_geom
 
@@ -106,7 +106,7 @@ def _get_cat_subset(selections, cat):
     """For an input set of data selections, get the catalog subset.
 
     Args:
-        selections (DataLoaders): object holding user's selections
+        selections (_DataSelector): object holding user's selections
         cat (intake_esm.core.esm_datastore): catalog
 
     Returns:
@@ -153,11 +153,11 @@ def _get_cat_subset(selections, cat):
     return cat_subset
 
 
-def _get_area_subset(area_subset, cached_area, location):
+def _get_area_subset(area_subset, cached_area, selections):
     """Get geometry to perform area subsetting with.
 
     Args:
-        location (climakitae.selectors.LocSelectorArea): location selection
+        selections (_DataSelector): object holding user's selections
 
     Returns:
         ds_region (shapely.geometry): geometry to use for subsetting
@@ -168,7 +168,7 @@ def _get_area_subset(area_subset, cached_area, location):
         return boundary_dataset[boundary_dataset.index == shape_index].iloc[0].geometry
 
     if area_subset == "lat/lon":
-        geom = _get_as_shapely(location)
+        geom = _get_as_shapely(selections)
         if not geom.is_valid:
             raise ValueError(
                 "Please go back to 'select' and choose" + " a valid lat/lon range."
@@ -176,27 +176,27 @@ def _get_area_subset(area_subset, cached_area, location):
         ds_region = [geom]
     elif area_subset != "none":
         shape_index = int(
-            location._geography_choose[location.area_subset][location.cached_area]
+            selections._geography_choose[selections.area_subset][selections.cached_area]
         )
         if area_subset == "states":
-            shape = set_subarea(location._geographies._us_states)
+            shape = set_subarea(selections._geographies._us_states)
         elif area_subset == "CA counties":
-            shape = set_subarea(location._geographies._ca_counties)
+            shape = set_subarea(selections._geographies._ca_counties)
         elif area_subset == "CA watersheds":
-            shape = set_subarea(location._geographies._ca_watersheds)
+            shape = set_subarea(selections._geographies._ca_watersheds)
         elif area_subset == "CA Electric Load Serving Entities (IOU & POU)":
-            shape = set_subarea(location._geographies._ca_utilities)
+            shape = set_subarea(selections._geographies._ca_utilities)
         elif area_subset == "CA Electricity Demand Forecast Zones":
-            shape = set_subarea(location._geographies._ca_forecast_zones)
+            shape = set_subarea(selections._geographies._ca_forecast_zones)
         elif area_subset == "CA Electric Balancing Authority Areas":
-            shape = set_subarea(location._geographies._ca_electric_balancing_areas)
+            shape = set_subarea(selections._geographies._ca_electric_balancing_areas)
         ds_region = [shape]
     else:
         ds_region = None
     return ds_region
 
 
-def _process_and_concat(selections, location, dsets, cat_subset):
+def _process_and_concat(selections, dsets, cat_subset):
     """Process all data; merge all datasets into one.
 
     Args:
@@ -341,7 +341,7 @@ def _process_and_concat(selections, location, dsets, cat_subset):
 # ============ Read from catalog function used by ck.Application ===============
 
 
-def _get_data_one_var(selections, location, cat):
+def _get_data_one_var(selections, cat):
     """Get data for one variable"""
 
     with warnings.catch_warnings():
@@ -420,9 +420,9 @@ def _get_data_one_var(selections, location, cat):
             area_subset = "none"
             cached_area = "entire domain"
         else:
-            area_subset = location.area_subset
-            cached_area = location.cached_area
-        ds_region = _get_area_subset(area_subset, cached_area, location)
+            area_subset = selections.area_subset
+            cached_area = selections.cached_area
+        ds_region = _get_area_subset(area_subset, cached_area, selections)
         if ds_region is not None:  # Perform subsetting
             try:
                 dset = dset.rio.clip(geometries=ds_region, crs=4326, drop=True)
@@ -451,7 +451,7 @@ def _get_data_one_var(selections, location, cat):
 
     # Merge individual Datasets into one DataArray object.
     da = _process_and_concat(
-        selections=selections, location=location, dsets=data_dict, cat_subset=cat_subset
+        selections=selections, dsets=data_dict, cat_subset=cat_subset
     )
 
     # Assign data type attribute
@@ -464,7 +464,7 @@ def _get_data_one_var(selections, location, cat):
         "data_type": selections.data_type,
         "resolution": selections.resolution,
         "frequency": selections.timescale,
-        "location_subset": location.cached_area,
+        "location_subset": selections.cached_area,
         "institution": institution_id,
         "data_history": "Data has been accessed through the Cal-Adapt: Analytics Engine using the open-source climakitae python package.",
     }
@@ -475,15 +475,13 @@ def _get_data_one_var(selections, location, cat):
     return da
 
 
-def _read_catalog_from_select(selections, location, cat, loop=False):
+def _read_catalog_from_select(selections, cat, loop=False):
     """The primary and first data loading method, called by
     core.Application.retrieve, it returns a DataArray (which can be quite large)
-    containing everything requested by the user (which is stored in 'selections'
-    and 'location').
+    containing everything requested by the user (which is stored in 'selections').
 
     Args:
         selections (DataLoaders): object holding user's selections
-        location (LocSelectorArea): object holding user's location selections
         cat (intake_esm.core.esm_datastore): catalog
 
     Returns:
@@ -533,11 +531,11 @@ def _read_catalog_from_select(selections, location, cat, loop=False):
         if "wind_speed_derived" in orig_var_id_selection:
             # Load u10 data
             selections.variable_id = ["u10"]
-            u10_da = _get_data_one_var(selections, location, cat)
+            u10_da = _get_data_one_var(selections, cat)
 
             # Load v10 data
             selections.variable_id = ["v10"]
-            v10_da = _get_data_one_var(selections, location, cat)
+            v10_da = _get_data_one_var(selections, cat)
 
             # Derive wind magnitude
             da = _compute_wind_mag(u10=u10_da, v10=v10_da)
@@ -545,15 +543,15 @@ def _read_catalog_from_select(selections, location, cat, loop=False):
         else:
             # Load temperature data
             selections.variable_id = ["t2"]
-            t2_da = _get_data_one_var(selections, location, cat)
+            t2_da = _get_data_one_var(selections, cat)
 
             # Load mixing ratio data
             selections.variable_id = ["q2"]
-            q2_da = _get_data_one_var(selections, location, cat)
+            q2_da = _get_data_one_var(selections, cat)
 
             # Load pressure data
             selections.variable_id = ["psfc"]
-            pressure_da = _get_data_one_var(selections, location, cat)
+            pressure_da = _get_data_one_var(selections, cat)
 
             # Derive relative humidity
             rh_da = _compute_relative_humidity(
@@ -587,19 +585,15 @@ def _read_catalog_from_select(selections, location, cat, loop=False):
         da.name = orig_variable_selection  # Set name of DataArray
 
     else:
-        da = _get_data_one_var(selections, location, cat)
+        da = _get_data_one_var(selections, cat)
 
     if selections.data_type == "Station":
         if loop:
             # print("Retrieving station data using a for loop")
-            da = _station_loop(
-                location, selection, da, stations_df, original_time_slice
-            )
+            da = _station_loop(selection, da, stations_df, original_time_slice)
         else:
             # print("Retrieving station data using xr.apply")
-            da = _station_apply(
-                location, selections, da, stations_df, original_time_slice
-            )
+            da = _station_apply(selections, da, stations_df, original_time_slice)
         # Reset original selections
         if "Historical Climate" not in original_scenario_historical:
             selections.scenario_historical.remove("Historical Climate")
@@ -612,7 +606,7 @@ def _read_catalog_from_select(selections, location, cat, loop=False):
 # USE XR APPLY TO GET BIAS CORRECTED DATA TO STATION
 
 
-def _station_apply(location, selections, da, stations_df, original_time_slice):
+def _station_apply(selections, da, stations_df, original_time_slice):
     # Grab zarr data
     station_subset = stations_df.loc[stations_df["station"].isin(selections.station)]
     filepaths = [
@@ -724,7 +718,7 @@ def _preprocess_hadisd(ds):
 #### LOOP THROUGH EACH STATION INSTEAD
 
 
-def _station_loop(location, selection, da, stations_df, original_time_slice):
+def _station_loop(selection, da, stations_df, original_time_slice):
     """Get the closest gridcell, perform bias correction using a for loop"""
     stations_da_list = []
     for station in selections.station:
@@ -896,21 +890,17 @@ def _retrieve_and_format_closest_gridcell(stations_df, station_name, data):
 # ============ Retrieve data from a csv input ===============
 
 
-def _read_catalog_from_csv(selections, location, cat, csv, merge=True):
+def _read_catalog_from_csv(selections, cat, csv, merge=True):
     """Retrieve data from csv input.
 
     Allows user to bypass app.select GUI and allows developers to
     pre-set inputs in a csv file for ease of use in a notebook.
-    location: LocSelectorArea
-        Location settings
     selections: DataSelector
         Data settings (variable, unit, timescale, etc)
     Parameters
     ----------
     selections: DataLoaders
         Data settings (variable, unit, timescale, etc).
-    location: LocSelectorArea
-        Location settings.
     cat: intake_esm.core.esm_datastore
         AE data catalog.
     csv: str
@@ -955,11 +945,11 @@ def _read_catalog_from_csv(selections, location, cat, csv, merge=True):
         # Evaluate string time slice as tuple... i.e "(1980,2000)" --> (1980,2000)
         selections.time_slice = literal_eval(row.time_slice)
         selections.units = row.units
-        location.area_subset = row.area_subset
-        location.cached_area = row.cached_area
+        selections.area_subset = row.area_subset
+        selections.cached_area = row.cached_area
 
         # Retrieve data
-        xr_da = _read_catalog_from_select(selections, location, cat)
+        xr_da = _read_catalog_from_select(selections, cat)
         xr_list.append(xr_da)
 
     if len(xr_list) > 1:  # If there's more than one element in the list

--- a/climakitae/explore.py
+++ b/climakitae/explore.py
@@ -18,7 +18,7 @@ class _AppExplore(object):
     Only functional in a jupyter notebook environment.
     """
 
-    def __init__(self, selections, location, _cat, map_view):
+    def __init__(self, selections, location, _cat, map_view, var_config):
         """Constructor
 
         Parameters
@@ -31,12 +31,15 @@ class _AppExplore(object):
             AE data catalog
         map_view: _ViewLocationSelections
             Class for producing visualization of the selected data on a map
+        var_config: pd.DataFrame
+            Variable descriptions, units, etc in table format
 
         """
         self.selections = selections
         self.location = location
         self._cat = _cat
         self.map_view = map_view
+        self.var_config = var_config
 
     def __repr__(self):
         """Print a string description of the available analysis method for this class."""
@@ -51,7 +54,10 @@ class _AppExplore(object):
         """Display Average Meteorological Year panel."""
         global tmy_ob
         tmy_ob = _AverageMeteorologicalYear(
-            selections=self.selections, location=self.location, cat=self._cat
+            selections=self.selections,
+            location=self.location,
+            cat=self._cat,
+            var_config=self.var_config,
         )
         return _amy_visualize(
             tmy_ob=tmy_ob,
@@ -87,7 +93,10 @@ class _AppExplore(object):
     def warming_levels(self):
         """Display Warming Levels panel."""
         warming_data = _WarmingLevels(
-            selections=self.selections, location=self.location, cat=self._cat
+            selections=self.selections,
+            location=self.location,
+            cat=self._cat,
+            var_config=self.var_config,
         )
         return _display_warming_levels(
             warming_data, self.selections, self.location, map_view=self.map_view

--- a/climakitae/explore.py
+++ b/climakitae/explore.py
@@ -18,7 +18,7 @@ class _AppExplore(object):
     Only functional in a jupyter notebook environment.
     """
 
-    def __init__(self, selections, _cat, map_view, var_config):
+    def __init__(self, selections, _cat, var_config):
         """Constructor
 
         Parameters
@@ -27,15 +27,12 @@ class _AppExplore(object):
             Data settings (variable, unit, timescale, etc)
         _cat: intake_esm.core.esm_datastore
             AE data catalog
-        map_view: _ViewLocationSelections
-            Class for producing visualization of the selected data on a map
         var_config: pd.DataFrame
             Variable descriptions, units, etc in table format
 
         """
         self.selections = selections
         self._cat = _cat
-        self.map_view = map_view
         self.var_config = var_config
 
     def __repr__(self):
@@ -58,7 +55,6 @@ class _AppExplore(object):
         return _amy_visualize(
             tmy_ob=tmy_ob,
             selections=self.selections,
-            map_view=self.map_view,
         )
 
     def amy_selections(self):
@@ -80,7 +76,6 @@ class _AppExplore(object):
         return _thresholds_visualize(
             thresh_data=thresh_data,
             selections=self.selections,
-            map_view=self.map_view,
             option=option,
         )
 
@@ -92,5 +87,6 @@ class _AppExplore(object):
             var_config=self.var_config,
         )
         return _display_warming_levels(
-            warming_data, self.selections, map_view=self.map_view
+            warming_data,
+            self.selections,
         )

--- a/climakitae/explore.py
+++ b/climakitae/explore.py
@@ -18,15 +18,13 @@ class _AppExplore(object):
     Only functional in a jupyter notebook environment.
     """
 
-    def __init__(self, selections, location, _cat, map_view, var_config):
+    def __init__(self, selections, _cat, map_view, var_config):
         """Constructor
 
         Parameters
         ----------
         selections: _DataSelector
             Data settings (variable, unit, timescale, etc)
-        location: _LocSelectorArea
-            Location Settings
         _cat: intake_esm.core.esm_datastore
             AE data catalog
         map_view: _ViewLocationSelections
@@ -36,7 +34,6 @@ class _AppExplore(object):
 
         """
         self.selections = selections
-        self.location = location
         self._cat = _cat
         self.map_view = map_view
         self.var_config = var_config
@@ -55,14 +52,12 @@ class _AppExplore(object):
         global tmy_ob
         tmy_ob = _AverageMeteorologicalYear(
             selections=self.selections,
-            location=self.location,
             cat=self._cat,
             var_config=self.var_config,
         )
         return _amy_visualize(
             tmy_ob=tmy_ob,
             selections=self.selections,
-            location=self.location,
             map_view=self.map_view,
         )
 
@@ -85,7 +80,6 @@ class _AppExplore(object):
         return _thresholds_visualize(
             thresh_data=thresh_data,
             selections=self.selections,
-            location=self.location,
             map_view=self.map_view,
             option=option,
         )
@@ -94,10 +88,9 @@ class _AppExplore(object):
         """Display Warming Levels panel."""
         warming_data = _WarmingLevels(
             selections=self.selections,
-            location=self.location,
             cat=self._cat,
             var_config=self.var_config,
         )
         return _display_warming_levels(
-            warming_data, self.selections, self.location, map_view=self.map_view
+            warming_data, self.selections, map_view=self.map_view
         )

--- a/climakitae/meteo_yr.py
+++ b/climakitae/meteo_yr.py
@@ -73,7 +73,6 @@ def _set_amy_year_inputs(year_start, year_end):
 
 def _retrieve_meteo_yr_data(
     selections=None,
-    location=None,
     _cat=None,
     ssp=None,
     year_start=2015,
@@ -89,8 +88,6 @@ def _retrieve_meteo_yr_data(
     ----------
     selections: DataSelector
         Data settings (variable, unit, timescale, etc)
-    location: LocSelectorArea
-        Location settings
     _cat: intake_esm.core.esm_datastore
         AE data catalog
     ssp: str, one of "SSP 2-4.5 -- Middle of the Road", "SSP 2-4.5 -- Middle of the Road", "SSP 3-7.0 -- Business as Usual", "SSP 5-8.5 -- Burn it All"
@@ -136,9 +133,9 @@ def _retrieve_meteo_yr_data(
     selections.units = units
 
     # Grab data from the catalog
-    amy_data = _read_catalog_from_select(
-        selections=selections, location=location, cat=_cat
-    ).isel(scenario=0, simulation=0)
+    amy_data = _read_catalog_from_select(selections=selections, cat=_cat).isel(
+        scenario=0, simulation=0
+    )
     return amy_data
 
 
@@ -593,8 +590,8 @@ class _AverageMeteorologicalYear(param.Parameterized):
         super().__init__(*args, **params)
 
         # Location defaults
-        self.location.area_subset = "CA counties"
-        self.location.cached_area = "Los Angeles County"
+        self.selections.area_subset = "CA counties"
+        self.selections.cached_area = "Los Angeles County"
 
         # Initialze tmy_adanced_options param
         self.param["computation_method"].objects = self.tmy_advanced_options_dict[
@@ -612,7 +609,6 @@ class _AverageMeteorologicalYear(param.Parameterized):
         # Postage data and anomalies defaults
         self.historical_tmy_data = _retrieve_meteo_yr_data(
             selections=self.selections,
-            location=self.location,
             _cat=self.cat,
             year_start=1981,
             year_end=2010,
@@ -620,7 +616,6 @@ class _AverageMeteorologicalYear(param.Parameterized):
         self.future_tmy_data = _retrieve_meteo_yr_data(
             _cat=self.cat,
             selections=self.selections,
-            location=self.location,
             year_start=self.warming_year_average_range[self.warmlevel][0],
             year_end=self.warming_year_average_range[self.warmlevel][1],
         ).compute()
@@ -688,7 +683,6 @@ class _AverageMeteorologicalYear(param.Parameterized):
 
         self.historical_tmy_data = _retrieve_meteo_yr_data(
             selections=self.selections,
-            location=self.location,
             _cat=self.cat,
             year_start=1981,
             year_end=2010,
@@ -696,7 +690,6 @@ class _AverageMeteorologicalYear(param.Parameterized):
         self.future_tmy_data = _retrieve_meteo_yr_data(
             _cat=self.cat,
             selections=self.selections,
-            location=self.location,
             year_start=self.warming_year_average_range[self.warmlevel][0],
             year_end=self.warming_year_average_range[self.warmlevel][1],
         ).compute()
@@ -725,7 +718,7 @@ class _AverageMeteorologicalYear(param.Parameterized):
             if self.computation_method == "Historical":
                 df = compute_amy(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nAbsolute {} Baseline".format(
-                    self.location.cached_area, self.computation_method
+                    self.selections.cached_area, self.computation_method
                 )
                 clabel = (
                     self.selections.variable
@@ -736,7 +729,7 @@ class _AverageMeteorologicalYear(param.Parameterized):
             else:
                 df = compute_amy(self.future_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nAbsolute {} at {}°C".format(
-                    self.location.cached_area, self.computation_method, self.warmlevel
+                    self.selections.cached_area, self.computation_method, self.warmlevel
                 )
                 clabel = self.selections.variable + " (" + self.selections.units + ")"
         elif self.data_type == "Difference":
@@ -746,7 +739,7 @@ class _AverageMeteorologicalYear(param.Parameterized):
                     self.future_tmy_data, days_in_year=days_in_year
                 ) - compute_amy(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Average Meteorological Year: {}\nDifference between {} at {}°C and Historical Baseline".format(
-                    self.location.cached_area, self.computation_method, self.warmlevel
+                    self.selections.cached_area, self.computation_method, self.warmlevel
                 )
                 clabel = self.selections.variable + " (" + self.selections.units + ")"
             else:
@@ -754,11 +747,13 @@ class _AverageMeteorologicalYear(param.Parameterized):
                     self.future_tmy_data, days_in_year=days_in_year
                 ) - compute_amy(self.historical_tmy_data, days_in_year=days_in_year)
                 title = "Severe Meteorological Year: {}\nDifference between {} at 90th percentile and Historical Baseline".format(
-                    self.location.cached_area, self.computation_method
+                    self.selections.cached_area, self.computation_method
                 )
                 clabel = self.selections.variable + " (" + self.selections.units + ")"
         else:
-            title = "Average Meteorological Year\n{}".format(self.location.cached_area)
+            title = "Average Meteorological Year\n{}".format(
+                self.selections.cached_area
+            )
 
         heatmap = meteo_yr_heatmap(
             meteo_yr_df=df,
@@ -773,7 +768,7 @@ class _AverageMeteorologicalYear(param.Parameterized):
 # =========================== OBJECT VISUALIZATION USING PARAM ==============================
 
 
-def _amy_visualize(tmy_ob, selections, location, map_view):
+def _amy_visualize(tmy_ob, selections, map_view):
     """
     Creates a new AMY focus panel object to display user selections
     """
@@ -805,10 +800,10 @@ def _amy_visualize(tmy_ob, selections, location, map_view):
                 width=280,
             ),
             pn.Column(
-                location.param.area_subset,
-                location.param.latitude,
-                location.param.longitude,
-                location.param.cached_area,
+                selections.param.area_subset,
+                selections.param.latitude,
+                selections.param.longitude,
+                selections.param.cached_area,
                 map_view.view,
                 pn.widgets.Button.from_param(
                     tmy_ob.param.reload_data,

--- a/climakitae/meteo_yr.py
+++ b/climakitae/meteo_yr.py
@@ -768,7 +768,7 @@ class _AverageMeteorologicalYear(param.Parameterized):
 # =========================== OBJECT VISUALIZATION USING PARAM ==============================
 
 
-def _amy_visualize(tmy_ob, selections, map_view):
+def _amy_visualize(tmy_ob, selections):
     """
     Creates a new AMY focus panel object to display user selections
     """
@@ -804,7 +804,7 @@ def _amy_visualize(tmy_ob, selections, map_view):
                 selections.param.latitude,
                 selections.param.longitude,
                 selections.param.cached_area,
-                map_view.view,
+                selections.map_view,
                 pn.widgets.Button.from_param(
                     tmy_ob.param.reload_data,
                     button_type="primary",

--- a/climakitae/meteo_yr.py
+++ b/climakitae/meteo_yr.py
@@ -41,12 +41,6 @@ import logging  # Silence warnings
 logging.getLogger("param").setLevel(logging.CRITICAL)
 xr.set_options(keep_attrs=True)  # Keep attributes when mutating xr objects
 
-# Variable info
-var_catalog_resource = pkg_resources.resource_filename(
-    "climakitae", "data/variable_descriptions.csv"
-)
-var_catalog = pd.read_csv(var_catalog_resource, index_col="variable_id")
-
 
 # =========================== HELPER FUNCTIONS: DATA RETRIEVAL ==============================
 
@@ -654,9 +648,9 @@ class _AverageMeteorologicalYear(param.Parameterized):
     @param.depends("selections.variable", "data_type", watch=True)
     def _update_cmap(self):
         """Set colormap depending on variable"""
-        cmap_name = var_catalog[
-            (var_catalog["display_name"] == self.selections.variable)
-            & (var_catalog["timescale"] == "hourly")
+        cmap_name = self.var_config[
+            (self.var_config["display_name"] == self.selections.variable)
+            & (self.var_config["timescale"] == "hourly")
         ].colormap.values[0]
 
         # Set to diverging colormap if difference is selected

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -22,20 +22,6 @@ from .catalog_convert import (
     _scenario_to_experiment_id,
 )
 
-# Import package data
-var_catalog_resource = pkg_resources.resource_filename(
-    "climakitae", "data/variable_descriptions.csv"
-)
-var_catalog = pd.read_csv(var_catalog_resource, index_col=None)
-unit_options_dict = _get_unit_conversion_options()
-
-stations = pkg_resources.resource_filename("climakitae", "data/hadisd_stations.csv")
-stations_df = pd.read_csv(stations)
-stations_gpd = gpd.GeoDataFrame(
-    stations_df,
-    crs="EPSG:4326",
-    geometry=gpd.points_from_xy(stations_df.LON_X, stations_df.LAT_Y),
-)
 
 # =========================== LOCATION SELECTIONS ==============================
 
@@ -431,6 +417,14 @@ class _ViewLocationSelections(param.Parameterized):
 
     """
 
+    stations = pkg_resources.resource_filename("climakitae", "data/hadisd_stations.csv")
+    stations_df = pd.read_csv(stations)
+    stations_gpd = gpd.GeoDataFrame(
+        stations_df,
+        crs="EPSG:4326",
+        geometry=gpd.points_from_xy(stations_df.LON_X, stations_df.LAT_Y),
+    )
+
     _wrf_bb = {
         "45 km": Polygon(
             [
@@ -577,8 +571,8 @@ class _ViewLocationSelections(param.Parameterized):
         if self.selections.data_type == "Station":
             # Subset the stations gpd to get just the user's selected stations
             # We need the stations gpd because it has the coordinates, which will be used to make the plot
-            stations_selection_gpd = stations_gpd.loc[
-                stations_gpd["station"].isin(self.selections.station)
+            stations_selection_gpd = self.stations_gpd.loc[
+                self.stations_gpd["station"].isin(self.selections.station)
             ]
             stations_selection_gpd = stations_selection_gpd.to_crs(
                 crs_proj4
@@ -687,17 +681,17 @@ def _get_user_options(cat, downscaling_method, timescale, resolution):
 
 
 def _get_variable_options_df(
-    var_catalog, unique_variable_ids, downscaling_method, timescale
+    var_config, unique_variable_ids, downscaling_method, timescale
 ):
     """Get variable options to display depending on downscaling method and timescale
 
     Parameters
     ----------
-    var_catalog: pd.DataFrame
+    var_config: pd.DataFrame
         Variable descriptions, units, etc in table format
     unique_variable_ids: list of strs
         List of unique variable ids from catalog.
-        Used to subset var_catalog
+        Used to subset var_config
     downscaling_method: list, one of ["Dynamical"], ["Statistical"], or ["Dynamical","Statistical"]
         Data downscaling method
     timescale: str, one of "hourly", "daily", or "monthly"
@@ -706,21 +700,21 @@ def _get_variable_options_df(
     Returns
     -------
     pd.DataFrame
-        Subset of var_catalog for input downscaling_method and timescale
+        Subset of var_config for input downscaling_method and timescale
     """
     # Catalog options and derived options together
     derived_variables = list(
-        var_catalog[var_catalog["variable_id"].str.contains("_derived")]["variable_id"]
+        var_config[var_config["variable_id"].str.contains("_derived")]["variable_id"]
     )
     var_options_plus_derived = unique_variable_ids + derived_variables
 
     # Subset dataframe
-    variable_options_df = var_catalog[
-        (var_catalog["show"] == True)
+    variable_options_df = var_config[
+        (var_config["show"] == True)
         & (  # Make sure it's a valid variable selection
-            var_catalog["variable_id"].isin(var_options_plus_derived)
+            var_config["variable_id"].isin(var_options_plus_derived)
             & (  # Make sure variable_id is part of the catalog options for user selections
-                var_catalog["timescale"].str.contains(timescale)
+                var_config["timescale"].str.contains(timescale)
             )  # Make sure its the right timescale
         )
     ]
@@ -738,18 +732,18 @@ def _get_variable_options_df(
     return variable_options_df
 
 
-def _get_var_ids(var_catalog, variable, downscaling_method, timescale):
+def _get_var_ids(var_config, variable, downscaling_method, timescale):
     """Get variable ids that match the selected variable, timescale, and downscaling method.
     Required to account for the fact that LOCA, WRF, and various timescales use different variable id values.
     Used to retrieve the correct variables from the catalog in the backend.
     """
-    var_id = var_catalog[
-        (var_catalog["display_name"] == variable)
+    var_id = var_config[
+        (var_config["display_name"] == variable)
         & (  # Make sure it's a valid variable selection
-            var_catalog["timescale"].str.contains(timescale)
+            var_config["timescale"].str.contains(timescale)
         )  # Make sure its the right timescale
         & (
-            var_catalog["downscaling_method"].isin(downscaling_method)
+            var_config["downscaling_method"].isin(downscaling_method)
         )  # Make sure it's the right downscaling method
     ]
     var_id = list(var_id.variable_id.values)
@@ -763,6 +757,9 @@ class _DataSelector(param.Parameterized):
     gui, but another UI could in principle be used to update these parameters
     instead.
     """
+
+    # Unit conversion options for each unit
+    unit_options_dict = _get_unit_conversion_options()
 
     # Defaults
     default_variable = "Air Temperature at 2m"
@@ -821,7 +818,7 @@ class _DataSelector(param.Parameterized):
             resolution=self.resolution,
         )
         self.variable_options_df = _get_variable_options_df(
-            var_catalog=var_catalog,
+            var_config=self.var_config,
             unique_variable_ids=unique_variable_ids,
             downscaling_method=self.downscaling_method,
             timescale=self.timescale,
@@ -858,7 +855,7 @@ class _DataSelector(param.Parameterized):
         self.units = var_info.unit.item()
         self.extended_description = var_info.extended_description.item()
         self.variable_id = _get_var_ids(
-            var_catalog, self.variable, self.downscaling_method, self.timescale
+            self.var_config, self.variable, self.downscaling_method, self.timescale
         )
         self._data_warning = ""
 
@@ -948,7 +945,7 @@ class _DataSelector(param.Parameterized):
                 resolution=self.resolution,
             )
             self.variable_options_df = _get_variable_options_df(
-                var_catalog=var_catalog,
+                var_config=self.var_config,
                 unique_variable_ids=unique_variable_ids,
                 downscaling_method=downscaling_method,
                 timescale=self.timescale,
@@ -963,7 +960,7 @@ class _DataSelector(param.Parameterized):
         ]  # Get info for just that variable
         self.extended_description = var_info.extended_description.item()
         self.variable_id = _get_var_ids(
-            var_catalog, self.variable, self.downscaling_method, self.timescale
+            self.var_config, self.variable, self.downscaling_method, self.timescale
         )
         self.colormap = var_info.colormap.item()
 
@@ -998,10 +995,10 @@ class _DataSelector(param.Parameterized):
         ]
         native_unit = var_info.unit.item()
         if (
-            native_unit in unit_options_dict.keys()
+            native_unit in self.unit_options_dict.keys()
         ):  # See if there's unit conversion options for native variable
-            self.param["units"].objects = unit_options_dict[native_unit]
-            if self.units not in unit_options_dict[native_unit]:
+            self.param["units"].objects = self.unit_options_dict[native_unit]
+            if self.units not in self.unit_options_dict[native_unit]:
                 self.units = native_unit
         else:  # Just use native units if no conversion options available
             self.param["units"].objects = [native_unit]
@@ -1281,7 +1278,7 @@ class _DataSelector(param.Parameterized):
         """Update the list of weather station options if the area subset changes"""
         if self.data_type == "Station":
             overlapping_stations = _get_overlapping_station_names(
-                stations_gpd,
+                self.stations_gpd,
                 self.location.area_subset,
                 self.location.cached_area,
                 self.location.latitude,

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -350,7 +350,7 @@ def _add_res_to_ax(
     )
 
 
-def _map_view(selections):
+def _map_view(selections, stations_gpd):
     """View the current location selections on a map
     Updates dynamically
 
@@ -358,6 +358,8 @@ def _map_view(selections):
     ----------
     selections: DataSelector
         User data selections
+    stations_gpd: gpd.DataFrame
+        DataFrame with station coordinates
 
     """
 
@@ -1276,7 +1278,7 @@ class _DataSelector(param.Parameterized):
     )
     def map_view(self):
         """Create a map of the location selections"""
-        return _map_view(selections=self)
+        return _map_view(selections=self, stations_gpd=self.stations_gpd)
 
 
 # ================ DISPLAY LOCATION/DATA SELECTIONS IN PANEL ===================

--- a/climakitae/threshold_panel.py
+++ b/climakitae/threshold_panel.py
@@ -16,13 +16,12 @@ from .threshold_tools import (
 # ============ Class and methods for the explore.thresholds() GUI ==============
 
 
-def _get_threshold_data(selections, location, cat):
+def _get_threshold_data(selections, cat):
     """
     This function pulls data from the catalog and reads it into memory
 
     Args:
         selections (DataLoaders): object holding user's selections
-        location (LocSelectorArea): location object containing boundary information
         cat (intake_esm.core.esm_datastore): catalog
 
     Returns:
@@ -30,7 +29,7 @@ def _get_threshold_data(selections, location, cat):
 
     """
     # Read data from catalog
-    data = _read_catalog_from_select(selections=selections, location=location, cat=cat)
+    data = _read_catalog_from_select(selections=selections, cat=cat)
     data = data.compute()  # Read into memory
     return data
 
@@ -83,13 +82,11 @@ class _ThresholdDataParams(param.Parameterized):
         self.selections.variable = "Air Temperature at 2m"
 
         # Location defaults
-        self.location.area_subset = "CA counties"
-        self.location.cached_area = "Los Angeles County"
+        self.selections.area_subset = "CA counties"
+        self.selections.cached_area = "Los Angeles County"
 
         # Get the underlying dataarray
-        self.da = _get_threshold_data(
-            selections=self.selections, location=self.location, cat=self.cat
-        )
+        self.da = _get_threshold_data(selections=self.selections, cat=self.cat)
 
         self.threshold_value = round(self.da.mean().values.item())
         self.param.threshold_value.label = f"Value (units: {self.selections.units})"
@@ -107,8 +104,8 @@ class _ThresholdDataParams(param.Parameterized):
     changed_units = param.Boolean(default=False)
 
     @param.depends(
-        "location.area_subset",
-        "location.cached_area",
+        "selections.area_subset",
+        "selections.cached_area",
         "selections.variable",
         watch=True,
     )
@@ -126,9 +123,7 @@ class _ThresholdDataParams(param.Parameterized):
         """If the button was clicked and the location, variable, or units were
         changed, reload the data from AWS"""
         if self.changed_loc_and_var:
-            self.da = _get_threshold_data(
-                selections=self.selections, location=self.location, cat=self.cat
-            )
+            self.da = _get_threshold_data(selections=self.selections, cat=self.cat)
             self.changed_loc_and_var = False
         if self.changed_units:
             self.da = _convert_units(da=self.da, selected_units=self.selections.units)
@@ -254,7 +249,7 @@ def _exceedance_visualize(choices, option=1):
     return exceedance_count_panel
 
 
-def _thresholds_visualize(thresh_data, selections, location, map_view, option=1):
+def _thresholds_visualize(thresh_data, selections, map_view, option=1):
     """
     Function for constructing and displaying the explore.thresholds() panel.
     """
@@ -279,10 +274,10 @@ def _thresholds_visualize(thresh_data, selections, location, map_view, option=1)
                 width=230,
             ),
             pn.Column(
-                location.param.area_subset,
-                location.param.latitude,
-                location.param.longitude,
-                location.param.cached_area,
+                selections.param.area_subset,
+                selections.param.latitude,
+                selections.param.longitude,
+                selections.param.cached_area,
                 width=230,
             ),
             pn.Column(map_view.view, width=180),

--- a/climakitae/threshold_panel.py
+++ b/climakitae/threshold_panel.py
@@ -249,7 +249,7 @@ def _exceedance_visualize(choices, option=1):
     return exceedance_count_panel
 
 
-def _thresholds_visualize(thresh_data, selections, map_view, option=1):
+def _thresholds_visualize(thresh_data, selections, option=1):
     """
     Function for constructing and displaying the explore.thresholds() panel.
     """
@@ -280,7 +280,7 @@ def _thresholds_visualize(thresh_data, selections, map_view, option=1):
                 selections.param.cached_area,
                 width=230,
             ),
-            pn.Column(map_view.view, width=180),
+            pn.Column(selections.map_view, width=180),
         ),
         title="Data Options",
         collapsible=False,

--- a/climakitae/uncertain_utils.py
+++ b/climakitae/uncertain_utils.py
@@ -137,7 +137,7 @@ def _clip_region(ds, area_subset, location):
         Input data
     area_subset: LocSelectorArea
         "counties"/"states" as options
-    location: LocSelectorArea
+    location: str
         county/state name
     all_touched: bool, optional
         Include all cells that intersect boundary, default is false
@@ -264,7 +264,7 @@ def _precip_flux_to_total(ds):
     return ds
 
 
-def _grab_ensemble_data_by_experiment_id(variable, cmip_names, location, experiment_id):
+def _grab_ensemble_data_by_experiment_id(variable, cmip_names, experiment_id):
     """Grab CMIP6 ensemble data
 
     Parameters
@@ -273,8 +273,6 @@ def _grab_ensemble_data_by_experiment_id(variable, cmip_names, location, experim
         Name of variable
     cmip_names: list of str
         Name of CMIP6 simulations
-    location: LocSelectorArea
-        Location for which to subset data
     experiment_id: scenario, one of "historical" or "ssp375"
 
     Returns
@@ -449,12 +447,8 @@ def get_ensemble_data(variable, location, cmip_names, warm_level=3.0):
 
     """
     # Get a list of datasets, each with one simulation (i.e. one dataset with several member_id values for CESM2, etc)
-    ssp_list = _grab_ensemble_data_by_experiment_id(
-        variable, cmip_names, location, "ssp370"
-    )
-    hist_list = _grab_ensemble_data_by_experiment_id(
-        variable, cmip_names, location, "historical"
-    )
+    ssp_list = _grab_ensemble_data_by_experiment_id(variable, cmip_names, "ssp370")
+    hist_list = _grab_ensemble_data_by_experiment_id(variable, cmip_names, "historical")
 
     # Reorder lists to match order of cmip_names
     hist_list_reordered = [
@@ -505,13 +499,13 @@ def get_ensemble_data(variable, location, cmip_names, warm_level=3.0):
     hist_ds = hist_ds.sel(time=slice("1981", "2010"))
 
     # Post-processing functions to perform on both datasets
-    def _postprocess(ds, location, variable):
+    def _postprocess(ds, selections, variable):
         """Subset the dataset by an input location, convert variables, perform area averaging"""
         # Perform area subsetting
         ds_region = _get_area_subset(
-            area_subset=location.area_subset,
-            cached_area=location.cached_area,
-            location=location,
+            selections.area_subset,
+            selections.cached_area,
+            selections,
         )
         ds = ds.rio.write_crs(4326)
         ds = ds.rio.clip(geometries=ds_region, crs=4326, drop=True)
@@ -525,8 +519,8 @@ def get_ensemble_data(variable, location, cmip_names, warm_level=3.0):
             ds = _area_wgt_average(ds)
         return ds
 
-    hist_ds = _postprocess(hist_ds, location, variable)
-    warm_ds = _postprocess(warm_ds, location, variable)
+    hist_ds = _postprocess(hist_ds, selections, variable)
+    warm_ds = _postprocess(warm_ds, selections, variable)
 
     return hist_ds, warm_ds
 

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -22,13 +22,12 @@ logging.getLogger("param").setLevel(logging.CRITICAL)
 xr.set_options(keep_attrs=True)  # Keep attributes when mutating xr objects
 
 
-def _get_postage_data(selections, location, cat):
+def _get_postage_data(selections, cat):
     """
     This function pulls data from the catalog and reads it into memory
 
     Args:
         selections (DataLoaders): object holding user's selections
-        location (LocSelectorArea): location object containing boundary information
         cat (intake_esm.core.esm_datastore): catalog
 
     Returns:
@@ -36,7 +35,7 @@ def _get_postage_data(selections, location, cat):
 
     """
     # Read data from catalog
-    data = _read_catalog_from_select(selections=selections, location=location, cat=cat)
+    data = _read_catalog_from_select(selections=selections, cat=cat)
     data = data.compute()  # Read into memory
     return data
 
@@ -229,13 +228,11 @@ class _WarmingLevels(param.Parameterized):
         self.selections.variable = "Air Temperature at 2m"
 
         # Location defaults
-        self.location.area_subset = "states"
-        self.location.cached_area = "CA"
+        self.selections.area_subset = "states"
+        self.selections.cached_area = "CA"
 
         # Postage data and anomalies defaults
-        self.postage_data = _get_postage_data(
-            selections=self.selections, location=self.location, cat=self.cat
-        )
+        self.postage_data = _get_postage_data(selections=self.selections, cat=self.cat)
         self._warm_all_anoms = get_anomaly_data(data=self.postage_data, warmlevel=1.5)
 
         self.cmap = _read_ae_colormap(cmap="ae_orange", cmap_hex=True)
@@ -265,8 +262,8 @@ class _WarmingLevels(param.Parameterized):
         self.cmap = _read_ae_colormap(cmap=cmap_name, cmap_hex=True)
 
     @param.depends(
-        "location.area_subset",
-        "location.cached_area",
+        "selections.area_subset",
+        "selections.cached_area",
         "selections.variable",
         "selections.units",
         watch=True,
@@ -281,7 +278,7 @@ class _WarmingLevels(param.Parameterized):
         reload the postage stamp data from AWS"""
         if self.changed_loc_and_var == True:
             self.postage_data = _get_postage_data(
-                selections=self.selections, location=self.location, cat=self.cat
+                selections=self.selections, cat=self.cat
             )
             self.changed_loc_and_var = False
         self._warm_all_anoms = get_anomaly_data(
@@ -612,7 +609,7 @@ class _WarmingLevels(param.Parameterized):
         return to_plot
 
 
-def _display_warming_levels(warming_data, selections, location, map_view):
+def _display_warming_levels(warming_data, selections, map_view):
     # Create panel doodad!
     data_options = pn.Card(
         pn.Row(
@@ -639,10 +636,10 @@ def _display_warming_levels(warming_data, selections, location, map_view):
                 width=230,
             ),
             pn.Column(
-                location.param.area_subset,
-                location.param.latitude,
-                location.param.longitude,
-                location.param.cached_area,
+                selections.param.area_subset,
+                selections.param.latitude,
+                selections.param.longitude,
+                selections.param.cached_area,
                 map_view.view,
                 width=230,
             ),

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -66,21 +66,17 @@ def get_anomaly_data(data, warmlevel=3.0, scenario="ssp370"):
         columns={"Unnamed: 0": "simulation", "Unnamed: 1": "run"}
     )
 
-    sim_and_runs_dict = {
-        "CESM2": "r11i1p1f1",
-        "CNRM-ESM2-1": "r1i1p1f2",
-        "FGOALS-g3": "r1i1p1f1",
-        "EC-Earth3-Veg": "r1i1p1f1",
-    }
     all_sims = xr.Dataset()
     all_sims.attrs = data.attrs
     central_year_l, year_start_l, year_end_l = [], [], []
     for simulation in data.simulation.values:
-        sim_str = simulation.split("_WRF")[0]
+        # The simulation coordinate includes more information than just the simulation
+        # Need to parse out the simulation and ensemble
+        downscaling_method, sim_str, ensemble = simulation.split("_")
         one_ts = data.sel(simulation=simulation).squeeze()
         gwl_times_subset = gwl_times[
             (gwl_times["simulation"] == sim_str)
-            & (gwl_times["run"] == sim_and_runs_dict[sim_str])
+            & (gwl_times["run"] == ensemble)
             & (gwl_times["scenario"] == scenario)
         ]
         centered_time_pd = gwl_times_subset[str(float(warmlevel))]
@@ -463,9 +459,9 @@ class _WarmingLevels(param.Parameterized):
         c370 = "#df0000"
         c585 = "#980002"
 
-        ipcc_data = hist_data.hvplot(
+        ipcc_data = self.hist_data.hvplot(
             y="Mean", color="k", label="Historical", width=width, height=height
-        ) * hist_data.hvplot.area(
+        ) * self.hist_data.hvplot.area(
             x="Year",
             y="5%",
             y2="95%",
@@ -479,30 +475,30 @@ class _WarmingLevels(param.Parameterized):
         if self.ssp == "All":
             ipcc_data = (
                 ipcc_data
-                * ssp119_data.hvplot(y="Mean", color=c119, label="SSP1-1.9")
-                * ssp126_data.hvplot(y="Mean", color=c126, label="SSP1-2.6")
-                * ssp245_data.hvplot(y="Mean", color=c245, label="SSP2-4.5")
-                * ssp370_data.hvplot(y="Mean", color=c370, label="SSP3-7.0")
-                * ssp585_data.hvplot(y="Mean", color=c585, label="SSP5-8.5")
+                * self.ssp119_data.hvplot(y="Mean", color=c119, label="SSP1-1.9")
+                * self.ssp126_data.hvplot(y="Mean", color=c126, label="SSP1-2.6")
+                * self.ssp245_data.hvplot(y="Mean", color=c245, label="SSP2-4.5")
+                * self.ssp370_data.hvplot(y="Mean", color=c370, label="SSP3-7.0")
+                * self.ssp585_data.hvplot(y="Mean", color=c585, label="SSP5-8.5")
             )
         elif self.ssp == "SSP 1-1.9 -- Very Low Emissions Scenario":
-            ipcc_data = ipcc_data * ssp119_data.hvplot(
+            ipcc_data = ipcc_data * self.ssp119_data.hvplot(
                 y="Mean", color=c119, label="SSP1-1.9"
             )
         elif self.ssp == "SSP 1-2.6 -- Low Emissions Scenario":
-            ipcc_data = ipcc_data * ssp126_data.hvplot(
+            ipcc_data = ipcc_data * self.ssp126_data.hvplot(
                 y="Mean", color=c126, label="SSP1-2.6"
             )
         elif self.ssp == "SSP 2-4.5 -- Middle of the Road":
-            ipcc_data = ipcc_data * ssp245_data.hvplot(
+            ipcc_data = ipcc_data * self.ssp245_data.hvplot(
                 y="Mean", color=c245, label="SSP2-4.5"
             )
         elif self.ssp == "SSP 3-7.0 -- Business as Usual":
-            ipcc_data = ipcc_data * ssp370_data.hvplot(
+            ipcc_data = ipcc_data * self.ssp370_data.hvplot(
                 y="Mean", color=c370, label="SSP3-7.0"
             )
         elif self.ssp == "SSP 5-8.5 -- Burn it All":
-            ipcc_data = ipcc_data * ssp585_data.hvplot(
+            ipcc_data = ipcc_data * self.ssp585_data.hvplot(
                 y="Mean", color=c585, label="SSP5-8.5"
             )
 
@@ -529,11 +525,11 @@ class _WarmingLevels(param.Parameterized):
 
             # Add interval line and shading around selected SSP
             ssp_dict = {
-                "SSP 1-1.9 -- Very Low Emissions Scenario": (ssp119_data, c119),
-                "SSP 1-2.6 -- Low Emissions Scenario": (ssp126_data, c126),
-                "SSP 2-4.5 -- Middle of the Road": (ssp245_data, c245),
-                "SSP 3-7.0 -- Business as Usual": (ssp370_data, c370),
-                "SSP 5-8.5 -- Burn it All": (ssp585_data, c585),
+                "SSP 1-1.9 -- Very Low Emissions Scenario": (self.ssp119_data, c119),
+                "SSP 1-2.6 -- Low Emissions Scenario": (self.ssp126_data, c126),
+                "SSP 2-4.5 -- Middle of the Road": (self.ssp245_data, c245),
+                "SSP 3-7.0 -- Business as Usual": (self.ssp370_data, c370),
+                "SSP 5-8.5 -- Burn it All": (self.ssp585_data, c585),
             }
 
             ssp_selected = ssp_dict[self.ssp][0]  # data selected

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -640,7 +640,7 @@ def _display_warming_levels(warming_data, selections, map_view):
                 selections.param.latitude,
                 selections.param.longitude,
                 selections.param.cached_area,
-                map_view.view,
+                selections.map_view,
                 width=230,
             ),
         ),

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -609,7 +609,7 @@ class _WarmingLevels(param.Parameterized):
         return to_plot
 
 
-def _display_warming_levels(warming_data, selections, map_view):
+def _display_warming_levels(warming_data, selections):
     # Create panel doodad!
     data_options = pn.Card(
         pn.Row(


### PR DESCRIPTION
This is a purely backend change, the user won't notice anything different. Now, map_view is an attribute of DataSelectors instead of Application. This cleans up the code quite a lot. 

**To test:** Just play around with climakitae (i.e. `app.select()`, `app.view()`, `app.explore`...) and make sure you don't find any weird bugs with the display of the map in the panel.