### PR TITLE
Plotting small geometries: A fix

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -425,7 +425,7 @@ def _get_data_one_var(selections, cat):
                 # all_touched: If True, all pixels touched by geometries will be burned in.  If false, only pixel whose center is within the polygon or that are selected by Bresenham's line algorithm will be burned in.
                 # drop: If True, drop the data outside of the extent of the mask geoemtries. Otherwise, it will return the same raster with the data masked.
                 dset = dset.rio.clip(
-                    geometries=ds_region, crs=4326, drop=True, all_touched=True
+                    geometries=ds_region, crs=4326, drop=True, all_touched=False
                 )
             else:
                 # LOCA does not have x,y coordinates. rioxarray hates this

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -421,9 +421,13 @@ def _get_data_one_var(selections, cat):
             cached_area = selections.cached_area
         ds_region = _get_area_subset(area_subset, cached_area, selections)
         if ds_region is not None:  # Perform subsetting
-            try:
-                dset = dset.rio.clip(geometries=ds_region, crs=4326, drop=True)
-            except:
+            if selections.downscaling_method == ["Dynamical"]:
+                # all_touched: If True, all pixels touched by geometries will be burned in.  If false, only pixel whose center is within the polygon or that are selected by Bresenham's line algorithm will be burned in.
+                # drop: If True, drop the data outside of the extent of the mask geoemtries. Otherwise, it will return the same raster with the data masked.
+                dset = dset.rio.clip(
+                    geometries=ds_region, crs=4326, drop=True, all_touched=True
+                )
+            else:
                 # LOCA does not have x,y coordinates. rioxarray hates this
                 # rioxarray will raise this error: MissingSpatialDimensionError: x dimension not found. 'rio.set_spatial_dims()' or using 'rename()' to change the dimension name to 'x' can address this.
                 # Therefore I need to rename the lat, lon dimensions to x,y, and then reset them after clipping.

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -424,9 +424,18 @@ def _get_data_one_var(selections, cat):
             if selections.downscaling_method == ["Dynamical"]:
                 # all_touched: If True, all pixels touched by geometries will be burned in.  If false, only pixel whose center is within the polygon or that are selected by Bresenham's line algorithm will be burned in.
                 # drop: If True, drop the data outside of the extent of the mask geoemtries. Otherwise, it will return the same raster with the data masked.
-                dset = dset.rio.clip(
-                    geometries=ds_region, crs=4326, drop=True, all_touched=False
-                )
+                try:
+                    dset = dset.rio.clip(
+                        geometries=ds_region, crs=4326, drop=True, all_touched=False
+                    )
+                except:
+                    # Catch small geometry error
+                    # Unsure how to catch the unique exception that rioxarray raises: NoDataInBounds
+                    # This will unfortunately catch all unrelated exceptions-- hopefully there's not other cases where the code will trigger an exception, but I'm not sure
+                    print(
+                        "COULD NOT RETRIEVE DATA: For the provided data selections, there is not sufficient data to retrieve. Try selecting a larger spatial area, or a higher resolution. Returning None."
+                    )
+                    return None
             else:
                 # LOCA does not have x,y coordinates. rioxarray hates this
                 # rioxarray will raise this error: MissingSpatialDimensionError: x dimension not found. 'rio.set_spatial_dims()' or using 'rename()' to change the dimension name to 'x' can address this.

--- a/climakitae/meteo_yr.py
+++ b/climakitae/meteo_yr.py
@@ -133,10 +133,13 @@ def _retrieve_meteo_yr_data(
     selections.units = units
 
     # Grab data from the catalog
-    amy_data = _read_catalog_from_select(selections=selections, cat=_cat).isel(
-        scenario=0, simulation=0
-    )
-    return amy_data
+    amy_data = _read_catalog_from_select(selections=selections, cat=_cat)
+    if amy_data is None:
+        # Catch small spatial resolutions
+        raise ValueError(
+            "COULD NOT RETRIEVE DATA: For the provided data selections, there is not sufficient data to retrieve. Try selecting a larger spatial area, or a higher resolution. Returning None."
+        )
+    return amy_data.isel(scenario=0, simulation=0)
 
 
 # =========================== HELPER FUNCTIONS: AMY/TMY CALCULATION ==============================

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -416,6 +416,7 @@ def _map_view(selections, stations_gpd):
     ]  # Western USA + a lil bit of baja (viva mexico)
     na_extent = [-150, -88, 8, 66]  # North America extent (largest extent)
     if selections.area_subset == "lat/lon":
