### PR TITLE
Update HadISD in backend retrieval code

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -809,7 +809,13 @@ def _get_bias_corrected_closest_gridcell(station_da, gridded_da, time_slice):
 
 
 def _bias_correct_model_data(
-    obs_da, gridded_da, time_slice, window=90, nquantiles=20, group="time.dayofyear", kind="+"
+    obs_da,
+    gridded_da,
+    time_slice,
+    window=90,
+    nquantiles=20,
+    group="time.dayofyear",
+    kind="+",
 ):
     """Bias correct model data using observational station data
     Converts units of the station data to whatever the input model data's units are
@@ -824,8 +830,9 @@ def _bias_correct_model_data(
 
     """
     # Get group by window
+    # Use 90 day window (+/- 45 days) to account for seasonality
     grouper = Grouper(group, window=window)
-    
+
     # Convert units to whatever the gridded data units are
     obs_da = _convert_units(obs_da, gridded_da.units)
     # Rechunk data. Cannot be chunked along time dimension

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -750,7 +750,7 @@ def _station_apply(selections, da, stations_df, original_time_slice):
     # Grab zarr data
     station_subset = stations_df.loc[stations_df["station"].isin(selections.station)]
     filepaths = [
-        "s3://cadcat/tmp/hadisd/HadISD_{}.zarr".format(s_id)
+        "s3://cadcat/hadisd/HadISD_{}.zarr".format(s_id)
         for s_id in station_subset["station id"]
     ]
 

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -853,7 +853,6 @@ def _bias_correct_model_data(
                 str(obs_da.time.values[0].year), str(obs_da.time.values[-1].year)
             )
         ),
-        window=window,
         nquantiles=nquantiles,
         group=grouper,
         kind=kind,


### PR DESCRIPTION
The HadISD zarr stores used to be in the AWS tmp directory. Now they are in the main catalog, so I fixed the filepath. 

I updated the QuantileDeltaMapping code in `data_loaders` following Beth's guidance to set a window of 90 days (+/- 45 days) to account for seasonality. 