### PR TITLE
Add wind direction as derived variable

### DIFF
--- a/climakitae/data/variable_descriptions.csv
+++ b/climakitae/data/variable_descriptions.csv
@@ -3,7 +3,7 @@ t2,Dynamical,hourly,K,Air Temperature at 2m,Temperature of the air 2m above Eart
 prec,Dynamical,hourly,mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE
 rh_derived,Dynamical,hourly,[0 to 100],Relative Humidity,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
 wind_speed_derived,Dynamical,hourly,m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE
-wind_direction_derived_hrly,Dynamical,hourly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention, direction is defined as where wind originates from (i.e., North is 0/360 deg).,ae_orange,TRUE
+wind_direction_derived_hrly,Dynamical,hourly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention direction is defined as where wind originates from (i.e. North is 0/360 deg).,ae_orange,TRUE
 dew_point_derived,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 dew_point_derived_hrly,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 u10,Dynamical,hourly,m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE
@@ -33,7 +33,7 @@ rh,Dynamical,daily/monthly,[0 to 100],Relative Humidity,The percentage of water 
 dew_point_derived,Dynamical,daily/monthly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 wspd10mean,Dynamical,daily/monthly,m/s,Mean wind speed at 10m,The average wind speed (magnitude) at 10m above the Earth's surface. ,ae_orange,TRUE
 wspd10max,Dynamical,daily/monthly,m/s,Maximum wind speed at 10m,The maximum wind speed at 10m above the Earth's surface. ,ae_orange,TRUE
-wind_direction_derived,Dynamical,daily/monthly,degrees,Wind direction at 10m,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention, direction is defined as where wind originates from (i.e., North is 0/360 deg).,ae_orange,TRUE
+wind_direction_derived,Dynamical,daily/monthly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention direction is defined as where wind originates from (i.e. North is 0/360 deg).,ae_orange,TRUE
 psfc,Dynamical,daily/monthly,hPa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE
 q2,Dynamical,daily/monthly,g/kg,Specific humidity at 2m,"The ratio of the mass of water vapor over the mass of total (moist) air, measured 2m above Earth's surface.",ae_blue,TRUE
 tskin,Dynamical,daily/monthly,K,Surface skin temperature,Temperature of the Earth's surface (ground surface).,ae_orange,TRUE

--- a/climakitae/data/variable_descriptions.csv
+++ b/climakitae/data/variable_descriptions.csv
@@ -3,6 +3,7 @@ t2,Dynamical,hourly,K,Air Temperature at 2m,Temperature of the air 2m above Eart
 prec,Dynamical,hourly,mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE
 rh_derived,Dynamical,hourly,[0 to 100],Relative Humidity,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
 wind_speed_derived,Dynamical,hourly,m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE
+wind_direction_derived_hourly,Dynamical,hourly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention, direction is defined as where wind originates from (i.e., North is 0/360 deg).,ae_orange,TRUE
 dew_point_derived,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 u10,Dynamical,hourly,m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE
 v10,Dynamical,hourly,m s-1,North-South component of Wind at 10m,"Wind coming from the north, measured at 10m above Earth's surface. By convention, wind coming from the south is negative.",ae_diverging,TRUE
@@ -31,6 +32,7 @@ rh,Dynamical,daily/monthly,[0 to 100],Relative Humidity,The percentage of water 
 dew_point_derived,Dynamical,daily/monthly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 wspd10mean,Dynamical,daily/monthly,m/s,Mean wind speed at 10m,The average wind speed (magnitude) at 10m above the Earth's surface. ,ae_orange,TRUE
 wspd10max,Dynamical,daily/monthly,m/s,Maximum wind speed at 10m,The maximum wind speed at 10m above the Earth's surface. ,ae_orange,TRUE
