### PR TITLE
Formatting fixes to sync with Pangeo image: 2022.09.21

### DIFF
--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -390,12 +390,12 @@ def _map_view(selections, stations_gpd):
         ),
     }
 
-    fig0 = Figure(figsize=(3.2, 3.2))
+    fig0 = Figure(figsize=(2.25, 2.25))
     proj = ccrs.Orthographic(-118, 40)
     crs_proj4 = proj.proj4_init  # used below
     xy = ccrs.PlateCarree()
     ax = fig0.add_subplot(111, projection=proj)
-    mpl_pane = pn.pane.Matplotlib(fig0, dpi=144)
+    mpl_pane = pn.pane.Matplotlib(fig0, dpi=1000)
 
     # Get geometry of selected location
     subarea_gpd = _get_subarea(
@@ -1175,7 +1175,7 @@ class _DataSelector(param.Parameterized):
         historical_central_year = sum(historical_climate_range) / 2
         historical_x_width = historical_central_year - historical_climate_range[0]
 
-        fig0 = Figure(figsize=(3, 2))
+        fig0 = Figure(figsize=(2, 2))
         ax = fig0.add_subplot(111)
         ax.spines["right"].set_color("none")
         ax.spines["left"].set_color("none")
@@ -1187,7 +1187,7 @@ class _DataSelector(param.Parameterized):
         ax.tick_params(labelsize=11)
         ax.xaxis.set_major_locator(ticker.AutoLocator())
         ax.xaxis.set_minor_locator(ticker.AutoMinorLocator())
-        mpl_pane = pn.pane.Matplotlib(fig0, dpi=144)
+        mpl_pane = pn.pane.Matplotlib(fig0, dpi=1000)
 
         y_offset = 0.15
         if (self.scenario_ssp is not None) and (self.scenario_historical is not None):
@@ -1205,13 +1205,13 @@ class _DataSelector(param.Parameterized):
                         center = historical_central_year
                         x_width = historical_x_width
                         ax.annotate(
-                            "Reconstruction", xy=(1967, y_offset + 0.06), fontsize=12
+                            "Reconstruction", xy=(1967 - 6, y_offset + 0.06), fontsize=9
                         )
                     else:
                         center = 1986  # 1950-2022
                         x_width = 36
                         ax.annotate(
-                            "Reconstruction", xy=(1955, y_offset + 0.06), fontsize=12
+                            "Reconstruction", xy=(1955 - 6, y_offset + 0.06), fontsize=9
                         )
 
                 elif scen == "Historical Climate":
@@ -1220,8 +1220,8 @@ class _DataSelector(param.Parameterized):
                     x_width = historical_x_width
                     ax.annotate(
                         "Historical",
-                        xy=(historical_climate_range[0], y_offset + 0.06),
-                        fontsize=12,
+                        xy=(historical_climate_range[0] - 6, y_offset + 0.06),
+                        fontsize=9,
                     )
 
                 elif "SSP" in scen:
@@ -1244,11 +1244,11 @@ class _DataSelector(param.Parameterized):
                         )
                         ax.annotate(
                             "Historical",
-                            xy=(historical_climate_range[0], y_offset + 0.06),
-                            fontsize=12,
+                            xy=(historical_climate_range[0] - 6, y_offset + 0.06),
+                            fontsize=9,
                         )
 
-                    ax.annotate(scen[:10], xy=(2035, y_offset + 0.06), fontsize=12)
+                    ax.annotate(scen[:10], xy=(2035, y_offset + 0.06), fontsize=9)
 
                 ax.errorbar(
                     x=center, y=y_offset, xerr=x_width, linewidth=8, color=color


### PR DESCRIPTION
## Overview 
This PR is branched off an outstanding branch `mapview`. It provides the formatting changes required to work around poor formatting in the intermediary pangeo image from 2022.09.21. This image appears to function fine but the figure displays are buggy. The resolution is quite bad and the sizing doesn't make much sense (which is why I had to resize the images and change the fontsize). 

## To test
Run this climakitae branch in the Pangeo image tagged for 2022.09.21 (You will need to change the date in your local Makefile). DO NOT RUN IN THE HUB-- the hub image is set to 2021.10.09, and cannot be changed by anyone but Brian. 

## Answers to questions you may have about why the figures/resolution can't be improved further in this image
For those who may ask, modifying the dpi of the images does NOT have any effect on the figure resolutions. The version of panel in the 2022.09.21 is buggy. I have tried modifying the fig sizes and resolutions of the images, but what you see in this branch is the best I could do. For those who may ask, I can't change the scenario figure in the bottom left to be less tall-- doing so just "cuts" the image instead of reducing its height. 

## Examples
The resolution and figure issues are kind of hard to see in these screenshots, but I included them anyways. The issues with the figures should be obvious if you run this branch in the sep 2022 image, though. 
### 2022.09.21 image, from this branch (`pangeo-img-nicole`): 
![Sep 2022 image](https://user-images.githubusercontent.com/66140951/236020338-f74008e7-072f-4be0-8446-5df2ec32d10d.png)

### 2021.10.09 image, from branch `mapview`: 
![Oct 2021 image](https://user-images.githubusercontent.com/66140951/236020888-329ebc5e-2b61-42cb-927f-3e36045b71ba.png)
