### PR TITLE
Update export readthedocs documentation

### DIFF
--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -11,7 +11,7 @@ from importlib.metadata import version as _version
 xr.set_options(keep_attrs=True)
 
 
-def _export_to_netcdf(data, save_name, **kwargs):
+def _export_to_netcdf(data, save_name):
     """
     exports user-selected data to netCDF format.
     this function is called from the _export_to_user
@@ -19,7 +19,6 @@ def _export_to_netcdf(data, save_name, **kwargs):
 
     data: xarray dataset or array to export
     save_name: string corresponding to desired output file name + file extension
-    kwargs: reserved for future use
     """
     print("Alright, exporting specified data to NetCDF.")
     comp = dict(_FillValue=None)
@@ -186,7 +185,7 @@ def _dataset_to_dataframe(dataset):
     return df
 
 
-def _export_to_csv(data, save_name, **kwargs):
+def _export_to_csv(data, save_name):
     """
     Export user-selected data to CSV format.
 
@@ -229,16 +228,19 @@ def _export_to_csv(data, save_name, **kwargs):
     df.to_csv(save_name, compression="gzip")
 
 
-def export(data, filename="dataexport.nc", format="NetCDF", **kwargs):
-    """
-    The data export method, called by core.Application.export_dataset. Saves
-    a dataset to the current working directory in the output
-    format requested by the user (which is stored in 'format').
+def export(data, filename="dataexport", format="NetCDF"):
+    """Save data as a file in the current working directory.
 
-    data: xarray ds or da to export
-    filename: string corresponding to desired output file name
-    format: data format to export to (NetCDF, CSV)
-    kwargs: variable, scenario, and simulation (as needed)
+    Parameters
+    ----------
+    data : xr.DataArray or xr.Dataset
+        Data to export, as output by e.g. `climakitae.Select().retrieve()`.
+    filename : str, optional
+        Output file name (without file extension, i.e. "my_filename" instead 
+        of "my_filename.nc"). The default is "dataexport".
+    format : str, optional
+        File format ("NetCDF" or "CSV"). The default is "NetCDF".
+
     """
     ftype = type(data)
 
@@ -330,9 +332,9 @@ def export(data, filename="dataexport.nc", format="NetCDF", **kwargs):
     # we will have different functions for each file type
     # to keep things clean-ish
     if "NetCDF" in req_format:
-        _export_to_netcdf(data, save_name, **kwargs)
+        _export_to_netcdf(data, save_name)
     elif "CSV" in req_format:
-        _export_to_csv(data, save_name, **kwargs)
+        _export_to_csv(data, save_name)
 
     return print(
         (

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -236,7 +236,7 @@ def export(data, filename="dataexport", format="NetCDF"):
     data : xr.DataArray or xr.Dataset
         Data to export, as output by e.g. `climakitae.Select().retrieve()`.
     filename : str, optional
-        Output file name (without file extension, i.e. "my_filename" instead 
+        Output file name (without file extension, i.e. "my_filename" instead
         of "my_filename.nc"). The default is "dataexport".
     format : str, optional
         File format ("NetCDF" or "CSV"). The default is "NetCDF".

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -46,7 +46,7 @@ of the  ``selectors`` object: ::
 
    selections.area_average = "Yes"
 
-To set the the variable to Air Temperature at 2m and retrive the data in units of degrees Fahrenheit: :: 
+To set the the variable to Air Temperature at 2m and retrieve the data in units of degrees Fahrenheit: :: 
 
    selections.variable = "Air Temperature at 2m" 
    selections.units = "degF"
@@ -64,7 +64,7 @@ You must set these attributes using the formatting and naming conventions
 exactly as they appear in the :py:class:`climakitae.Select()` GUI.  
 For example, you must set ``timescale`` to ``hourly``, not ``Hourly``. Only ``scenario_ssp``, ``scenario_historical``, and ``time_slice`` accept multiple values.
 
-Lastly, you'll need to retrive the data: :: 
+Lastly, you'll need to retrieve the data: :: 
 
    data = selections.retrieve()
 
@@ -131,26 +131,15 @@ the documentation in the API for more information.
 
 Export the data 
 ################
-To export your final data (which should be an :py:class:`xarray.DataArray` object), first create the export
-object using :py:class:`climakitae.Export()`. Then the filetype you want to export the data to using the
-:py:func:`climakitae.Export().export_as()` dropdown menu. This will allow you to choose between three
-options: NetCDF, csv, and GeoTIFF. ::
+To save data as a file, use the :py:func:`climakitae.export()` method and input your desired
+1) data to export – an :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset` object, as output by e.g. `selections.retrieve()`
+2) output file name (without file extension)
+3) file format ("NetCDF" or "CSV")
 
-   export = ck.Export()
-   export.export_as()
+We recommend NetCDF, which suits data and outputs from the Analytics Engine well – it efficiently stores large data containing multiple variables and dimensions. Metadata will be retained in NetCDF files.
 
-We recommend exporting the data to NetCDF, which will work with any number of variables and dimensions. 
-csv and GeoTIFF can only be used for datasets with a single variable.
-csv works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported 
-with a separate metadata file. 
-For GeoTIFF exports, metadata will be accessible as "tags" in the tif file. 
-GeoTIFF can accept 3 dimensions total:
+CSV can also store Analytics Engine data with any number of variables and dimensions. It works the best for smaller data with fewer dimensions. The output file will be compressed to ensure efficient storage. Metadata will be preserved in a separate file.
 
-* Horizontal dimensions; i.e. x and y (required)
-* The third dimension is flexible and will be a "band" in the file: time, simulation, or scenario could go here
+CSV stores data in tabular format. Rows will be indexed by the index coordinate(s) of the DataArray or Dataset (e.g. scenario, simulation, time). Columns will be formed by the data variable(s) and non-index coordinate(s). :: 
 
-After selecting your desired output filetype, input the data you want to export and the 
-desired filename (excluding the file extension) as arguments to the 
-:py:func:`climakitae.Export().export_dataset()` function. :: 
-
-   export.export_dataset(data, "my_filename")
+   ck.export(data, "my_filename", "NetCDF")

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -132,6 +132,7 @@ the documentation in the API for more information.
 Export the data 
 ################
 To save data as a file, use the :py:func:`climakitae.export()` method and input your desired
+
 * data to export – an :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset` object, as output by e.g. :py:func:`selections.retrieve()`
 * output file name (without file extension)
 * file format ("NetCDF" or "CSV")

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -132,9 +132,9 @@ the documentation in the API for more information.
 Export the data 
 ################
 To save data as a file, use the :py:func:`climakitae.export()` method and input your desired
-1) data to export – an :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset` object, as output by e.g. `selections.retrieve()`
-2) output file name (without file extension)
-3) file format ("NetCDF" or "CSV")
+* data to export – an :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset` object, as output by e.g. :py:func:`selections.retrieve()`
+* output file name (without file extension)
+* file format ("NetCDF" or "CSV")
 
 We recommend NetCDF, which suits data and outputs from the Analytics Engine well – it efficiently stores large data containing multiple variables and dimensions. Metadata will be retained in NetCDF files.
 


### PR DESCRIPTION
This PR updates data export-related readthedocs documentation: "working with data" page and `export` function docstring. The updates are similar to those applied to the notebooks in [this PR](https://github.com/cal-adapt/cae-notebooks/pull/65). 