+wind_direction_derived,Dynamical,daily/monthly,degrees,Wind direction at 10m,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention, direction is defined as where wind originates from (i.e., North is 0/360 deg).,ae_orange,TRUE
 psfc,Dynamical,daily/monthly,hPa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE
 q2,Dynamical,daily/monthly,g/kg,Specific humidity at 2m,"The ratio of the mass of water vapor over the mass of total (moist) air, measured 2m above Earth's surface.",ae_blue,TRUE
 tskin,Dynamical,daily/monthly,K,Surface skin temperature,Temperature of the Earth's surface (ground surface).,ae_orange,TRUE

--- a/climakitae/data/variable_descriptions.csv
+++ b/climakitae/data/variable_descriptions.csv
@@ -3,7 +3,7 @@ t2,Dynamical,hourly,K,Air Temperature at 2m,Temperature of the air 2m above Eart
 prec,Dynamical,hourly,mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE
 rh_derived,Dynamical,hourly,[0 to 100],Relative Humidity,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
 wind_speed_derived,Dynamical,hourly,m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE
-wind_direction_derived_hrly,Dynamical,hourly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention direction is defined as where wind originates from (i.e. North is 0/360 deg).,ae_orange,TRUE
+wind_direction_derived,Dynamical,hourly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention direction is defined as where wind originates from (i.e. North is 0/360 deg).,ae_orange,TRUE
 dew_point_derived,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 dew_point_derived_hrly,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 u10,Dynamical,hourly,m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE
@@ -33,7 +33,6 @@ rh,Dynamical,daily/monthly,[0 to 100],Relative Humidity,The percentage of water 
 dew_point_derived,Dynamical,daily/monthly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
 wspd10mean,Dynamical,daily/monthly,m/s,Mean wind speed at 10m,The average wind speed (magnitude) at 10m above the Earth's surface. ,ae_orange,TRUE
 wspd10max,Dynamical,daily/monthly,m/s,Maximum wind speed at 10m,The maximum wind speed at 10m above the Earth's surface. ,ae_orange,TRUE
-wind_direction_derived,Dynamical,daily/monthly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention direction is defined as where wind originates from (i.e. North is 0/360 deg).,ae_orange,TRUE
 psfc,Dynamical,daily/monthly,hPa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE
 q2,Dynamical,daily/monthly,g/kg,Specific humidity at 2m,"The ratio of the mass of water vapor over the mass of total (moist) air, measured 2m above Earth's surface.",ae_blue,TRUE
 tskin,Dynamical,daily/monthly,K,Surface skin temperature,Temperature of the Earth's surface (ground surface).,ae_orange,TRUE

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -26,6 +26,7 @@ from .utils import _readable_bytes, get_closest_gridcell
 from .derive_variables import (
     _compute_relative_humidity,
     _compute_wind_mag,
+    _compute_wind_dir,
     _compute_dewpointtemp,
     _compute_specific_humidity,
 )

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -543,6 +543,22 @@ def _read_catalog_from_select(selections, cat, loop=False):
             # Derive wind magnitude
             da = _compute_wind_mag(u10=u10_da, v10=v10_da)  # m/s  # m/s
 
+        elif orig_var_id_selection == "wind_direction_derived":
+            # Load u10 data
+            selections.variable_id = ["u10"]
+            selections.units = (
+                "m s-1"  # Need to set units to required units for _compute_wind_mag
+            )
+            u10_da = _get_data_one_var(selections, cat)
+
+            # Load v10 data
+            selections.variable_id = ["v10"]
+            selections.units = "m s-1"
+            v10_da = _get_data_one_var(selections, cat)
+
+            # Derive wind direction
+            da = xr.apply_ufunc(_compute_wind_dir, u10=u10_da, v10=v10_da)
+
         elif orig_var_id_selection == "dew_point_derived":
             # Daily/monthly dew point inputs have different units
             # Hourly dew point temp derived differently because you also have to derive relative humidity

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -557,7 +557,7 @@ def _read_catalog_from_select(selections, cat, loop=False):
             v10_da = _get_data_one_var(selections, cat)
 
             # Derive wind direction
