### PR TITLE
Fosberg Derived Index fix where statements reclassing data incorrectly

### DIFF
--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -2,6 +2,7 @@
 
 import xarray as xr
 import numpy as np
+import rioxarray
 
 
 def effective_temp(T):
@@ -165,6 +166,7 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
 
     # If fosberg index is negative, set to 0
     #FFWI = xr.where(FFWI > 0, FFWI, 0, keep_attrs=True)
+    FFWI = xr.where((FFWI < 0) & (FFWI != FFWI.rio.nodata), 0, FFWI, keep_attrs=True)
 
     # Reassign coordinate attributes
     # For some reason, these get improperly assigned in the xr.where step

--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -166,7 +166,7 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
 
     # If fosberg index is negative, set to 0
     #FFWI = xr.where(FFWI > 0, FFWI, 0, keep_attrs=True)
-    FFWI = xr.where((FFWI < 0) & (FFWI > -1000), 0, FFWI, keep_attrs=True)
+    #FFWI = xr.where((FFWI < 0) & (FFWI > -1000), 0, FFWI, keep_attrs=True)
 
     # Reassign coordinate attributes
     # For some reason, these get improperly assigned in the xr.where step

--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -162,7 +162,7 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
     FFWI = (n * ((1 + U**2) ** 0.5)) / 0.3002
 
     # If fosberg index > 100, reset to 100
-    FFWI = xr.where(FFWI < 100, FFWI, 100, keep_attrs=True)
+    #FFWI = xr.where(FFWI < 100, FFWI, 100, keep_attrs=True)
 
     # If fosberg index is negative, set to 0
     #FFWI = xr.where(FFWI > 0, FFWI, 0, keep_attrs=True)

--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -2,7 +2,6 @@
 
 import xarray as xr
 import numpy as np
-import rioxarray
 
 
 def effective_temp(T):
@@ -159,7 +158,7 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
 
     # Compute the index
     U = windspeed_mph
-    FFWI = (n * ((1 + U**2) ** 0.5)) / 0.3002
+    FFWI = np.clip((n * ((1 + U**2) ** 0.5)) / 0.3002, 0.0, 100.0)
 
     # If fosberg index > 100, reset to 100
     #FFWI = xr.where(FFWI < 100, FFWI, 100, keep_attrs=True)

--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -161,7 +161,7 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
     FFWI = (n * ((1 + U**2) ** 0.5)) / 0.3002
 
     # If fosberg index > 100, reset to 100
-    #FFWI = xr.where(FFWI < 100, FFWI, 100, keep_attrs=True)
+    FFWI = xr.where(FFWI < 100, FFWI, 100, keep_attrs=True)
 
     # If fosberg index is negative, set to 0
     #FFWI = xr.where(FFWI > 0, FFWI, 0, keep_attrs=True)

--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -161,10 +161,10 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
     FFWI = (n * ((1 + U**2) ** 0.5)) / 0.3002
 
     # If fosberg index > 100, reset to 100
-    FFWI = xr.where(FFWI < 100, FFWI, 100, keep_attrs=True)
+    #FFWI = xr.where(FFWI < 100, FFWI, 100, keep_attrs=True)
 
     # If fosberg index is negative, set to 0
-    FFWI = xr.where(FFWI > 0, FFWI, 0, keep_attrs=True)
+    #FFWI = xr.where(FFWI > 0, FFWI, 0, keep_attrs=True)
 
     # Reassign coordinate attributes
     # For some reason, these get improperly assigned in the xr.where step

--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -158,14 +158,8 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
 
     # Compute the index
     U = windspeed_mph
+    # If the value falls out of [0-100] range clip the value
     FFWI = np.clip((n * ((1 + U**2) ** 0.5)) / 0.3002, 0.0, 100.0)
-
-    # If fosberg index > 100, reset to 100
-    #FFWI = xr.where(FFWI < 100, FFWI, 100, keep_attrs=True)
-
-    # If fosberg index is negative, set to 0
-    #FFWI = xr.where(FFWI > 0, FFWI, 0, keep_attrs=True)
-    #FFWI = xr.where((FFWI < 0) & (FFWI > -1000), 0, FFWI, keep_attrs=True)
 
     # Reassign coordinate attributes
     # For some reason, these get improperly assigned in the xr.where step

--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -166,7 +166,7 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
 
     # If fosberg index is negative, set to 0
     #FFWI = xr.where(FFWI > 0, FFWI, 0, keep_attrs=True)
-    FFWI = xr.where((FFWI < 0) & (FFWI != FFWI.rio.nodata), 0, FFWI, keep_attrs=True)
+    FFWI = xr.where((FFWI < 0) & (FFWI > -1000), 0, FFWI, keep_attrs=True)
 
     # Reassign coordinate attributes
     # For some reason, these get improperly assigned in the xr.where step


### PR DESCRIPTION
This PR changes the way the Fosberg Fire Index is generated. Removes 2 where statements that tried to reclass values < 0 and > 100 to 0 and 100. Unfortunately, the `xr.where` statements reclassified data outside of the spatially clipped region. PR uses `np.clip` to clip values outside of [0-100] to the boundary values.