### PR TITLE
Export file options for TMY data

### DIFF
--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -477,9 +477,9 @@ def _tmy_header(location_name, df):
     )
 
     # line 2 - data field name and units, manually setting to ensure matches TMY3 labeling
-    # tmy dataframe headers handles this
+    line_2 = "Air Temperature at 2m (degC),Dew point temperature (degC),Relative humidity (%),Instantaneous downwelling shortwave flux at bottom (W m-2),Shortwave surface downward diffuse irradiance (W m-2),Instantaneous downwelling longwave flux at bottom (W m-2),Wind speed at 10m (m s-1),Wind direction at 10m (deg),Surface Pressure (Pa)\n"
 
-    headers = [line_1]
+    headers = [line_1, line_2]
 
     return headers
 
@@ -513,7 +513,7 @@ def _epw_header(location_name, df):
     )
 
     # line 7 - comments 2, putting the data variables here manually as they are not specified in epw format, and we are not including all
-    line_7 = "COMMENTS 2,Air Temperature at 2m,Dew point temperature,Relative humidity,Instantaneous downwelling shortwave flux at bottom,Shortwave surface downward diffuse irradiance,Instantaneous downwelling longwave flux at bottom,Wind speed at 10m,Wind direction at 10m,Surface Pressure\n"
+    line_7 = "COMMENTS 2,Air Temperature at 2m (degC),Dew point temperature (degC),Relative humidity (%),Instantaneous downwelling shortwave flux at bottom (W m-2),Shortwave surface downward diffuse irradiance (W m-2),Instantaneous downwelling longwave flux at bottom (W m-2),Wind speed at 10m (m s-1),Wind direction at 10m (deg),Surface Pressure (Pa)\n"
 
     # line 8 - data periods, num data periods, num records per hour, data period name, data period start day of week, data period start (Jan 1), data period end (Dec 31)
     line_8 = "DATA PERIODS,1,1,Data,,1/1,12/31\n"