-            da = xr.apply_ufunc(_compute_wind_dir, u10=u10_da, v10=v10_da)
+            da = _compute_wind_dir(u10=u10_da, v10=v10_da)
 
         elif orig_var_id_selection == "dew_point_derived":
             # Daily/monthly dew point inputs have different units

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -547,7 +547,7 @@ def _read_catalog_from_select(selections, cat, loop=False):
             # Load u10 data
             selections.variable_id = ["u10"]
             selections.units = (
-                "m s-1"  # Need to set units to required units for _compute_wind_mag
+                "m s-1"  # Need to set units to required units for _compute_wind_dir
             )
             u10_da = _get_data_one_var(selections, cat)
 

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -527,7 +527,7 @@ def _read_catalog_from_select(selections, cat, loop=False):
     orig_unit_selection = selections.units
     orig_variable_selection = selections.variable
     if "_derived" in orig_var_id_selection:
-        if orig_var_id_selection == "wind_speed_derived":
+        if orig_var_id_selection in ["wind_speed_derived", "wind_direction_derived"]:
             # Load u10 data
             selections.variable_id = ["u10"]
             selections.units = (
@@ -541,23 +541,11 @@ def _read_catalog_from_select(selections, cat, loop=False):
             v10_da = _get_data_one_var(selections, cat)
 
             # Derive wind magnitude
-            da = _compute_wind_mag(u10=u10_da, v10=v10_da)  # m/s  # m/s
-
-        elif orig_var_id_selection == "wind_direction_derived":
-            # Load u10 data
-            selections.variable_id = ["u10"]
-            selections.units = (
-                "m s-1"  # Need to set units to required units for _compute_wind_dir
-            )
-            u10_da = _get_data_one_var(selections, cat)
-
-            # Load v10 data
-            selections.variable_id = ["v10"]
-            selections.units = "m s-1"
-            v10_da = _get_data_one_var(selections, cat)
-
-            # Derive wind direction
-            da = _compute_wind_dir(u10=u10_da, v10=v10_da)
+            if orig_var_id_selection == "wind_speed_derived":
+                da = _compute_wind_mag(u10=u10_da, v10=v10_da)  # m/s  # m/s
+            # Or, derive wind speed
+            elif orig_var_id_selection == "wind_direction_derived":
+                da = _compute_wind_dir(u10=u10_da, v10=v10_da)
 
         elif orig_var_id_selection == "dew_point_derived":
             # Daily/monthly dew point inputs have different units

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -226,3 +226,25 @@ def _compute_wind_mag(u10, v10, name="wind_speed_derived"):
     wind_mag = np.sqrt(np.square(u10) + np.square(v10))
     wind_mag.name = "wind_speed_derived"
     return wind_mag
+
+
+def _compute_wind_dir(u10, v10, name="wind_direction_derived"):
+    """Compute wind direction at 10 meters
+
+    Args:
+        u10 (xr.DataArray): Zonal velocity at 10 meters height in m/s
+        v10 (xr.DataArray): Meridional velocity at 10 meters height in m/s
+        name (str, optional): Name to assign to output DataArray
+
+    Returns:
+        wind_dir (xr.DataArray): Wind direction, in [0, 360] degrees,
+            with 0/360 defined as north, by meteorological convention
+
+    Notes:
+    1. https://sites.google.com/view/raybellwaves/cheat-sheets/xarray
+    2. must be calculated as `xr.apply_ufunc(_compute_wind_dir, u10, v10)`
+    """
+
+    wind_dir = np.mod(90 - np.arctan2(-v10, -u10) * (180 / np.pi), 360)
+    return wind_dir
+

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -245,6 +245,5 @@ def _compute_wind_dir(u10, v10, name="wind_direction_derived"):
     # source:  https://sites.google.com/view/raybellwaves/cheat-sheets/xarray
     wind_dir = np.mod(90 - np.arctan2(-v10, -u10) * (180 / np.pi), 360)
     wind_dir.name = "wind_direction_derived"
-    wind_dir.attrs['units'] = "degrees"
+    wind_dir.attrs["units"] = "degrees"
     return wind_dir
-

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -246,5 +246,7 @@ def _compute_wind_dir(u10, v10, name="wind_direction_derived"):
     """
 
     wind_dir = np.mod(90 - np.arctan2(-v10, -u10) * (180 / np.pi), 360)
+    wind_dir.name = "wind_direction_derived"
+    wind_dir.attrs['units'] = "degrees"
     return wind_dir
 

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -241,11 +241,8 @@ def _compute_wind_dir(u10, v10, name="wind_direction_derived"):
         wind_dir (xr.DataArray): Wind direction, in [0, 360] degrees,
             with 0/360 defined as north, by meteorological convention
 
-    Notes:
-    1. https://sites.google.com/view/raybellwaves/cheat-sheets/xarray
-    2. must be calculated as `xr.apply_ufunc(_compute_wind_dir, u10, v10)`
     """
-
+    # source:  https://sites.google.com/view/raybellwaves/cheat-sheets/xarray
     wind_dir = np.mod(90 - np.arctan2(-v10, -u10) * (180 / np.pi), 360)
     wind_dir.name = "wind_direction_derived"
     wind_dir.attrs['units'] = "degrees"

--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -241,9 +241,11 @@ def _compute_wind_dir(u10, v10, name="wind_direction_derived"):
         wind_dir (xr.DataArray): Wind direction, in [0, 360] degrees,
             with 0/360 defined as north, by meteorological convention
 
+    Notes:
+        source:  https://sites.google.com/view/raybellwaves/cheat-sheets/xarray
     """
-    # source:  https://sites.google.com/view/raybellwaves/cheat-sheets/xarray
+
     wind_dir = np.mod(90 - np.arctan2(-v10, -u10) * (180 / np.pi), 360)
-    wind_dir.name = "wind_direction_derived"
+    wind_dir.name = name
     wind_dir.attrs["units"] = "degrees"
     return wind_dir

--- a/tests/derive_variables/test_derived_variables.py
+++ b/tests/derive_variables/test_derived_variables.py
@@ -39,7 +39,7 @@ def wind_dir(test_data_2022_monthly_45km):
     da = xr.apply_ufunc(
         _compute_wind_dir,
         u10=test_data_2022_monthly_45km["U10"],
-        v10=test_data_2022_monthly_45km["V10"]
+        v10=test_data_2022_monthly_45km["V10"],
     )
     return da
 

--- a/tests/derive_variables/test_derived_variables.py
+++ b/tests/derive_variables/test_derived_variables.py
@@ -7,6 +7,7 @@ import os
 from climakitae.derive_variables import (
     _compute_relative_humidity,
     _compute_wind_mag,
+    _compute_wind_dir,
     _compute_dewpointtemp,
     _compute_specific_humidity,
 )
@@ -28,6 +29,17 @@ def wind_mag(test_data_2022_monthly_45km):
     """Compute wind magnitude and return data"""
     da = _compute_wind_mag(
         u10=test_data_2022_monthly_45km["U10"], v10=test_data_2022_monthly_45km["V10"]
+    )
+    return da
+
+
+@pytest.fixture
+def wind_dir(test_data_2022_monthly_45km):
+    """Compute wind direction and return data"""
+    da = xr.apply_ufunc(
+        _compute_wind_dir,
+        u10=test_data_2022_monthly_45km["U10"],
+        v10=test_data_2022_monthly_45km["V10"]
     )
     return da
 


### PR DESCRIPTION
This PR adds wind direction as an hourly variable. 

**To test**
Try retrieving hourly wind direction! Noting, would recommend this for a coarse resolution and/or small location because of the data involved in computing. 

***Note:*** Wind direction is not normally displayed as such. I have a trello card up to add a AE-branded cyclic colormap that I'll get to next, as well as setting the colorbar limits to 0-360. **If** we decide to pursue wind velocity in the future (magnitude + direction), we can investigate barbs for wind direction as an option too. 