### PR TITLE
Fix bug in display of lat/lon selections

### DIFF
--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -416,6 +416,7 @@ def _map_view(selections, stations_gpd):
     ]  # Western USA + a lil bit of baja (viva mexico)
     na_extent = [-150, -88, 8, 66]  # North America extent (largest extent)
     if selections.area_subset == "lat/lon":
+        extent = na_extent  # default
         # Dynamically update extent depending on borders of lat/lon selection
         for extent_i in [ca_extent, us_extent, na_extent]:
             # Construct a polygon from the extent
@@ -432,7 +433,7 @@ def _map_view(selections, stations_gpd):
         extent = ca_extent
     elif (selections.resolution == "9 km") or (selections.area_subset == "states"):
         extent = us_extent
-    elif selections.area_subset in ["none", "lat/lon"]:
+    elif selections.area_subset == "none":
         extent = na_extent
     else:  # Default for all other selections
         extent = ca_extent


### PR DESCRIPTION
Tianchi had noticed a bug in the map display of lat/lon selection. If you selected too large of a lat/lon region using the slider box thing, ```app.select()``` would throw an error. This PR just resolves that! 

See this comment for the error message (which you should *not* see in this branch!): https://github.com/cal-adapt/climakitae/pull/210#pullrequestreview-1415613228

**To test**: Open up ```app.select()``` in this branch. Try to use the sliders to adjust the lat/lon selection to a large region. Ensure no error is raised. 