@@ -551,7 +551,7 @@ def write_tmy_file(filename_to_export, df, location_name = "location", file_ext=
             df = df.drop(
                 columns=["simulation", "lat", "lon", "scenario"]
             )  # drops header columns from df
-            dfAsString = df.to_csv(sep=",", header=True, index=False)
+            dfAsString = df.to_csv(sep=",", header=False, index=False)
             f.write(dfAsString)  # writes file
         print("TMY data exported to .tmy format with filename {}.tmy".format(filename_to_export))
 

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -526,15 +526,16 @@ def write_tmy_file(filename_to_export, df, station_name, file_ext="tmy"):
     filename_to_export (str): Filename string, constructed with station name and simulation
     df (pd.DataFrame): Dataframe of TMY data to export
     station_name (str): Station name string
-    file_ext (str, optional): File extension for export, default is .tmy
+    file_ext (str, optional): File extension for export, default is .tmy, options are "tmy" and "epw"
 
     Returns
     -------
     None
     '''
 
+    # typical meteorological year format
     if file_ext == "tmy":
-        path_to_file = filename_to_export + ".tmy" # typical meteorological year format
+        path_to_file = filename_to_export + ".tmy" 
 
         with open(path_to_file, 'w') as f:
             f.writelines(tmy_header(station_name, df)) # writes required header lines
@@ -542,10 +543,9 @@ def write_tmy_file(filename_to_export, df, station_name, file_ext="tmy"):
             dfAsString = df.to_csv(sep=',', header=True, index=False)
             f.write(dfAsString) # writes file
 
-
+    # energy plus weather format
     elif file_ext == "epw":
-        path_to_file = filename_to_export + ".epw" # energy plus weather format
-
+        path_to_file = filename_to_export + ".epw" 
         with open(path_to_file, 'w') as f:
             f.writelines(epw_header(station_name, df)) # writes required header lines
             df = df.drop(columns=['simulation', 'lat', 'lon', 'scenario']) # drops header columns from df

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -523,7 +523,7 @@ def _epw_header(location_name, df):
     return headers
 
 
-def write_tmy_file(filename_to_export, df, location_name = "location", file_ext="tmy"):
+def write_tmy_file(filename_to_export, df, location_name="location", file_ext="tmy"):
     """Exports TMY data either as .epw or .tmy file
 
     Paramters
@@ -540,7 +540,9 @@ def write_tmy_file(filename_to_export, df, location_name = "location", file_ext=
 
     # check that data passed is a DataFrame object
     if type(df) != pd.DataFrame:
-        raise ValueError("The function requires a pandas DataFrame object as the data input")
+        raise ValueError(
+            "The function requires a pandas DataFrame object as the data input"
+        )
 
     # typical meteorological year format
     if file_ext == "tmy":
@@ -553,7 +555,11 @@ def write_tmy_file(filename_to_export, df, location_name = "location", file_ext=
             )  # drops header columns from df
             dfAsString = df.to_csv(sep=",", header=False, index=False)
             f.write(dfAsString)  # writes file
-        print("TMY data exported to .tmy format with filename {}.tmy".format(filename_to_export))
+        print(
+            "TMY data exported to .tmy format with filename {}.tmy".format(
+                filename_to_export
+            )
+        )
 
     # energy plus weather format
     elif file_ext == "epw":
@@ -565,7 +571,11 @@ def write_tmy_file(filename_to_export, df, location_name = "location", file_ext=
             )  # drops header columns from df
             dfAsString = df.to_csv(sep=",", header=False, index=False)
             f.write(dfAsString)  # writes file
-        print("TMY data exported to .epw format with filename {}.epw".format(filename_to_export))
-        
+        print(
+            "TMY data exported to .epw format with filename {}.epw".format(
+                filename_to_export
+            )
+        )
+
     else:
         print('Please pass either "tmy" or "epw" as a file format for export.')

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -457,3 +457,47 @@ def _metadata_to_file(ds, output_name):
             ):
                 f.write(str(att_keys) + " : " + str(att_values))
                 f.write("\n")
+
+
+## TMY export functions
+def epw_header(station_name, df):
+    '''Constructs the header for the TMY output file in .epw format'''
+    
+    # line 1 - location
+    line_1 = "LOCATION,{0},{1},{2}\n".format(station_name, df['lat'][0], df['lon'][0])
+    
+    # line 2 - design conditions, leave blank for now
+    line_2 = "#DESIGN CONDITIONS\n"
+    
+    # line 3 - typical/extreme periods, leave blank for now
+    line_3 = "#TYPICAL/EXTREME PERIODS\n"
+    
+    # line 4 - ground temperatures, leave blank for now
+    line_4 = "#GROUND TEMPERATURES\n"
+    
+    # line 5 - holidays/daylight savings, leave blank for now
+    line_5 = "#HOLIDAYS/DAYLIGHT SAVINGS\n"
+    
+    # line 6 - comments 1, going to include simulation + scenario information here
+    line_6 = "COMMENTS 1,Scenario: {0}, Simulation: {1}\n".format(df['scenario'][0], df['simulation'][0])
+    
+    # line 7 - comments 2, maybe a "produced on the analytics engine"
+    line_7 = "COMMENTS 2,Typical meteorological year data produced on the Cal-Adapt: Analytics Engine\n"
+    
+    # line 8 - data periods, leave blank for now
+    line_8 = "#DATA PERIODS\n"
+    
+    headers = [line_1, line_2, line_3, line_4, line_5, line_6, line_7, line_8]
+    
+    return headers
+
+def write_epw_file(filename_to_export, df, station_name):
+    '''Exports a .epw file of TMY data'''
+
+    path_to_file = filename_to_export + ".epw" # energy plus weather format
+
+    with open(path_to_file, 'w') as f:
+        f.writelines(epw_header(station_name, df)) # writes required header lines
+        df = df.drop(columns=['simulation', 'lat', 'lon', 'scenario']) # drops header columns from df
+        dfAsString = df.to_csv(sep=',', header=False, index=False)
+        f.write(dfAsString) # writes file

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -468,18 +468,20 @@ def tmy_header(station_name, df):
 
     # line 1 - site information
     # line 1: USAF, station name quote delimited, station state, time zone, lat, lon, elev (m)
-    # line 1: we provide station name, lat, lon
-    line_1 = "'{0}', {1}, {2}, {3}".format(station_name, df['lat'].values[0], df['lon'].values[0])
+    # line 1: we provide station name, lat, lon, and simulation
+    line_1 = "'{0}', {1}, {2}, {3}".format(station_name, df['lat'].values[0], df['lon'].values[0], df['simulation'].values[0])
 
-    # line 2 - data field name and units
-        'Air Temperature at 2m',
-       'Relative humidity',
-       'Instantaneous downwelling shortwave flux at bottom',
-       'Shortwave surface downward diffuse irradiance',
-       'Instantaneous downwelling longwave flux at bottom',
-       'Wind speed at 10m', 
-       'Wind direction at 10m', 
-       'Surface Pressure'
+    # line 2 - data field name and units, manually setting to ensure matches TMY3 labeling
+    line_2 = "Dry-bulb temperature (degC), \
+                Relative humidity (percent),\
+                Global horizontal irradiance (W m-2),\
+                Diffuse horizontal irradiance (W m-2),\
+                Downwelling infrared radiation (W m-2),\
+                Wind speed (m s-1),\
+                Wind direction (degrees from north),\
+                Station pressure (mb)"
+                # Direct normal irradiance (W m-2) # once in catalog after GHI and before DHI
+
     headers = [line_1, line_2]
 
     return headers
@@ -531,14 +533,17 @@ def write_tmy_file(filename_to_export, df, station_name, file_ext="tmy"):
     None
     '''
 
-    if file_ext = "tmy":
+    if file_ext == "tmy":
         path_to_file = filename_to_export + ".tmy" # typical meteorological year format
 
         with open(path_to_file, 'w') as f:
             f.writelines(tmy_header(station_name, df)) # writes required header lines
+            df = df.drop(columns=['simulation', 'lat', 'lon', 'scenario']) # drops header columns from df
+            dfAsString = df.to_csv(sep=',', header=True, index=False)
+            f.write(dfAsString) # writes file
 
 
-    elif file_ext = "epw":
+    elif file_ext == "epw":
         path_to_file = filename_to_export + ".epw" # energy plus weather format
 
         with open(path_to_file, 'w') as f:

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -513,7 +513,7 @@ def epw_header(station_name, df):
     )
 
     # line 7 - comments 2, putting the data variables here manually as they are not specified in epw format, and we are not including all
