### PR TITLE
Fix unit conversions for derived variables

### DIFF
--- a/climakitae/data/variable_descriptions.csv
+++ b/climakitae/data/variable_descriptions.csv
@@ -3,7 +3,7 @@ t2,Dynamical,hourly,K,Air Temperature at 2m,Temperature of the air 2m above Eart
 prec,Dynamical,hourly,mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE
 rh_derived,Dynamical,hourly,[0 to 100],Relative Humidity,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
 wind_speed_derived,Dynamical,hourly,m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE
-dew_point_derived,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
+dew_point_derived_hrly,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 u10,Dynamical,hourly,m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE
 v10,Dynamical,hourly,m s-1,North-South component of Wind at 10m,"Wind coming from the north, measured at 10m above Earth's surface. By convention, wind coming from the south is negative.",ae_diverging,TRUE
 psfc,Dynamical,hourly,Pa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -594,6 +594,7 @@ def _read_catalog_from_select(selections, cat, loop=False):
                     )
 
         da = _convert_units(da, selected_units=orig_unit_selection)
+        da.attrs["units"] = orig_unit_selection
         da.attrs["variable_id"] = orig_var_id_selection  # Reset variable ID attribute
         da.name = orig_variable_selection  # Set name of DataArray
 

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -225,4 +225,5 @@ def _compute_wind_mag(u10, v10, name="wind_speed_derived"):
     """
     wind_mag = np.sqrt(np.square(u10) + np.square(v10))
     wind_mag.name = "wind_speed_derived"
+    wind_mag.units = "m s-1"
     return wind_mag

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -225,5 +225,5 @@ def _compute_wind_mag(u10, v10, name="wind_speed_derived"):
     """
     wind_mag = np.sqrt(np.square(u10) + np.square(v10))
     wind_mag.name = "wind_speed_derived"
-    wind_mag.units = "m s-1"
+    wind_mag.attrs["units"] = "m s-1"
     return wind_mag


### PR DESCRIPTION
The derived variable retrieval only worked if you selected the default variable. For example, you could grab dew point in Kelvin, but not degF or degC. This PR fixes that issue.