### PR TITLE
updated cmap update for redesigned warming

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -172,13 +172,12 @@ def get_sliced_data(y, years, window=15, anom="Yes"):
 
 def _get_cmap(wl_params):
     """Set colormap depending on variable"""
-    cmap_name = wl_params._variable_descriptions[
-        (wl_params._variable_descriptions["display_name"] == wl_params.variable)
-        & (wl_params._variable_descriptions["timescale"] == "daily, monthly")
-    ].colormap.values[0]
-
-    # Colormap normalization for hvplot -- only for relative humidity!
-    if wl_params.variable == "Relative Humidity":
+    if (
+        wl_params.variable == "Air Temperature at 2m" 
+        or wl_params.variable == "Dew point temperature"
+    ):
+        cmap_name = "ae_orange"
+    else:
         cmap_name = "ae_diverging"
 
     # Read colormap hex
@@ -303,7 +302,7 @@ class WarmingLevelVisualize(param.Parameterized):
         one_warming_level = str(float(self.warmlevel))
         all_plot_data = _select_one_gwl(one_warming_level, self.gwl_snapshots)
         if all_plot_data.all_sims.size != 0:
-            if self.wl_params.variable == "Relative Humidity":
+            if self.wl_params.variable == "Relative humidity":
                 all_plot_data = all_plot_data * 100
 
             # Set up plotting arguments
@@ -357,7 +356,7 @@ class WarmingLevelVisualize(param.Parameterized):
         one_warming_level = str(float(self.warmlevel))
         all_plot_data = _select_one_gwl(one_warming_level, self.gwl_snapshots)
         if all_plot_data.all_sims.size != 0:
-            if self.wl_params.variable == "Relative Humidity":
+            if self.wl_params.variable == "Relative humidity":
                 all_plot_data = all_plot_data * 100
 
             # compute stats

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -173,7 +173,7 @@ def get_sliced_data(y, years, window=15, anom="Yes"):
 def _get_cmap(wl_params):
     """Set colormap depending on variable"""
     if (
-        wl_params.variable == "Air Temperature at 2m" 
+        wl_params.variable == "Air Temperature at 2m"
         or wl_params.variable == "Dew point temperature"
     ):
         cmap_name = "ae_orange"


### PR DESCRIPTION
1. Colormaps for variables should be ae_diverging instead of their assigned colormap according to the data_descriptions file, with the exception of air temperature and dew point temperature. This fixes an issue Naomi had noticed specifically for precipitation, but upon testing was relevant for all other vars.
2. The assignment to humidity to 100% when displayed had a typo, now fixed.

----

To test:
Run the warming_levels notebook and make sure that:
- air temp and dew point have ae_orange colormaps
- relative humidity is on a 100% scale (range is not -5 - 5)
- any other variable selection has a diverging colormap