### PR TITLE
Bug fix on TMY: elevation in export

### DIFF
--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -966,11 +966,11 @@ def write_tmy_file(
             state = station_df.loc[station_df["station id"] == station_code][
                 "state"
             ].values[0]
-            station_code = str(station_code)[:6]
-            timezone = _utc_offset_timezone(lon=stn_lon, lat=stn_lat)
             elevation = station_df.loc[station_df["station id"] == station_code][
                 "elevation"
             ].values[0]
+            station_code = str(station_code)[:6]
+            timezone = _utc_offset_timezone(lon=stn_lon, lat=stn_lat)
 
     # typical meteorological year format
     if file_ext == "tmy":

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -933,6 +933,7 @@ def write_tmy_file(
     stn_lat,
     stn_lon,
     stn_state,
+    stn_elev=0.0,
     file_ext="tmy",
 ):
     """Exports TMY data either as .epw or .tmy file
@@ -941,7 +942,12 @@ def write_tmy_file(
     ---------
     filename_to_export (str): Filename string, constructed with station name and simulation
     df (pd.DataFrame): Dataframe of TMY data to export
-    location_name (str, optional): Location name string, often station name
+    location_name (str): Location name string, often station name
+    station_code (int): Station code 
+    stn_lat (float): Station latitude
+    stn_lon (float): Station longitude
+    stn_state (str): State of station location
+    stn_elev (float, optional): Elevation of station, default is 0.0
     file_ext (str, optional): File extension for export, default is .tmy, options are "tmy" and "epw"
 
     Returns
@@ -962,7 +968,7 @@ def write_tmy_file(
         station_code = station_code
         state = stn_state
         timezone = _utc_offset_timezone(lon=stn_lon, lat=stn_lat)
-        elevation = 0.0  # set to 0 on custom inputs for now
+        elevation = stn_elev  # default of 0.0 on custom inputs if elevation is not provided
 
     elif type(station_code) == int:  # hadisd statio code passed
         # look up info

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -754,7 +754,9 @@ def _utc_offset_timezone(lat, lon):
     return diff
 
 
-def _tmy_header(location_name, station_code, stn_lat, stn_lon, state, timezone, elevation, df):
+def _tmy_header(
+    location_name, station_code, stn_lat, stn_lon, state, timezone, elevation, df
+):
     """
     Constructs the header for the TMY output file in .tmy format
     Source: https://www.nrel.gov/docs/fy08osti/43156.pdf (pg. 3)
@@ -781,7 +783,9 @@ def _tmy_header(location_name, station_code, stn_lat, stn_lon, state, timezone, 
     return headers
 
 
-def _epw_header(location_name, station_code, stn_lat, stn_lon, state, timezone, elevation, df):
+def _epw_header(
+    location_name, station_code, stn_lat, stn_lon, state, timezone, elevation, df
+):
     """
     Constructs the header for the TMY output file in .epw format
     Source: EnergyPlus Version 23.1.0 Documentation
@@ -958,7 +962,7 @@ def write_tmy_file(
         station_code = station_code
         state = stn_state
         timezone = _utc_offset_timezone(lon=stn_lon, lat=stn_lat)
-        elevation = 0.0 # set to 0 on custom inputs for now
+        elevation = 0.0  # set to 0 on custom inputs for now
 
     elif type(station_code) == int:  # hadisd statio code passed
         # look up info
@@ -979,7 +983,14 @@ def write_tmy_file(
         with open(path_to_file, "w") as f:
             f.writelines(
                 _tmy_header(
-                    location_name, station_code, stn_lat, stn_lon, state, timezone, elevation, df
+                    location_name,
+                    station_code,
+                    stn_lat,
+                    stn_lon,
+                    state,
+                    timezone,
+                    elevation,
+                    df,
                 )
             )  # writes required header lines
             df = df.drop(
@@ -999,7 +1010,14 @@ def write_tmy_file(
         with open(path_to_file, "w") as f:
             f.writelines(
                 _epw_header(
-                    location_name, station_code, stn_lat, stn_lon, state, timezone, elevation, df
+                    location_name,
+                    station_code,
+                    stn_lat,
+                    stn_lon,
+                    state,
+                    timezone,
+                    elevation,
+                    df,
                 )
             )  # writes required header lines
             df_string = _epw_format_data(df).to_csv(sep=",", header=False, index=False)

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -943,7 +943,7 @@ def write_tmy_file(
     filename_to_export (str): Filename string, constructed with station name and simulation
     df (pd.DataFrame): Dataframe of TMY data to export
     location_name (str): Location name string, often station name
-    station_code (int): Station code 
+    station_code (int): Station code
     stn_lat (float): Station latitude
     stn_lon (float): Station longitude
     stn_state (str): State of station location
@@ -968,7 +968,9 @@ def write_tmy_file(
         station_code = station_code
         state = stn_state
         timezone = _utc_offset_timezone(lon=stn_lon, lat=stn_lat)
-        elevation = stn_elev  # default of 0.0 on custom inputs if elevation is not provided
+        elevation = (
+            stn_elev  # default of 0.0 on custom inputs if elevation is not provided
+        )
 
     elif type(station_code) == int:  # hadisd statio code passed
         # look up info

--- a/climakitae/data/hadisd_stations.csv
+++ b/climakitae/data/hadisd_stations.csv
@@ -1,34 +1,34 @@
-,state,station,city,ID,LAT_Y,LON_X,station id
-0,CA,Bakersfield Meadows Field (KBFL),Bakersfield,KBFL,35.43424,-119.05524,72384023155
-1,CA,Blythe Asos (KBLH),Blythe,KBLH,33.61876,-114.71451,74718823158
-2,CA,Burbank-Glendale-Pasadena Airport (KBUR),Burbank,KBUR,34.19966,-118.36543,72288023152
-3,CA,Needles Airport (KEED),Needles,KEED,34.76783,-114.61842,72380523179
-4,CA,Fresno Yosemite International Airport (KFAT),Fresno,KFAT,36.77999,-119.72016,72389093193
-5,CA,Imperial County Airport (KIPL),Imperial,KIPL,32.83464,-115.57656,74718503144
-6,CA,Los Angeles International Airport (KLAX),Lax,KLAX,33.93816,-118.3866,72295023174
-7,CA,Long Beach Daugherty Field (KLGB),Long Beach,KLGB,33.81177,-118.14718,72297023129
-8,CA,Modesto City-County Airport (KMOD),Modesto,KMOD,37.62544,-120.95492,72492623258
-9,CA,San Diego Miramar Wscmo (KNKX),Miramar,KNKX,32.866667,-117.133333,72293193107
-10,CA,Oakland Metro International Airport (KOAK),Oakland,KOAK,37.7178,-122.23301,72493023230
-11,CA,Oxnard Ventura County Airport (KOXR),Oxnard,KOXR,34.20012,-119.20417,72392793110
-12,CA,Palm Springs Regional Airport (KPSP),Palm Springs,KPSP,33.82216,-116.50433,72286893138
-13,CA,Riverside Municipal Airport (KRAL),Riverside,KRAL,33.95282,-117.43523,72286903171
-14,CA,Red Bluff Municipal Airport (KRBL),Red Bluff,KRBL,40.15186,-122.25478,72591024216
-15,CA,Sacramento Executive Airport (KSAC),Sacramento,KSAC,38.50659,-121.49604,72483023232
-16,CA,San Diego Lindbergh Field (KSAN),San Diego,KSAN,32.7336,-117.1831,72290023188
-17,CA,Santa Barbara Municipal Airport (KSBA),Santa Barbara,KSBA,34.4241,-119.84249,72392523190
-18,CA,San Luis Obispo Airport (KSBP),San Luis Obispo,KSBP,35.23815,-120.64406,72289793206
-19,CA,Gillespie Field Airport (KSEE),Santee,KSEE,32.826111,-116.9725,72290753143
-20,CA,San Francisco International Airport (KSFO),San Francisco,KSFO,37.61962,-122.36562,72494023234
-21,CA,San Jose International Airport (KSJC),San Jose,KSJC,37.35938,-121.92444,72494523293
-22,CA,Santa Ana John Wayne Airport (KSNA),Santa Ana,KSNA,33.67975,-117.86746,72297793184
-23,CA,Desert Resorts Regional Airport (KTRM),Thermal,KTRM,33.63166,-116.16412,74718703104
-24,CA,Ukiah Municipal Airport (KUKI),Ukiah,KUKI,39.12781,-123.20015,72590523275
-25,CA,Lancaster William J Fox Field (KWJF),Lancaster,KWJF,34.74121,-118.21255,72381603159
-26,CA,Arcata Eureka Airport (KACV),Arcata,KACV,40.97844,-124.10479,72594524283
-27,CA,Stockton Airport (KSCK),Stockton,KSCK,37.88997,-121.22637,72492023237
-28,CA,Redding Airport (KRDD),Redding,KRDD,40.51462,-122.29773,72592024257
-29,CA,Merced Municipal Airport MacReady Field (KMCE),Merced,KMCE,37.285,-120.514,72481523257
-30,NV,McCarran International Airport (KLAS),Las Vegas,KLAS,36.072,-115.163,72386023169
-31,CA,Downtown Los Angeles USC Campus (KCQT),Los Angeles,KCQT,34.024,-118.291,72287493134
-32,CA,Ontario International Airport (KONT),Ontario,KONT,34.067,-117.65,74704003102
+,state,station,city,ID,LAT_Y,LON_X,station id,elevation
+0,CA,Bakersfield Meadows Field (KBFL),Bakersfield,KBFL,35.43424,-119.05524,72384023155,149.3
+1,CA,Blythe Asos (KBLH),Blythe,KBLH,33.61876,-114.71451,74718823158,120.4
+2,CA,Burbank-Glendale-Pasadena Airport (KBUR),Burbank,KBUR,34.19966,-118.36543,72288023152,222.7
+3,CA,Needles Airport (KEED),Needles,KEED,34.76783,-114.61842,72380523179,270.6
+4,CA,Fresno Yosemite International Airport (KFAT),Fresno,KFAT,36.77999,-119.72016,72389093193,101.9
+5,CA,Imperial County Airport (KIPL),Imperial,KIPL,32.83464,-115.57656,74718503144,-16
+6,CA,Los Angeles International Airport (KLAX),Lax,KLAX,33.93816,-118.3866,72295023174,29.7
+7,CA,Long Beach Daugherty Field (KLGB),Long Beach,KLGB,33.81177,-118.14718,72297023129,10.2
+8,CA,Modesto City-County Airport (KMOD),Modesto,KMOD,37.62544,-120.95492,72492623258,26.6
+9,CA,San Diego Miramar Wscmo (KNKX),Miramar,KNKX,32.866667,-117.133333,72293193107,145.7
+10,CA,Oakland Metro International Airport (KOAK),Oakland,KOAK,37.7178,-122.23301,72493023230,1.5
+11,CA,Oxnard Ventura County Airport (KOXR),Oxnard,KOXR,34.20012,-119.20417,72392793110,11.9
+12,CA,Palm Springs Regional Airport (KPSP),Palm Springs,KPSP,33.82216,-116.50433,72286893138,145
+13,CA,Riverside Municipal Airport (KRAL),Riverside,KRAL,33.95282,-117.43523,72286903171,249
+14,CA,Red Bluff Municipal Airport (KRBL),Red Bluff,KRBL,40.15186,-122.25478,72591024216,108.1
+15,CA,Sacramento Executive Airport (KSAC),Sacramento,KSAC,38.50659,-121.49604,72483023232,5.9
+16,CA,San Diego Lindbergh Field (KSAN),San Diego,KSAN,32.7336,-117.1831,72290023188,4.6
+17,CA,Santa Barbara Municipal Airport (KSBA),Santa Barbara,KSBA,34.4241,-119.84249,72392523190,2.5
+18,CA,San Luis Obispo Airport (KSBP),San Luis Obispo,KSBP,35.23815,-120.64406,72289793206,65
+19,CA,Gillespie Field Airport (KSEE),Santee,KSEE,32.826111,-116.9725,72290753143,118
+20,CA,San Francisco International Airport (KSFO),San Francisco,KSFO,37.61962,-122.36562,72494023234,3.2
+21,CA,San Jose International Airport (KSJC),San Jose,KSJC,37.35938,-121.92444,72494523293,15
+22,CA,Santa Ana John Wayne Airport (KSNA),Santa Ana,KSNA,33.67975,-117.86746,72297793184,13
+23,CA,Desert Resorts Regional Airport (KTRM),Thermal,KTRM,33.63166,-116.16412,74718703104,-36
+24,CA,Ukiah Municipal Airport (KUKI),Ukiah,KUKI,39.12781,-123.20015,72590523275,183.7
+25,CA,Lancaster William J Fox Field (KWJF),Lancaster,KWJF,34.74121,-118.21255,72381603159,712.6
+26,CA,Arcata Eureka Airport (KACV),Arcata,KACV,40.97844,-124.10479,72594524283,64.5
+27,CA,Stockton Airport (KSCK),Stockton,KSCK,37.88997,-121.22637,72492023237,8.3
+28,CA,Redding Airport (KRDD),Redding,KRDD,40.51462,-122.29773,72592024257,153
+29,CA,Merced Municipal Airport MacReady Field (KMCE),Merced,KMCE,37.285,-120.514,72481523257,48
+30,NV,McCarran International Airport (KLAS),Las Vegas,KLAS,36.072,-115.163,72386023169,662.8
+31,CA,Downtown Los Angeles USC Campus (KCQT),Los Angeles,KCQT,34.024,-118.291,72287493134,54.6
+32,CA,Ontario International Airport (KONT),Ontario,KONT,34.067,-117.65,74704003102,303.9


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
Previously, TMY file export was breaking on using an API requests call to the EPQS DEM to obtain elevation. As far as I can tell, this is on the EPQS side of things and not on our code base. To address this, I added the corresponding elevation values from `wecc-station` csv to the `hadisd_stations` csv file that is used in the climakitae backend, and modified the TMY code to obtain the corresponding elevation value when requested. At present, when a custom location is passed, elevation is set to 0. This will be a future fix. 

**Relevant motivation and context**

**Dependencies required for this change?**
N/A

**Fixes # (issue), delete if not necessary**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**
To test, please run the TMY notebook and ensure that both .tmy and .epw files are produced

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works -- N/A
- [ ] New and existing unit tests pass locally with my changes -- N/A
- [x] Any dependent changes have been merged and published in downstream modules

