### PR TITLE
Export Dataset to CSV

### DIFF
--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -593,6 +593,7 @@ def _metadata_to_file(ds, output_name):
                     f.write(str(att_keys) + " : " + str(att_values))
                     f.write("\n")
 
+
 ## TMY export functions
 def _tmy_header(location_name, df):
     """

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -97,6 +97,7 @@ def _export_to_csv(data_to_export, save_name, **kwargs):
         variable = data_to_export.name
         df = _add_unit_to_header(df, variable, unit)
 
+    # Warn about exceedance of Excel row or column limit
     excel_row_limit = 1048576
     excel_column_limit = 16384
     csv_nrows, csv_ncolumns = df.shape


### PR DESCRIPTION
This PR allows users to export xarray Dataset to the CSV format. Previously only DataArray can be exported to CSV. Now, users are able to export station data as well as all the Dataset outputs from the threshold_tools_basics and threshold_tools_application_examples notebooks.

**Implementation details:**
- The function `export_dataset` no longer raises an exception when users export a Dataset. The Dataset would be exported via `_export_to_csv`.
- The functions `_export_to_csv`and `_metadata_to_file` are branched depending on whether the data to export is a DataArray or a Dataset. 
- Helper functions are created/updated to hold code that works for both data types.
- Existing code specific to DataArray is moved to `_dataarray_to_dataframe` with structural changes needed to leverage the helpers.

**As an example**, for a Dataset containing 3 stations, the header of the exported CSV looks like this:
![Screenshot 2023-08-15 133239](https://github.com/cal-adapt/climakitae/assets/56141689/037dba82-e1a9-46fb-9085-4247ed340e16)


 
**Note**: The climate variable name is not currently in the header as it is not readily available in the Dataset. Will be pulled from variable_description.csv later.

**To test**: In the refactor branch of cae-notebooks, try export some station data and/or other Dataset.