### PR TITLE
Change function to convert calendar to noleapyear for station data

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -942,7 +942,7 @@ def _bias_correct_model_data(
         # Input data, sliced to time period of observational data
         gridded_da.sel(
             time=slice(
-                str(obs_da.time.values[0].year), str(obs_da.time.values[-1].year)
+                str(obs_da.time.values[0].astype('datetime64[Y]')), str(obs_da.time.values[-1].astype('datetime64[Y]'))
             )
         ),
         nquantiles=nquantiles,

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -930,10 +930,11 @@ def _bias_correct_model_data(
     # Rechunk data. Cannot be chunked along time dimension
     # Error raised by xclim: ValueError: Multiple chunks along the main adjustment dimension time is not supported.
     gridded_da = gridded_da.chunk(dict(time=-1))
+    obs_da = obs_da.sel(time=slice(obs_da.time.values[0], "2014-08-31"))
     obs_da = obs_da.chunk(dict(time=-1))
     # Convert calendar to no leap year
-    obs_da.convert_calendar("noleap")
-    gridded_da.convert_calendar("noleap")
+    obs_da = obs_da.convert_calendar("noleap")
+    gridded_da = gridded_da.convert_calendar("noleap")
     # Data at the desired time slice
     data_sliced = gridded_da.sel(time=slice(str(time_slice[0]), str(time_slice[1])))
     # Get QDS
@@ -942,8 +943,8 @@ def _bias_correct_model_data(
         # Input data, sliced to time period of observational data
         gridded_da.sel(
             time=slice(
-                str(obs_da.time.values[0].astype("datetime64[Y]")),
-                str(obs_da.time.values[-1].astype("datetime64[Y]")),
+                str(obs_da.time.values[0]),
+                str(obs_da.time.values[-1]),
             )
         ),
         nquantiles=nquantiles,
@@ -953,6 +954,8 @@ def _bias_correct_model_data(
     # Bias correct the data
     da_adj = QDM.adjust(data_sliced)
     da_adj.name = gridded_da.name  # Rename it to get back to original name
+    da_adj["time"] = da_adj.indexes["time"].to_datetimeindex()
+
     return da_adj
 
 

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -932,8 +932,8 @@ def _bias_correct_model_data(
     gridded_da = gridded_da.chunk(dict(time=-1))
     obs_da = obs_da.chunk(dict(time=-1))
     # Convert calendar to no leap year
-    obs_da = xr.convert_calendar(obs_da, "noleap")
-    gridded_da = xr.convert_calendar(gridded_da, "noleap")
+    obs_da.convert_calendar("noleap")
+    gridded_da.convert_calendar("noleap")
     # Data at the desired time slice
     data_sliced = gridded_da.sel(time=slice(str(time_slice[0]), str(time_slice[1])))
     # Get QDS

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -942,7 +942,8 @@ def _bias_correct_model_data(
         # Input data, sliced to time period of observational data
         gridded_da.sel(
             time=slice(
-                str(obs_da.time.values[0].astype('datetime64[Y]')), str(obs_da.time.values[-1].astype('datetime64[Y]'))
+                str(obs_da.time.values[0].astype("datetime64[Y]")),
+                str(obs_da.time.values[-1].astype("datetime64[Y]")),
             )
         ),
         nquantiles=nquantiles,

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -12,7 +12,6 @@ import warnings
 from functools import partial
 from ast import literal_eval
 from shapely.geometry import box
-from xclim.core.calendar import convert_calendar
 from xclim.sdba import Grouper
 from xclim.sdba.adjustment import QuantileDeltaMapping
 from climakitae.core.boundaries import Boundaries
@@ -933,8 +932,8 @@ def _bias_correct_model_data(
     gridded_da = gridded_da.chunk(dict(time=-1))
     obs_da = obs_da.chunk(dict(time=-1))
     # Convert calendar to no leap year
-    obs_da = convert_calendar(obs_da, "noleap")
-    gridded_da = convert_calendar(gridded_da, "noleap")
+    obs_da = xr.convert_calendar(obs_da, "noleap")
+    gridded_da = xr.convert_calendar(gridded_da, "noleap")
     # Data at the desired time slice
     data_sliced = gridded_da.sel(time=slice(str(time_slice[0]), str(time_slice[1])))
     # Get QDS


### PR DESCRIPTION
This PR replaces `xclim.core.calendar.convert_calendar` which outputs `CFTime` with `xarray.Dataset.convert_calendar` which outputs `datetime64`.