### PR TITLE
Revert adding pygeos to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     scipy
     shapely
     xarray
-    pygeos
     xclim
 tests_require =
     pytest


### PR DESCRIPTION
Revert adding `pygeos` to `setup.cfg` as it is not strictly required for `climakitae`