### PR TITLE
Remove sopt from hvplot.image call

### DIFF
--- a/climakitae/core/data_view.py
+++ b/climakitae/core/data_view.py
@@ -13,7 +13,13 @@ def compute_vmin_vmax(da_min, da_max):
     """Compute min, max, and center for plotting"""
     vmin = np.nanpercentile(da_min, 1)
     vmax = np.nanpercentile(da_max, 99)
-    return vmin, vmax
+    # define center for diverging symmetric data
+    if (vmin < 0) and (vmax > 0):
+        # dabs = abs(vmax) - abs(vmin)
+        sopt = True
+    else:
+        sopt = None
+    return vmin, vmax, sopt
 
 
 def view(data, lat_lon=True, width=None, height=None, cmap=None):
@@ -74,13 +80,14 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
         # Such that the colorbar is standardized
         vmin = None
         vmax = None
+        sopt = None
         if "simulation" in data.dims:
             # But, only do this if the data is already read into memory
             # Or else the computation of min and max will take forever
             if data.chunks is None or str(data.chunks) == "Frozen({})":
                 min_data = data.min(dim="simulation")
                 max_data = data.max(dim="simulation")
-                vmin, vmax = compute_vmin_vmax(min_data, max_data)
+                vmin, vmax, sopt = compute_vmin_vmax(min_data, max_data)
 
         # Set default cmap if no user input
         if cmap is None:
@@ -147,6 +154,7 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
                     width=width,
                     height=height,
                     clim=(vmin, vmax),
+                    symmetric=sopt,
                 )
             else:
                 # Make a scatter plot if it's just one grid cell
@@ -164,6 +172,7 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
                     height=height,
                     s=150,  # Size of marker
                     clim=(vmin, vmax),
+                    symmetric=sopt,
                 )
         except:
             # Print message instead of raising error

--- a/climakitae/core/data_view.py
+++ b/climakitae/core/data_view.py
@@ -13,13 +13,7 @@ def compute_vmin_vmax(da_min, da_max):
     """Compute min, max, and center for plotting"""
     vmin = np.nanpercentile(da_min, 1)
     vmax = np.nanpercentile(da_max, 99)
-    # define center for diverging symmetric data
-    if (vmin < 0) and (vmax > 0):
-        # dabs = abs(vmax) - abs(vmin)
-        sopt = True
-    else:
-        sopt = None
-    return vmin, vmax, sopt
+    return vmin, vmax
 
 
 def view(data, lat_lon=True, width=None, height=None, cmap=None):
@@ -80,14 +74,13 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
         # Such that the colorbar is standardized
         vmin = None
         vmax = None
-        sopt = None
         if "simulation" in data.dims:
             # But, only do this if the data is already read into memory
             # Or else the computation of min and max will take forever
             if data.chunks is None or str(data.chunks) == "Frozen({})":
                 min_data = data.min(dim="simulation")
                 max_data = data.max(dim="simulation")
-                vmin, vmax, sopt = compute_vmin_vmax(min_data, max_data)
+                vmin, vmax = compute_vmin_vmax(min_data, max_data)
 
         # Set default cmap if no user input
         if cmap is None:
@@ -154,7 +147,6 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
                     width=width,
                     height=height,
                     clim=(vmin, vmax),
-                    sopt=sopt,
                 )
             else:
                 # Make a scatter plot if it's just one grid cell
@@ -172,7 +164,6 @@ def view(data, lat_lon=True, width=None, height=None, cmap=None):
                     height=height,
                     s=150,  # Size of marker
                     clim=(vmin, vmax),
-                    sopt=sopt,
                 )
         except:
             # Print message instead of raising error


### PR DESCRIPTION
This PR removes the `sopt` parameter that is passed to `hvplot.image` and not recognized. The `sopt` parameter seems to have been used when data is divergent but I am not sure what it's intended purpose was?