### PR TITLE
Move Boundary data load out of init and to load method

### DIFF
--- a/climakitae/core/boundaries.py
+++ b/climakitae/core/boundaries.py
@@ -26,6 +26,14 @@ class Boundaries:
             Table of Electric Balancing Areas
         """
         self._cat = boundary_catalog
+        self._us_states = None
+        self._ca_counties = None
+        self._ca_watersheds = None
+        self._ca_utilities = None
+        self._ca_forecast_zones = None
+        self._ca_electric_balancing_areas = None
+
+    def load(self):
         self._us_states = self._cat.states.read()
         self._ca_counties = self._cat.counties.read().sort_values("NAME")
         self._ca_watersheds = self._cat.huc8.read().sort_values("Name")

--- a/climakitae/core/boundaries.py
+++ b/climakitae/core/boundaries.py
@@ -4,34 +4,35 @@ import pandas as pd
 class Boundaries:
     """Get geospatial polygon data from the S3 stored parquet catalog.
     Used to access boundaries for subsetting data by state, county, etc.
+
+    Parameters
+    -----------
+    _us_states: pd.DataFrame
+        Table of US state names and geometries
+    _ca_counties: pd.DataFrame
+        Table of California county names and geometries
+        Sorted by county name alphabetical order
+    _ca_watersheds: pd.DataFrame
+        Table of California watershed names and geometries
+        Sorted by watershed name alphabetical order
+    _ca_utilities: pd.DataFrame
+        Table of California IOUs and POUs, names and geometries
+    _ca_forecast_zones: pd.DataFrame
+        Table of California Demand Forecast Zones
+    _ca_electric_balancing_areas: pd.DataFrame
+        Table of Electric Balancing Areas
     """
 
+    _cat = None
+    _us_states = None
+    _ca_counties = None
+    _ca_watersheds = None
+    _ca_utilities = None
+    _ca_forecast_zones = None
+    _ca_electric_balancing_areas = None
+
     def __init__(self, boundary_catalog):
-        """
-        Parameters
-        -----------
-        _us_states: pd.DataFrame
-            Table of US state names and geometries
-        _ca_counties: pd.DataFrame
-            Table of California county names and geometries
-            Sorted by county name alphabetical order
-        _ca_watersheds: pd.DataFrame
-            Table of California watershed names and geometries
-            Sorted by watershed name alphabetical order
-        _ca_utilities: pd.DataFrame
-            Table of California IOUs and POUs, names and geometries
-        _ca_forecast_zones: pd.DataFrame
-            Table of California Demand Forecast Zones
-        _ca_electric_balancing_areas: pd.DataFrame
-            Table of Electric Balancing Areas
-        """
         self._cat = boundary_catalog
-        self._us_states = None
-        self._ca_counties = None
-        self._ca_watersheds = None
-        self._ca_utilities = None
-        self._ca_forecast_zones = None
-        self._ca_electric_balancing_areas = None
 
     def load(self):
         self._us_states = self._cat.states.read()

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -531,7 +531,9 @@ class DataInterface:
 
         # Get geography boundaries
         self._boundary_catalog = intake.open_catalog(boundary_catalog_url)
-        self._geographies = Boundaries(self.boundary_catalog).load()
+        self._geographies = Boundaries(self.boundary_catalog)
+
+        self._geographies.load()
 
     @property
     def variable_descriptions(self):

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -533,7 +533,7 @@ class DataInterface:
         self._boundary_catalog = intake.open_catalog(boundary_catalog_url)
         self._geographies = Boundaries(self.boundary_catalog)
 
-        self._geographies.load()
+        #self._geographies.load()
 
     @property
     def variable_descriptions(self):

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -531,7 +531,7 @@ class DataInterface:
 
         # Get geography boundaries
         self._boundary_catalog = intake.open_catalog(boundary_catalog_url)
-        self._geographies = Boundaries(self.boundary_catalog)
+        self._geographies = Boundaries(self.boundary_catalog).load()
 
     @property
     def variable_descriptions(self):

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -533,8 +533,6 @@ class DataInterface:
         self._boundary_catalog = intake.open_catalog(boundary_catalog_url)
         self._geographies = Boundaries(self.boundary_catalog)
 
-        #self._geographies.load()
-
     @property
     def variable_descriptions(self):
         return self._variable_descriptions

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -505,6 +505,25 @@ def _map_view(selections, stations_gdf):
     return mpl_pane
 
 
+class VariableDescriptions:
+    """Load Variable Desciptions CSV only once
+
+    This is a singleton class that needs to be called separately from DataInterface
+    because variable descriptions are used without DataInterface in ck.view. Also
+    ck.view is loaded on package load so this avoids loading boundary data when not
+    needed.
+
+    """
+
+    def __new__(cls):
+        if not hasattr(cls, "instance"):
+            cls.instance = super(VariableDescriptions, cls).__new__(cls)
+        return cls.instance
+
+    def __init__(self):
+        self.variable_descriptions = read_csv_file(variable_descriptions_csv_path)
+
+
 class DataInterface:
     """Load data connections into memory once
 
