### PR TITLE
Add singleton 'scenario' dimension for 'historical climate'

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -479,6 +479,7 @@ def _merge_all(selections, data_dict, cat_subset):
         )
     else:
         all_ssps = all_hist
+        all_ssps = all_ssps.assign_coords({"scenario": selections.scenario_historical})
 
     # Rename expanded dimension:
     all_ssps = all_ssps.rename({"member_id": "simulation"})

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -479,7 +479,10 @@ def _merge_all(selections, data_dict, cat_subset):
         )
     else:
         all_ssps = all_hist
-        all_ssps = all_ssps.assign_coords({"scenario": selections.scenario_historical})
+        all_ssps = all_ssps.assign_coords(
+            {"scenario": selections.scenario_historical[0]}
+        )
+        all_ssps = all_ssps.expand_dims(dim={"scenario": 1})
 
     # Rename expanded dimension:
     all_ssps = all_ssps.rename({"member_id": "simulation"})


### PR DESCRIPTION
This should fix the issue in the AMY panel that popped up after the data_loaders refactor: seems to require that there be a singleton dimension for scenario if 'Historical Climate' is present without any SSP. This PR adds one.