### PR TITLE
Tag software as 0.0.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ project = "Climakitae"
 copyright = "2022, Cal-Adapt Analytics Engine"
 author = "Cal-Adapt Analytics Engine Team"
 # The full version, including alpha/beta/rc tags
-release = "0.0.1"
+release = "0.0.2"
 
 # -- General configuration ---------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = climakitae
-version = 0.0.1
+version = 0.0.2
 author = Cal-Adapt Analytics Engine Team
 author_email = analytics@cal-adapt.org
 description = Climate data analysis toolkit


### PR DESCRIPTION
Just had a thought that we should tag the current software as `0.0.2` so that it can be loaded as a pre-refactor software release.