@@ -520,7 +539,7 @@ class DataInterface:
         return cls.instance
 
     def __init__(self):
-        self._variable_descriptions = read_csv_file(variable_descriptions_csv_path)
+        self._variable_descriptions = VariableDescriptions().variable_descriptions
         self._stations = read_csv_file(stations_csv_path)
         self._stations_gdf = gpd.GeoDataFrame(
             self.stations,

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -522,8 +522,8 @@ class VariableDescriptions:
             cls.instance = super(VariableDescriptions, cls).__new__(cls)
         return cls.instance
 
-    def load(self):
-        if self.variable_descriptions == None:
+    def load(self) :
+        if self.variable_descriptions.empty:
             self.variable_descriptions = read_csv_file(variable_descriptions_csv_path)
 
 

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -515,14 +515,15 @@ class VariableDescriptions:
 
     """
 
-    variable_descriptions = None
-
     def __new__(cls):
         if not hasattr(cls, "instance"):
             cls.instance = super(VariableDescriptions, cls).__new__(cls)
         return cls.instance
 
-    def load(self) :
+    def __init__(self):
+        self.variable_descriptions = pd.DataFrame
+
+    def load(self):
         if self.variable_descriptions.empty:
             self.variable_descriptions = read_csv_file(variable_descriptions_csv_path)
 

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -533,6 +533,8 @@ class DataInterface:
         self._boundary_catalog = intake.open_catalog(boundary_catalog_url)
         self._geographies = Boundaries(self.boundary_catalog)
 
+        self._geographies.load()
+
     @property
     def variable_descriptions(self):
         return self._variable_descriptions

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -515,13 +515,16 @@ class VariableDescriptions:
 
     """
 
+    variable_descriptions = None
+
     def __new__(cls):
         if not hasattr(cls, "instance"):
             cls.instance = super(VariableDescriptions, cls).__new__(cls)
         return cls.instance
 
-    def __init__(self):
-        self.variable_descriptions = read_csv_file(variable_descriptions_csv_path)
+    def load(self):
+        if self.variable_descriptions == None:
+            self.variable_descriptions = read_csv_file(variable_descriptions_csv_path)
 
 
 class DataInterface:
@@ -539,7 +542,9 @@ class DataInterface:
         return cls.instance
 
     def __init__(self):
-        self._variable_descriptions = VariableDescriptions().variable_descriptions
+        var_desc = VariableDescriptions()
+        var_desc.load()
+        self._variable_descriptions = var_desc.variable_descriptions
         self._stations = read_csv_file(stations_csv_path)
         self._stations_gdf = gpd.GeoDataFrame(
             self.stations,

--- a/climakitae/core/data_view.py
+++ b/climakitae/core/data_view.py
@@ -5,8 +5,8 @@ import numpy as np
 import hvplot.xarray
 import matplotlib.pyplot as plt
 import panel as pn
-from climakitae.util.utils import read_csv_file, reproject_data, read_ae_colormap
-from climakitae.core.paths import variable_descriptions_csv_path
+from climakitae.util.utils import reproject_data, read_ae_colormap
+from climakitae.core.data_interface import VariableDescriptions
 
 
 def compute_vmin_vmax(da_min, da_max):
@@ -59,7 +59,7 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
         Warn user that the function will be slow if data has not been loaded into memory
     """
 
-    variable_descriptions = read_csv_file(variable_descriptions_csv_path)
+    variable_descriptions = VariableDescriptions().variable_descriptions
 
     # Warn user about speed if passing a zarr to the function
     if data.chunks is None or str(data.chunks) == "Frozen({})":

--- a/climakitae/core/data_view.py
+++ b/climakitae/core/data_view.py
@@ -59,7 +59,10 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
         Warn user that the function will be slow if data has not been loaded into memory
     """
 
-    variable_descriptions = VariableDescriptions().variable_descriptions
+    var_desc = VariableDescriptions()
+    var_desc.load()
+
+    variable_descriptions = var_desc.variable_descriptions
 
     # Warn user about speed if passing a zarr to the function
     if data.chunks is None or str(data.chunks) == "Frozen({})":

--- a/climakitae/core/data_view.py
+++ b/climakitae/core/data_view.py
@@ -5,8 +5,8 @@ import numpy as np
 import hvplot.xarray
 import matplotlib.pyplot as plt
 import panel as pn
-from climakitae.util.utils import reproject_data, read_ae_colormap
-from climakitae.core.data_interface import DataInterface
+from climakitae.util.utils import read_csv_file, reproject_data, read_ae_colormap
+from climakitae.core.paths import variable_descriptions_csv_path
 
 
 def compute_vmin_vmax(da_min, da_max):
@@ -59,7 +59,7 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
         Warn user that the function will be slow if data has not been loaded into memory
     """
 
-    variable_descriptions = DataInterface().variable_descriptions
+    variable_descriptions = read_csv_file(variable_descriptions_csv_path)
 
     # Warn user about speed if passing a zarr to the function
     if data.chunks is None or str(data.chunks) == "Frozen({})":

--- a/climakitae/explore/uncertainty.py
+++ b/climakitae/explore/uncertainty.py
@@ -9,8 +9,7 @@ from scipy import stats
 from xmip.preprocessing import rename_cmip6
 
 from climakitae.util.utils import read_csv_file
-from climakitae.core.paths import boundary_catalog_url
-from climakitae.core.boundaries import Boundaries
+from climakitae.core.data_interface import DataInterface
 from climakitae.core.data_load import area_subset_geometry
 from climakitae.core.paths import gwl_1850_1900_file, gwl_1981_2010_file
 
@@ -143,8 +142,7 @@ def _clip_region(ds, area_subset, location):
     xr.Dataset
         Clipped dataset to region of interest
     """
-    boundary_catalog = intake.open_catalog(boundary_catalog_url)
-    geographies = Boundaries(boundary_catalog)
+    geographies = DataInterface.geographies
     us_states = geographies._us_states
     us_counties = geographies._ca_counties
     ds = ds.rio.write_crs(4326)

--- a/climakitae/explore/uncertainty.py
+++ b/climakitae/explore/uncertainty.py
@@ -142,7 +142,8 @@ def _clip_region(ds, area_subset, location):
     xr.Dataset
         Clipped dataset to region of interest
     """
-    geographies = DataInterface.geographies
+    data_interface = DataInterface()
+    geographies = data_interface.geographies
     us_states = geographies._us_states
     us_counties = geographies._ca_counties
     ds = ds.rio.write_crs(4326)


### PR DESCRIPTION
This PR moves `Boundaries` data loading to a `load` method that is then called on `DataInterface` init.