-    line_7 = "COMMENTS 2,Air Temperature at 2m,Relative humidity,Instantaneous downwelling shortwave flux at bottom,Shortwave surface downward diffuse irradiance,Instantaneous downwelling longwave flux at bottom,Wind speed at 10m,Wind direction at 10m,Surface Pressure\n"
+    line_7 = "COMMENTS 2,Air Temperature at 2m,Dew point temperature,Relative humidity,Instantaneous downwelling shortwave flux at bottom,Shortwave surface downward diffuse irradiance,Instantaneous downwelling longwave flux at bottom,Wind speed at 10m,Wind direction at 10m,Surface Pressure\n"
 
     # line 8 - data periods, num data periods, num records per hour, data period name, data period start day of week, data period start (Jan 1), data period end (Dec 31)
     line_8 = "DATA PERIODS,1,1,Data,,1/1,12/31\n"

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -469,50 +469,45 @@ def tmy_header(station_name, df):
     # line 1 - site information
     # line 1: USAF, station name quote delimited, station state, time zone, lat, lon, elev (m)
     # line 1: we provide station name, lat, lon, and simulation
-    line_1 = "'{0}', {1}, {2}, {3}".format(station_name, df['lat'].values[0], df['lon'].values[0], df['simulation'].values[0])
+    line_1 = "'{0}', {1}, {2}, {3}\n".format(station_name, df['lat'].values[0], df['lon'].values[0], df['simulation'].values[0])
 
     # line 2 - data field name and units, manually setting to ensure matches TMY3 labeling
-    line_2 = "Dry-bulb temperature (degC), \
-                Relative humidity (percent),\
-                Global horizontal irradiance (W m-2),\
-                Diffuse horizontal irradiance (W m-2),\
-                Downwelling infrared radiation (W m-2),\
-                Wind speed (m s-1),\
-                Wind direction (degrees from north),\
-                Station pressure (mb)"
-                # Direct normal irradiance (W m-2) # once in catalog after GHI and before DHI
+    # tmy dataframe headers handles this
 
-    headers = [line_1, line_2]
+    headers = [line_1]
 
     return headers
 
 
 def epw_header(station_name, df):
-    '''Constructs the header for the TMY output file in .epw format'''
+    '''
+    Constructs the header for the TMY output file in .epw format
+    Source:https://designbuilder.co.uk/cahelp/Content/EnergyPlusWeatherFileFormat.htm#:~:text=The%20EPW%20weather%20data%20format,based%20with%20comma%2Dseparated%20data.
+    '''
     
     # line 1 - location
     line_1 = "LOCATION,{0},{1},{2}\n".format(station_name, df['lat'].values[0], df['lon'].values[0])
     
     # line 2 - design conditions, leave blank for now
