### PR TITLE
Fix bug in 3km data retrieval for SSPs 585 and 245 

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -323,12 +323,19 @@ def _process_and_concat(selections, dsets, cat_subset):
                     )
                     sim_list.append(da_sim_member_id)
 
+        # Raise an appropriate error if no data found
+        if len(sim_list) == 0:
+            raise ValueError(
+                "You've encountered a bug in the source code. The data selections you've set do not correspond to a valid data option in the Analytics Engine catalog."
+            )
+
         # Concatenate along simulation dimension
-        da = xr.concat(
-            sim_list, dim="simulation", coords="minimal", compat="broadcast_equals"
-        )
-        da = da.assign_coords({"scenario": scen_name})
-        da_list.append(da)
+        else:
+            da = xr.concat(
+                sim_list, dim="simulation", coords="minimal", compat="broadcast_equals"
+            )
+            da = da.assign_coords({"scenario": scen_name})
+            da_list.append(da)
 
     da_final = xr.concat(
         da_list, dim="scenario", coords="minimal", compat="broadcast_equals"

--- a/climakitae/selectors.py
+++ b/climakitae/selectors.py
@@ -896,22 +896,25 @@ class _DataSelector(param.Parameterized):
         else:
             downscaling_method = self.downscaling_method
 
+        (
+            self.scenario_options,
+            self.simulation,
+            unique_variable_ids,
+        ) = _get_user_options(
+            cat=self.cat,
+            downscaling_method=downscaling_method,
+            timescale=self.timescale,
+            resolution=self.resolution,
+        )
+
         if self.data_type == "Station":
+            # If station is selected, the only valid option is air temperature
             temp = "Air Temperature at 2m"
             self.param["variable"].objects = [temp]
             self.variable = temp
 
         else:
-            (
-                self.scenario_options,
-                self.simulation,
-                unique_variable_ids,
-            ) = _get_user_options(
-                cat=self.cat,
-                downscaling_method=downscaling_method,
-                timescale=self.timescale,
-                resolution=self.resolution,
-            )
+            # Otherwise, get a list of variable options using the catalog search
             self.variable_options_df = _get_variable_options_df(
                 var_config=self.var_config,
                 unique_variable_ids=unique_variable_ids,
@@ -972,7 +975,7 @@ class _DataSelector(param.Parameterized):
             self.param["units"].objects = [native_unit]
             self.units = native_unit
 
-    @param.depends("resolution", "downscaling_method", watch=True)
+    @param.depends("resolution", "downscaling_method", "data_type", watch=True)
     def _update_scenarios(self):
         """
         Update scenario options. Raise data warning if a bad selection is made.


### PR DESCRIPTION
We don’t have gridded data at 3km for SSPs 585 and 245 but ```app.select()``` shows them as options for 3km station data, then promptly raises a nonsensical error when you attempt to retrieve the data. 

This PR does the following: 
1) Removes SSP 585 and 245 as options when 3km is selected
2) Modifies the ```data_loaders``` module to raise a descriptive error if no data is found. Hopefully this should never actually be raised, but is in place for us developers in case things fall through the cracks. 

**To test**: Ensure that when you select "station" and "3km", only Historical Climate and SSP 375 are shown as options in ```app.select()```