### PR TITLE
Station range for consistency.

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -622,7 +622,7 @@ def _read_catalog_from_select(selections, cat):
             selections.scenario_historical.append("Historical Climate")
         obs_data_bounds = (
             1980,
-            2010,
+            2014,
         )  # Bounds of the observational data used in bias-correction
         if original_time_slice[0] > obs_data_bounds[0]:
             selections.time_slice = (obs_data_bounds[0], original_time_slice[1])


### PR DESCRIPTION
The bias-correction already uses the same range in the gridded data as the station data that was read-in. This changes that reference range in one other spot for consistency, where we make sure the gridded data selected is expanded to include the same range as the station obs.