### PR TITLE
Refresh the current documentation. Fix broken environment.yml file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,10 @@ You'll only need to do steps 1 and 3 **once** to build the environment. Then, ju
 
 1. If you haven't already, build the conda environment for this project: ``conda env create -f environment.yml``
 2. Next, activate the conda environment for this project: ``conda activate climakitae-tests``
-3. In the conda environment, install the following packages through pip: ``pip install sphinx-book-theme sphinx-design``
+3. In the conda environment, install the following packages through pip: ``pip install sphinx-book-theme==0.3.3 sphinx-design==0.3.0``
 4. Serialize RST to HTML and start a web server (locally): ``make serve-docs`` 
 5. To see the locally served docs: http://localhost:8000/
+6. Push changes to the file `docs/climakitae.rst`
 
 ## If you're working on a windows device 
 You may encounter issues when trying to build the docs due to path issues.<br><br> If you encounter this error message when building the docs:<br> 

--- a/docs/climakitae.rst
+++ b/docs/climakitae.rst
@@ -60,6 +60,14 @@ climakitae.explore module
    :undoc-members:
    :show-inheritance:
 
+climakitae.indices module
+-------------------------
+
+.. automodule:: climakitae.indices
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 climakitae.metadata\_update module
 ----------------------------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - xmip
   - pygeos
   - pip
+  - pip:
     - dask-gateway
     - dask-geopandas
     - xclim


### PR DESCRIPTION
The readthedocs page doesn't automatically update (it should!! see [this](https://trello.com/c/jTwpvNkP/347-troubleshoot-readthedocs-issue) open trello card). So, here I force-refreshed the documentation to update it with the current code. I branched off of my effective temp branch (eft) so that the index code was included in this. 

I also noticed an issue when trying to rebuild the conda environment, which is used to build the documentation. Just some minor formatting issues, which I easily resolved :D 