### PR TITLE
Quick fix to switch threshold assignment for CDH/HDH

### DIFF
--- a/climakitae/derive_variables.py
+++ b/climakitae/derive_variables.py
@@ -76,10 +76,10 @@ def compute_hdh_cdh(t2, hdh_threshold, cdh_threshold):
 
     # Calculate heating and cooling hours
     cooling_hours = t2.where(
-        t2 > hdh_threshold
+        t2 > cdh_threshold
     )  # temperatures above threshold, require cooling
-    heating_hours = (-1) * t2.where(
-        t2 < cdh_threshold
+    heating_hours = t2.where(
+        t2 < hdh_threshold
     )  # temperatures below threshold, require heating
 
     # Compute CDH: count number of hours and resample to daily (max 24 value)


### PR DESCRIPTION
Thresholds were assigned in reverse, and an unnecessary negative one multiplier was included. 

**To test**: just make sure that the HDH/CDH calculations in the INTRO_annual notebook runs