### PR TITLE
Colormap update fix for WL

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -266,13 +266,16 @@ class WarmingLevelParameters(DataParametersWithPanes):
     @param.depends("variable", watch=True)
     def _update_cmap(self):
         """Set colormap depending on variable"""
-        cmap_name = self._variable_descriptions[
-            (self._variable_descriptions["display_name"] == self.variable)
-            & (self._variable_descriptions["timescale"] == "daily, monthly")
-        ].colormap.values[0]
+        # cmap_name = self._variable_descriptions[
+        #     (self._variable_descriptions["display_name"] == self.variable)
+        #     & (self._variable_descriptions["timescale"] == "daily, monthly")
+        # ].colormap.values[0]
 
-        # Colormap normalization for hvplot -- only for relative humidity!
-        if self.variable == "Relative Humidity":
+        # Colormap normalization for hvplot
+        if self.variable == "Air Temperature at 2m" or self.variable == "Dew point temperature":
+            cmap_name = "ae_orange"
+
+        else:
             cmap_name = "ae_diverging"
 
         # Read colormap hex
@@ -304,8 +307,9 @@ class WarmingLevelParameters(DataParametersWithPanes):
     def _GCM_PostageStamps_MAIN(self):
         # Get plot data
         all_plot_data = self.warm_all_anoms
-        if self.variable == "Relative Humidity":
+        if self.variable == "Relative humidity":
             all_plot_data = all_plot_data * 100
+
 
         # Get int number of simulations
         num_simulations = len(all_plot_data.simulation.values)

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -266,12 +266,6 @@ class WarmingLevelParameters(DataParametersWithPanes):
     @param.depends("variable", watch=True)
     def _update_cmap(self):
         """Set colormap depending on variable"""
-        # cmap_name = self._variable_descriptions[
-        #     (self._variable_descriptions["display_name"] == self.variable)
-        #     & (self._variable_descriptions["timescale"] == "daily, monthly")
-        # ].colormap.values[0]
-
-        # Colormap normalization for hvplot
         if self.variable == "Air Temperature at 2m" or self.variable == "Dew point temperature":
             cmap_name = "ae_orange"
 
@@ -309,7 +303,6 @@ class WarmingLevelParameters(DataParametersWithPanes):
         all_plot_data = self.warm_all_anoms
         if self.variable == "Relative humidity":
             all_plot_data = all_plot_data * 100
-
 
         # Get int number of simulations
         num_simulations = len(all_plot_data.simulation.values)

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -266,7 +266,10 @@ class WarmingLevelParameters(DataParametersWithPanes):
     @param.depends("variable", watch=True)
     def _update_cmap(self):
         """Set colormap depending on variable"""
-        if self.variable == "Air Temperature at 2m" or self.variable == "Dew point temperature":
+        if (
+            self.variable == "Air Temperature at 2m"
+            or self.variable == "Dew point temperature"
+        ):
             cmap_name = "ae_orange"
 
         else:


### PR DESCRIPTION
1. Colormaps for variables should be ae_diverging instead of their assigned colormap according to the data_descriptions file, with the exception of air temperature and dew point temperature. This fixes an issue Naomi had noticed specifically for precipitation, but upon testing was relevant for all other vars. 
2. The assignment to humidity to 100% when displayed had a typo, now fixed. 

---
To test:
Run the warming_levels notebook and make sure that:
- air temp and dew point have ae_orange colormaps
- relative humidity is on a 100% scale (range is not -5 - 5)
- any other variable selection has a diverging colormap