### PR TITLE
Restored retrieval of reanalysis-driven WRF run

### DIFF
--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -115,7 +115,10 @@ def _sim_index_item(ds_name, member_id):
     downscaling_type = ds_name.split(".")[0]
     gcm_name = ds_name.split(".")[2]
     ensemble_member = str(member_id.values)
-    return "_".join([downscaling_type, gcm_name, ensemble_member])
+    if ensemble_member != 'nan':
+        return "_".join([downscaling_type, gcm_name, ensemble_member])
+    else:
+        return "_".join([downscaling_type, gcm_name])
 
 
 def _scenarios_in_data_dict(keys):
@@ -484,6 +487,16 @@ def _merge_all(selections, data_dict, cat_subset):
             {"scenario": selections.scenario_historical[0]}
         )
         all_ssps = all_ssps.expand_dims(dim={"scenario": 1})
+        reconstruction = [one for one in data_dict.keys() if "reanalysis" in one]
+        if reconstruction:
+            one_key = reconstruction[0]
+            all_ssps = xr.concat(
+                [all_ssps,
+                    _process_dset(one_key, data_dict[one_key], selections)
+                ],
+                dim="member_id",
+            )
+
 
     # Rename expanded dimension:
     all_ssps = all_ssps.rename({"member_id": "simulation"})

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -409,6 +409,7 @@ def _concat_sims(data_dict, hist_data, selections, scenario):
 
     # Append historical if relevant:
     if hist_data != None:
+        hist_data = hist_data.sel(member_id=one_scenario.member_id)
         scen_name = "Historical + " + scen_name
         one_scenario = xr.concat([hist_data, one_scenario], dim="time")
 
@@ -438,20 +439,22 @@ def _override_unit_defaults(da, var_id):
         da.attrs["units"] = "W/m2"
     return da
 
-def _add_scenario_dim(da,scen_name):
+
+def _add_scenario_dim(da, scen_name):
     """Add a singleton dimension for 'scenario' to the DataArray.
 
     Args:
         da (xr.DataArray): Consolidated data object missing a scenario dimension
         scen_name (string): desired value for scenario along new dimension
-    
+
     Returns:
         da (xr.DataArray): Data object with singleton scenario dimension added.
-    
+
     """
     da = da.assign_coords({"scenario": scen_name})
     da = da.expand_dims(dim={"scenario": 1})
     return da
+
 
 def _merge_all(selections, data_dict, cat_subset):
     """Merge all datasets into one, subsetting each consistently;
@@ -512,7 +515,7 @@ def _merge_all(selections, data_dict, cat_subset):
             one_key = reconstruction[0]
             all_ssps = _process_dset(one_key, data_dict[one_key], selections)
             all_ssps = _add_scenario_dim(all_ssps, "Historical Reconstruction")
-        
+
     # Rename expanded dimension:
     all_ssps = all_ssps.rename({"member_id": "simulation"})
 

--- a/climakitae/data_loaders.py
+++ b/climakitae/data_loaders.py
@@ -491,12 +491,14 @@ def _merge_all(selections, data_dict, cat_subset):
                     [all_ssps, _process_dset(one_key, data_dict[one_key], selections)],
                     dim="member_id",
                 )
+                hist_scen = "Historical"
+            else:
+                hist_scen = "Historical Climate"
         elif reconstruction:
             one_key = reconstruction[0]
             all_ssps = _process_dset(one_key, data_dict[one_key], selections)
-        all_ssps = all_ssps.assign_coords(
-            {"scenario": selections.scenario_historical[0]}
-        )
+            hist_scen = "Historical Reconstruction"
+        all_ssps = all_ssps.assign_coords({"scenario": hist_scen})
         all_ssps = all_ssps.expand_dims(dim={"scenario": 1})
 
     # Rename expanded dimension:


### PR DESCRIPTION
This PR fixes degradation introduced in https://github.com/cal-adapt/climakitae/pull/238, after which 'retrieve' failed to return anything for "Historical Reconstruction" (e.g. the reanalysis-driven WRF simulation). 

The structure of the xr.DataArray in which the ERA5_WRF data is returned is different from before when "Historical Climate" and "Historical Reconstruction" are both selected. The "ERA5_WRF" label is appended along the "simulation" dimension, but the scenario dimension is labeled "Historical" to avoid the inefficiency of a sparse array with two values along the 'scenario' dimension.