### PR TITLE
Fix bugs in station data 

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -175,9 +175,7 @@ def _get_area_subset(area_subset, cached_area, selections):
             )
         ds_region = [geom]
     elif area_subset != "none":
-        shape_index = int(
-            selections._geography_choose[selections.area_subset][selections.cached_area]
-        )
+        shape_index = int(selections._geography_choose[area_subset][cached_area])
         if area_subset == "states":
             shape = set_subarea(selections._geographies._us_states)
         elif area_subset == "CA counties":
@@ -406,17 +404,9 @@ def _get_data_one_var(selections, cat):
 
         # Perform area subsetting
 
-        # Bay Area airport stations are tricky, requires some hacky coding
         # You need to retrieve the entire domain because the shapefiles will cut out the ocean grid cells
-        # But the bay area airports closest gridcells are the ocean!
-        # Ideally the shapefiles should be modified to include the bay area water regions
-        bay_stations = [
-            "Oakland Metro International Airport",
-            "San Francisco International Airport",
-        ]
-        if (selections.data_type == "Station") and any(
-            x in selections.station for x in bay_stations
-        ):
+        # But the some station's closest gridcells are the ocean!
+        if selections.data_type == "Station":
             area_subset = "none"
             cached_area = "entire domain"
         else:

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -54,7 +54,9 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
     """
 
     # Warn user about speed if passing a zarr to the function
-    if data.chunks is not None:
+    if data.chunks is None or str(data.chunks) == "Frozen({})":
+        pass
+    else:
         warnings.warn(
             "This function may be quite slow unless you call .compute() on your data before passing it to app.view()"
         )


### PR DESCRIPTION
This PR retrieves the entire spatial domain of the model data when station data is retrieved, then finds the closest gridcell using the entire dataset. Previously, the model data could have been subsetted depending on if the user had selected a certain area subset in ```app.select``` before picking the station. Hopefully this solves the issue of the station data sometimes returning nans. My suspicion is that that was occurring because sometimes the closest gridcell was one that had been "NaN"ed by the area subsetting. 

This PR also fixes the erroneous "please read your data" warning in ```app.view``` for station data, since the rechunking in the bias correction sets the dask chunks to an empty dask "Frozen" object instead of "None".

**To test:** Retrieve some station data using the area subsetting (i.e. select a spatial region to reduce the station options first). Then retrieve a weather station or two's worth of data. Then call ```app.load(data)``` before ```app.view(data)``` and make sure no warning is raised telling you to read the data into memory. 