### PR TITLE
Add pygeos to environmental.yml and requirementss.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
   - shapely=1.8.4
   - xarray=2022.6.0
   - xmip=0.6.1rc0
+  - pygeos=0.13
   - pip
   - pip:
     - dask-gateway==2023.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ rioxarray==0.12.2
 s3fs==2022.8.2
 scipy==1.9.1
 shapely==1.8.4
+pygeos==0.13
 xclim==0.42.0


### PR DESCRIPTION
This addes `pygeos=0.13` to `environmental.yml` and `requirements.txt` to address the requirement of `dask-geopandas` encountered in test added to #238.