### PR TITLE
app.view() should have a fixed colorbar across simulations

### DIFF
--- a/climakitae/view.py
+++ b/climakitae/view.py
@@ -16,6 +16,19 @@ var_catalog_resource = pkg_resources.resource_filename(
 var_catalog = pd.read_csv(var_catalog_resource, index_col=None)
 
 
+def _compute_vmin_vmax(da_min, da_max):
+    """Compute min, max, and center for plotting"""
+    vmin = np.nanpercentile(da_min, 1)
+    vmax = np.nanpercentile(da_max, 99)
+    # define center for diverging symmetric data
+    if (vmin < 0) and (vmax > 0):
+        # dabs = abs(vmax) - abs(vmin)
+        sopt = True
+    else:
+        sopt = None
+    return vmin, vmax, sopt
+
+
 def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
     """Create a generic visualization of the data
 
@@ -65,6 +78,19 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
     if set(["x", "y"]).issubset(set(data.dims)) or set(["lon", "lat"]).issubset(
         set(data.dims)
     ):
+        # If simulation is a dimension, make it so the colorbar plots the min and max across the simulations
+        # Such that the colorbar is standardized
+        vmin = None
+        vmax = None
+        sopt = None
+        if "simulation" in data.dims:
+            # But, only do this if the data is already read into memory
+            # Or else the computation of min and max will take forever
+            if data.chunks is None or str(data.chunks) == "Frozen({})":
+                min_data = data.min(dim="simulation")
+                max_data = data.max(dim="simulation")
+                vmin, vmax, sopt = _compute_vmin_vmax(min_data, max_data)
+
         # Set default cmap if no user input
         if cmap is None:
             try:
@@ -153,6 +179,8 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
                     cmap=cmap,
                     width=width,
                     height=height,
+                    clim=(vmin, vmax),
+                    sopt=sopt,
                 )
             else:
                 # Create map
@@ -164,6 +192,8 @@ def _visualize(data, lat_lon=True, width=None, height=None, cmap=None):
                     cmap=cmap,
                     width=width,
                     height=height,
+                    clim=(vmin, vmax),
+                    sopt=sopt,
                 )
 
     # Workflow if data contains only time dimension

--- a/climakitae/warming_levels.py
+++ b/climakitae/warming_levels.py
@@ -13,6 +13,7 @@ import pkg_resources
 from .utils import _read_ae_colormap
 from .data_loaders import _read_catalog_from_select
 from .catalog_convert import _scenario_to_experiment_id
+from .view import _compute_vmin_vmax
 
 
 # Silence warnings
@@ -117,19 +118,6 @@ def get_anomaly_data(data, warmlevel=3.0, scenario="ssp370"):
     # Rename
     anomaly_da.name = data.name + " Anomalies"
     return anomaly_da
-
-
-def _compute_vmin_vmax(da_min, da_max):
-    """Compute min, max, and center for plotting"""
-    vmin = np.nanpercentile(da_min, 1)
-    vmax = np.nanpercentile(da_max, 99)
-    # define center for diverging symmetric data
-    if (vmin < 0) and (vmax > 0):
-        # dabs = abs(vmax) - abs(vmin)
-        sopt = True
-    else:
-        sopt = None
-    return vmin, vmax, sopt
 
 
 def _make_hvplot(data, clabel, clim, cmap, sopt, title, width=225, height=210):


### PR DESCRIPTION
This PR makes it so app.view() has a fixed colorbar limits across simulations, by computing the min and max (1 and 99th percentile) of the data across the simulation dimension, if the data contains that dimension. I reused the helper function ```_compute_vmin_vmax``` from the warming_levels module, and moved it into the view module, where I think it is more appropriately located. 

**To test**: Make some plots! Make sure the colorbar limits are fixed. Note-- this will only work if you've already loaded the data into memory before calling `app.view(data)`, because computing the min and max will take forever on a dask lazily loaded array. 