-    line_2 = "#DESIGN CONDITIONS\n"
+    line_2 = "DESIGN CONDITIONS\n"
     
     # line 3 - typical/extreme periods, leave blank for now
-    line_3 = "#TYPICAL/EXTREME PERIODS\n"
+    line_3 = "TYPICAL/EXTREME PERIODS\n"
     
     # line 4 - ground temperatures, leave blank for now
-    line_4 = "#GROUND TEMPERATURES\n"
+    line_4 = "GROUND TEMPERATURES\n"
     
-    # line 5 - holidays/daylight savings, leave blank for now
-    line_5 = "#HOLIDAYS/DAYLIGHT SAVINGS\n"
+    # line 5 - holidays/daylight savings, leap year (yes/no), daylight savings start, daylight savings end, num of holidays
+    line_5 = "HOLIDAYS/DAYLIGHT SAVINGS,No,0,0,0\n"
     
     # line 6 - comments 1, going to include simulation + scenario information here
-    line_6 = "COMMENTS 1,Scenario: {0}, Simulation: {1}\n".format(df['scenario'].values[0], df['simulation'].values[0])
+    line_6 = "COMMENTS 1,Typical meteorological year data produced on the Cal-Adapt: Analytics Engine, Scenario: {0}, Simulation: {1}\n".format(df['scenario'].values[0], df['simulation'].values[0])
     
-    # line 7 - comments 2, maybe a "produced on the analytics engine"
-    line_7 = "COMMENTS 2,Typical meteorological year data produced on the Cal-Adapt: Analytics Engine\n"
+    # line 7 - comments 2, putting the data variables here manually as they are not specified in epw format, and we are not including all
+    line_7 = "COMMENTS 2,Air Temperature at 2m,Relative humidity,Instantaneous downwelling shortwave flux at bottom,Shortwave surface downward diffuse irradiance,Instantaneous downwelling longwave flux at bottom,Wind speed at 10m,Wind direction at 10m,Surface Pressure\n"
     
-    # line 8 - data periods, leave blank for now
-    line_8 = "#DATA PERIODS\n"
+    # line 8 - data periods, num data periods, num records per hour, data period name, data period start day of week, data period start (Jan 1), data period end (Dec 31)
+    line_8 = "DATA PERIODS,1,1,Data,,1/1,12/31\n"
     
     headers = [line_1, line_2, line_3, line_4, line_5, line_6, line_7, line_8]
     

--- a/climakitae/data_export.py
+++ b/climakitae/data_export.py
@@ -461,15 +461,20 @@ def _metadata_to_file(ds, output_name):
 
 ## TMY export functions
 def tmy_header(station_name, df):
-    '''
+    """
     Constructs the header for the TMY output file in .tmy format
     Source: https://www.nrel.gov/docs/fy08osti/43156.pdf (pg. 3)
-    '''
+    """
 
     # line 1 - site information
     # line 1: USAF, station name quote delimited, station state, time zone, lat, lon, elev (m)
     # line 1: we provide station name, lat, lon, and simulation
-    line_1 = "'{0}', {1}, {2}, {3}\n".format(station_name, df['lat'].values[0], df['lon'].values[0], df['simulation'].values[0])
+    line_1 = "'{0}', {1}, {2}, {3}\n".format(
+        station_name,
+        df["lat"].values[0],
+        df["lon"].values[0],
+        df["simulation"].values[0],
+    )
 
     # line 2 - data field name and units, manually setting to ensure matches TMY3 labeling
     # tmy dataframe headers handles this
@@ -480,41 +485,46 @@ def tmy_header(station_name, df):
 
 
 def epw_header(station_name, df):
-    '''
+    """
     Constructs the header for the TMY output file in .epw format
     Source:https://designbuilder.co.uk/cahelp/Content/EnergyPlusWeatherFileFormat.htm#:~:text=The%20EPW%20weather%20data%20format,based%20with%20comma%2Dseparated%20data.
