### PR TITLE
Remove numba from environment.yml so that conda env solvable.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - jinja2=3.1.2
   - matplotlib=3.6.0
   - metpy=1.3.1
-  - numba=0.53.1
   - numpy=1.23.3
   - pandas=1.5.0
   - panel=0.13.1


### PR DESCRIPTION
This PR removes numba requirement from `environment.yml` that was added in #190. I am not entirely sure why it is not needed anymore. Shrug. But the conda environment should hopefully be solvable now...