+        extent = na_extent  # default
         # Dynamically update extent depending on borders of lat/lon selection
         for extent_i in [ca_extent, us_extent, na_extent]:
             # Construct a polygon from the extent
@@ -432,7 +433,7 @@ def _map_view(selections, stations_gpd):
         extent = ca_extent
     elif (selections.resolution == "9 km") or (selections.area_subset == "states"):
         extent = us_extent
-    elif selections.area_subset in ["none", "lat/lon"]:
+    elif selections.area_subset == "none":
         extent = na_extent
     else:  # Default for all other selections
         extent = ca_extent

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -118,7 +118,7 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
 
         # Create map
         try:
-            if len(data.x) > 1 and len(data.y) > 1:
+            if len(data[x]) > 1 and len(data[y]) > 1:
                 # If data has more than one grid cell, make a pretty map
                 _plot = data.hvplot.image(
                     x=x,
@@ -144,8 +144,8 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
                 )
         except:
             # Print message instead of raising error
-            print("Default map could not be generated for input data.")
-            return None
+            print("Unknown error: default map could not be generated for input data.")
+            _plot = None
 
     # Workflow if data contains only time dimension
     elif "time" in data.dims:
@@ -165,7 +165,8 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
 
     # Error raised if data does not contain [x,y] or time dimensions
     else:
-        raise ValueError(
-            "Input data must contain valid spatial dimensions (x,y and/or lat,lon) and/or time dimensions"
+        print(
+            "Default plot could not be generated: input data must contain valid spatial dimensions (x,y and/or lat,lon) and/or time dimensions"
         )
+        _plot = None
     return _plot

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -102,19 +102,20 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
         if height is None:
             height = 450
 
-        x = "lon"
-        y = "lat"
         if set(["x", "y"]).issubset(set(data.dims)):
+            x = "x"
+            y = "y"
             # Reproject data to lat/lon
             if lat_lon == True:
                 try:
                     data = _reproject_data(
                         xr_da=data, proj="EPSG:4326", fill_value=np.nan
                     )
-                    x = "x"
-                    y = "y"
                 except:  # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error)
                     pass
+        if set(["lat", "lon"]).issubset(set(data.dims)):
+            x = "lon"
+            y = "lat"
 
         # Create map
         try:
@@ -131,10 +132,13 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
                 )
             else:
                 # Make a scatter plot if it's just one grid cell