-    '''
-    
+    """
+
     # line 1 - location
-    line_1 = "LOCATION,{0},{1},{2}\n".format(station_name, df['lat'].values[0], df['lon'].values[0])
-    
+    line_1 = "LOCATION,{0},{1},{2}\n".format(
+        station_name, df["lat"].values[0], df["lon"].values[0]
+    )
+
     # line 2 - design conditions, leave blank for now
     line_2 = "DESIGN CONDITIONS\n"
-    
+
     # line 3 - typical/extreme periods, leave blank for now
     line_3 = "TYPICAL/EXTREME PERIODS\n"
-    
+
     # line 4 - ground temperatures, leave blank for now
     line_4 = "GROUND TEMPERATURES\n"
-    
+
     # line 5 - holidays/daylight savings, leap year (yes/no), daylight savings start, daylight savings end, num of holidays
     line_5 = "HOLIDAYS/DAYLIGHT SAVINGS,No,0,0,0\n"
-    
+
     # line 6 - comments 1, going to include simulation + scenario information here
-    line_6 = "COMMENTS 1,Typical meteorological year data produced on the Cal-Adapt: Analytics Engine, Scenario: {0}, Simulation: {1}\n".format(df['scenario'].values[0], df['simulation'].values[0])
-    
+    line_6 = "COMMENTS 1,Typical meteorological year data produced on the Cal-Adapt: Analytics Engine, Scenario: {0}, Simulation: {1}\n".format(
+        df["scenario"].values[0], df["simulation"].values[0]
+    )
+
     # line 7 - comments 2, putting the data variables here manually as they are not specified in epw format, and we are not including all
     line_7 = "COMMENTS 2,Air Temperature at 2m,Relative humidity,Instantaneous downwelling shortwave flux at bottom,Shortwave surface downward diffuse irradiance,Instantaneous downwelling longwave flux at bottom,Wind speed at 10m,Wind direction at 10m,Surface Pressure\n"
-    
+
     # line 8 - data periods, num data periods, num records per hour, data period name, data period start day of week, data period start (Jan 1), data period end (Dec 31)
     line_8 = "DATA PERIODS,1,1,Data,,1/1,12/31\n"
-    
+
     headers = [line_1, line_2, line_3, line_4, line_5, line_6, line_7, line_8]
-    
+
     return headers
 
+
 def write_tmy_file(filename_to_export, df, station_name, file_ext="tmy"):
-    '''Exports TMY data either as .epw or .tmy file
+    """Exports TMY data either as .epw or .tmy file
 
     Paramters
     ---------
@@ -526,26 +536,30 @@ def write_tmy_file(filename_to_export, df, station_name, file_ext="tmy"):
     Returns
     -------
     None
-    '''
+    """
 
     # typical meteorological year format
     if file_ext == "tmy":
-        path_to_file = filename_to_export + ".tmy" 
+        path_to_file = filename_to_export + ".tmy"
 
-        with open(path_to_file, 'w') as f:
-            f.writelines(tmy_header(station_name, df)) # writes required header lines
-            df = df.drop(columns=['simulation', 'lat', 'lon', 'scenario']) # drops header columns from df
-            dfAsString = df.to_csv(sep=',', header=True, index=False)
-            f.write(dfAsString) # writes file
+        with open(path_to_file, "w") as f:
+            f.writelines(tmy_header(station_name, df))  # writes required header lines
+            df = df.drop(
+                columns=["simulation", "lat", "lon", "scenario"]
+            )  # drops header columns from df
+            dfAsString = df.to_csv(sep=",", header=True, index=False)
+            f.write(dfAsString)  # writes file
 
     # energy plus weather format
     elif file_ext == "epw":
-        path_to_file = filename_to_export + ".epw" 
-        with open(path_to_file, 'w') as f:
-            f.writelines(epw_header(station_name, df)) # writes required header lines
-            df = df.drop(columns=['simulation', 'lat', 'lon', 'scenario']) # drops header columns from df
-            dfAsString = df.to_csv(sep=',', header=False, index=False)
-            f.write(dfAsString) # writes file
+        path_to_file = filename_to_export + ".epw"
+        with open(path_to_file, "w") as f:
+            f.writelines(epw_header(station_name, df))  # writes required header lines
+            df = df.drop(
+                columns=["simulation", "lat", "lon", "scenario"]
+            )  # drops header columns from df
+            dfAsString = df.to_csv(sep=",", header=False, index=False)
+            f.write(dfAsString)  # writes file
 
     else:
         print('Please pass either "tmy" or "epw" as a file format for export.')


### PR DESCRIPTION
Adds two new fancy formats for how TMY data is used: .epw (energy plus weather) and .tmy (typical meteorological year)
These formats are effectively csv files with specific headers and information included. Sources are included in the header construction functions. 

---
To test:
Run through the AMY_to_TMY notebook in the amy_to_tmy branch on cae-examples (https://github.com/cal-adapt/cae-examples/pull/47) and play around with the file_ext as both "tmy" and "epw" in the export code cell (the very last one)