-                print("Warning: your input data has only one grid cell")
+                print(
+                    "Warning: your input data has 2 or less gridcells. Due to plotting limitations for small areas, a scatter plot will be generated."
+                )
                 _plot = data.hvplot.scatter(
                     x=x,
                     y=y,
+                    hover_cols=data.name,  # Add variable name as hover column
                     grid=True,
                     clabel=clabel,
                     cmap=cmap,

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -145,6 +145,7 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
         except:
             # Print message instead of raising error
             print("Default map could not be generated for input data.")
+            return None
 
     # Workflow if data contains only time dimension
     elif "time" in data.dims:

--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -79,75 +79,50 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
             except:  # If variable not found, set to ae_orange without raising error
                 cmap = "ae_orange"
 
-        # Must have more than one grid cell to generate a map
-        if (len(data["lon"]) <= 1) or (len(data["lat"]) <= 1):
-            print(
-                "Your data contains only one grid cell in height and/or width. A plot will be created using a default method that may or may not have spatial coordinates as the x and y axes."
-            )  # Warn user that plot may be weird
+        # Define colorbar label using variable and units
+        try:
+            clabel = data.name + " (" + data.attrs["units"] + ")"
+        except:  # Try except just in case units attribute is missing from data
+            clabel = data.name
 
-            # Set default cmap if no user input
-            # Different if using matplotlib (no "hex")
-            if cmap in [
-                "categorical_cb",
-                "ae_orange",
-                "ae_diverging",
-                "ae_blue",
-                "ae_diverging_r",
-            ]:
-                cmap = _read_ae_colormap(cmap=cmap, cmap_hex=False)
+        # Set default cmap if no user input
+        # Different if using hvplot (we need "hex")
+        if cmap in [
+            "categorical_cb",
+            "ae_orange",
+            "ae_diverging",
+            "ae_blue",
+            "ae_diverging_r",
+        ]:
+            cmap = _read_ae_colormap(cmap=cmap, cmap_hex=True)
 
-            with warnings.catch_warnings():
-                # Silence annoying matplotlib deprecation error
-                warnings.simplefilter("ignore")
+        # Set default width & height
+        if width is None:
+            width = 550
+        if height is None:
+            height = 450
 
-                # Use generic static xarray plot
+        x = "lon"
+        y = "lat"
+        if set(["x", "y"]).issubset(set(data.dims)):
+            # Reproject data to lat/lon
+            if lat_lon == True:
                 try:
-                    _matplotlib_plot = data.isel(time=0).plot(cmap=cmap)
-                except:
-                    _matplotlib_plot = data.isel(
-                        time=0
-                    ).plot()  # Make histogram for data the plotting function doesn't know how to handle
-                _plot = plt.gcf()  # Add plot to figure
-                plt.close()  # Close to prevent annoying matplotlib collections object line from showing in notebook
-        # If there's more than one grid cell, generate a pretty map
-        else:
-            # Define colorbar label using variable and units
-            try:
-                clabel = data.name + " (" + data.attrs["units"] + ")"
-            except:  # Try except just in case units attribute is missing from data
-                clabel = data.name
+                    data = _reproject_data(
+                        xr_da=data, proj="EPSG:4326", fill_value=np.nan
+                    )
+                    x = "x"
+                    y = "y"
+                except:  # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error)
+                    pass
 
-            # Set default cmap if no user input
-            # Different if using hvplot (we need "hex")
-            if cmap in [
-                "categorical_cb",
-                "ae_orange",
-                "ae_diverging",
-                "ae_blue",
-                "ae_diverging_r",
-            ]:
-                cmap = _read_ae_colormap(cmap=cmap, cmap_hex=True)
-
-            # Set default width & height
-            if width is None:
-                width = 550
-            if height is None:
-                height = 450
-
-            if set(["x", "y"]).issubset(set(data.dims)):
-                # Reproject data to lat/lon
-                if lat_lon == True:
-                    try:
-                        data = _reproject_data(
-                            xr_da=data, proj="EPSG:4326", fill_value=np.nan
-                        )
-                    except:  # Reprojection can fail if the data doesn't have a crs element. If that happens, just carry on without projection (i.e. don't raise an error)
-                        pass
-
-                # Create map
+        # Create map
+        try:
+            if len(data.x) > 1 and len(data.y) > 1:
+                # If data has more than one grid cell, make a pretty map
                 _plot = data.hvplot.image(
-                    x="x",
-                    y="y",
+                    x=x,
+                    y=y,
                     grid=True,
                     clabel=clabel,
                     cmap=cmap,
@@ -155,16 +130,21 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
                     height=height,
                 )
             else:
-                # Create map
-                _plot = data.hvplot.image(
-                    x="lon",
-                    y="lat",
+                # Make a scatter plot if it's just one grid cell
+                print("Warning: your input data has only one grid cell")
+                _plot = data.hvplot.scatter(
+                    x=x,
+                    y=y,
                     grid=True,
                     clabel=clabel,
                     cmap=cmap,
                     width=width,
                     height=height,
+                    s=150,  # Size of marker
                 )
+        except:
+            # Print message instead of raising error
+            print("Default map could not be generated for input data.")
 
     # Workflow if data contains only time dimension
     elif "time" in data.dims:

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -161,6 +161,7 @@ def _make_hvplot(data, clabel, clim, cmap, sopt, title, width=225, height=210):
         _plot = data.hvplot.scatter(
             x="x",
             y="y",
+            hover_cols=data.name,
             grid=True,
             width=width,
             height=height,

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -114,6 +114,12 @@ def get_anomaly_data(data, warmlevel=3.0, scenario="ssp370"):
     ] = "year that defines the end of the 30-year window around which the anomaly was computed"
     anomaly_da.attrs["warming_level"] = warmlevel
 
+    # If x and y are not dimensions, make them dimensions
+    # This might happen for data that is only one grid cell
+    for dim in ["x", "y"]:
+        if dim not in anomaly_da.dims:
+            anomaly_da = anomaly_da.expand_dims(dim)
+
     # Rename
     anomaly_da.name = data.name + " Anomalies"
     return anomaly_da
@@ -134,20 +140,39 @@ def _compute_vmin_vmax(da_min, da_max):
 
 def _make_hvplot(data, clabel, clim, cmap, sopt, title, width=225, height=210):
     """Make single map"""
-    _plot = data.hvplot.image(
-        x="x",
-        y="y",
-        grid=True,
-        width=width,
-        height=height,
-        xaxis=None,
-        yaxis=None,
-        clabel=clabel,
-        clim=clim,
-        cmap=cmap,
-        symmetric=sopt,
-        title=title,
-    )
+    if len(data.x) > 1 and len(data.y) > 1:
+        # If data has more than one grid cell, make a pretty map
+        _plot = data.hvplot.image(
+            x="x",
+            y="y",
+            grid=True,
+            width=width,
+            height=height,
+            xaxis=None,
+            yaxis=None,
+            clabel=clabel,
+            clim=clim,
+            cmap=cmap,
+            symmetric=sopt,
+            title=title,
+        )
+    else:
+        # Make a scatter plot if it's just one grid cell
+        _plot = data.hvplot.scatter(
+            x="x",
+            y="y",
+            grid=True,
+            width=width,
+            height=height,
+            xaxis=None,
+            yaxis=None,
+            clabel=clabel,
+            clim=clim,
+            cmap=cmap,
+            symmetric=sopt,
+            title=title,
+            s=150,  # Size of marker
+        )
     return _plot
 
 
@@ -636,9 +661,9 @@ def _display_warming_levels(warming_data, selections):
                 width=230,
             ),
             pn.Column(
-                selections.param.area_subset,
                 selections.param.latitude,
                 selections.param.longitude,
+                selections.param.area_subset,
                 selections.param.cached_area,
                 selections.map_view,
                 width=230,

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -36,7 +36,13 @@ def _get_postage_data(selections, cat):
     """
     # Read data from catalog
     data = _read_catalog_from_select(selections=selections, cat=cat)
-    data = data.compute()  # Read into memory
+    if data is not None:
+        data = data.compute()  # Read into memory
+    else:
+        # Catch small spatial resolutions
+        raise ValueError(
+            "COULD NOT RETRIEVE DATA: For the provided data selections, there is not sufficient data to retrieve. Try selecting a larger spatial area, or a higher resolution. Returning None."
+        )
     return data
 
 


### PR DESCRIPTION
This PR addresses the issue of plotting gridded data that's only one grid cell. Previously a bug had been raised by ```app.explore.warming_levels()```. Also, in ```app.view()```, data that was only one grid cell would output a weird lineplot with simulation or scenario on the axis. Now, data with only one grid cell is shown as a scatter plot. 

**To test**: Confirm that app.view() still works-- check a view geometries, station data, area average, etc. To make sure I didn't *introduce* any bugs with this bug fix. Confirm that ```app.explore.warming_levels()``` works for small geometries (i.e. a small county at 45km resolution)