### PR TITLE
Large Data Warnings

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1186,11 +1186,15 @@ class DataParameters(param.Parameterized):
                 )
             elif da.nbytes >= int(5e9) and da.nbytes < int(1e10):
                 print(
-                    "!! Returned data array is very large and operations will take considerably more time !!"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "!! Returned data array is very large and operations will take considerably more time !!\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
                 )
             elif da.nbytes >= int(1e10):
                 print(
-                    "!!! Returned data array is huge and operations will take vastly more time !!!"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "!!! Returned data array is huge and operations will take vastly more time !!!\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
                 )
 
         if config is not None:

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1180,9 +1180,9 @@ class DataParameters(param.Parameterized):
         def warnoflargefilesize(da):
             if da.nbytes >= int(1e9) and da.nbytes < int(5e9):
                 print(
-                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-                    "! Returned data array is large and operations will take extra time !"
-                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "! Returned data array is large and operations will take extra time !\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
                 )
             elif da.nbytes >= int(5e9) and da.nbytes < int(1e10):
                 print(

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1188,7 +1188,7 @@ class DataParameters(param.Parameterized):
             raise ValueError(
                 "COULD NOT RETRIEVE DATA: For the provided data selections, there is not sufficient data to retrieve. Try selecting a larger spatial area, or a higher resolution. Returning None."
             )
-
+        print("Test print output...")
 
 class DataParametersWithPanes(DataParameters):
     """Extends DataParameters class to include panel widgets that display the time scale and a map overview"""

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1180,7 +1180,9 @@ class DataParameters(param.Parameterized):
         def warnoflargefilesize(da):
             if da.nbytes >= int(1e9) and da.nbytes < int(5e9):
                 print(
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
                     "! Returned data array is large and operations will take extra time !"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
                 )
             elif da.nbytes >= int(5e9) and da.nbytes < int(1e10):
                 print(

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1513,7 +1513,7 @@ def _display_select(self):
             pn.Column(
                 widgets["downscaling_method_text"],
                 widgets["downscaling_method"],
-                width=270,
+                width=300,
             ),
             pn.Column(
                 widgets["data_warning"],

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1175,6 +1175,7 @@ class DataParameters(param.Parameterized):
             Only an option if a config file is provided.
 
         """
+        print("Test print output...")
         if config is not None:
             if type(config) == str:
                 return read_catalog_from_csv(self, config, merge)
@@ -1188,7 +1189,6 @@ class DataParameters(param.Parameterized):
             raise ValueError(
                 "COULD NOT RETRIEVE DATA: For the provided data selections, there is not sufficient data to retrieve. Try selecting a larger spatial area, or a higher resolution. Returning None."
             )
-        print("Test print output...")
 
 class DataParametersWithPanes(DataParameters):
     """Extends DataParameters class to include panel widgets that display the time scale and a map overview"""

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1175,7 +1175,7 @@ class DataParameters(param.Parameterized):
             Only an option if a config file is provided.
 
         """
-        print("<span style="color:red">Test print output...</span>")
+        print("<span style=""color:red"">Test print output...</span>")
         if config is not None:
             if type(config) == str:
                 return read_catalog_from_csv(self, config, merge)

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1179,11 +1179,17 @@ class DataParameters(param.Parameterized):
 
         def warnoflargefilesize(da):
             if da.nbytes >= int(1e9) and da.nbytes < int(5e9):
-                print("! Returned data array is large and operations will take extra time !")
+                print(
+                    "! Returned data array is large and operations will take extra time !"
+                )
             elif da.nbytes >= int(5e9) and da.nbytes < int(1e10):
-                print("!! Returned data array is very large and operations will take considerably more time !!")
+                print(
+                    "!! Returned data array is very large and operations will take considerably more time !!"
+                )
             elif da.nbytes >= int(1e10):
-                print("!!! Returned data array is huge and operations will take vastly more time !!!")
+                print(
+                    "!!! Returned data array is huge and operations will take vastly more time !!!"
+                )
 
         if config is not None:
             if type(config) == str:

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1179,7 +1179,11 @@ class DataParameters(param.Parameterized):
 
         def warnoflargefilesize(da):
             if da.nbytes > int(1e9):
-                print("Returned data is large and operations may take some time.")
+                print("! Returned data array is large and operations will take extra time !")
+            elif da.nbytes > int(5e9):
+                print("!! Returned data array is very large and operations will take considerably more time !!")
+            elif da.nbytes > int(1e10):
+                print("!!! Returned data array is huge and operations will take vastly more time !!!")
 
         if config is not None:
             if type(config) == str:

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1178,11 +1178,11 @@ class DataParameters(param.Parameterized):
         """
 
         def warnoflargefilesize(da):
-            if da.nbytes > int(1e9):
+            if da.nbytes >= int(1e9) and da.nbytes < int(5e9):
                 print("! Returned data array is large and operations will take extra time !")
-            elif da.nbytes > int(5e9):
+            elif da.nbytes >= int(5e9) and da.nbytes < int(1e10):
                 print("!! Returned data array is very large and operations will take considerably more time !!")
-            elif da.nbytes > int(1e10):
+            elif da.nbytes >= int(1e10):
                 print("!!! Returned data array is huge and operations will take vastly more time !!!")
 
         if config is not None:

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1175,7 +1175,7 @@ class DataParameters(param.Parameterized):
             Only an option if a config file is provided.
 
         """
-        print("Test print output...")
+        print("<span style="color:red">Test print output...</span>")
         if config is not None:
             if type(config) == str:
                 return read_catalog_from_csv(self, config, merge)
@@ -1189,6 +1189,7 @@ class DataParameters(param.Parameterized):
             raise ValueError(
                 "COULD NOT RETRIEVE DATA: For the provided data selections, there is not sufficient data to retrieve. Try selecting a larger spatial area, or a higher resolution. Returning None."
             )
+
 
 class DataParametersWithPanes(DataParameters):
     """Extends DataParameters class to include panel widgets that display the time scale and a map overview"""

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1513,7 +1513,7 @@ def _display_select(self):
             pn.Column(
                 widgets["downscaling_method_text"],
                 widgets["downscaling_method"],
-                width=300,
+                width=325,
             ),
             pn.Column(
                 widgets["data_warning"],

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1,4 +1,5 @@
 import os
+import xarray as xr
 import pandas as pd
 import geopandas as gpd
 from shapely.geometry import box, Polygon
@@ -1175,20 +1176,30 @@ class DataParameters(param.Parameterized):
             Only an option if a config file is provided.
 
         """
-        print("<span style=""color:red"">Test print output...</span>")
+
+        def warnoflargefilesize(da):
+            if da.nbytes > int(1e9):
+                print("Returned data is large and operations may take some time.")
+
         if config is not None:
             if type(config) == str:
-                return read_catalog_from_csv(self, config, merge)
+                data_return = read_catalog_from_csv(self, config, merge)
             else:
                 raise ValueError(
                     "To retrieve data specified in a configuration file, please input the path to your local configuration csv as a string"
                 )
         try:
-            return read_catalog_from_select(self)
+            data_return = read_catalog_from_select(self)
         except:
             raise ValueError(
                 "COULD NOT RETRIEVE DATA: For the provided data selections, there is not sufficient data to retrieve. Try selecting a larger spatial area, or a higher resolution. Returning None."
             )
+        if isinstance(data_return, list):
+            for l in data_return:
+                warnoflargefilesize(l)
+        else:
+            warnoflargefilesize(data_return)
+        return data_return
 
 
 class DataParametersWithPanes(DataParameters):

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1180,21 +1180,21 @@ class DataParameters(param.Parameterized):
         def warnoflargefilesize(da):
             if da.nbytes >= int(1e9) and da.nbytes < int(5e9):
                 print(
-                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
-                    "! Returned data array is large and operations will take extra time !\n"
-                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "! Returned data array is large. Operations could take up to 5x longer than 1GB of data!\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
                 )
             elif da.nbytes >= int(5e9) and da.nbytes < int(1e10):
                 print(
-                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
-                    "!! Returned data array is very large and operations will take considerably more time !!\n"
-                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "!! Returned data array is very large. Operations could take up to 8x longer than 1GB of data !!\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
                 )
             elif da.nbytes >= int(1e10):
                 print(
-                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
-                    "!!! Returned data array is huge and operations will take vastly more time !!!\n"
-                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                    "!!! Returned data array is huge. Operations could take 10x to infinity longer than 1GB of data !!!\n"
+                    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
                 )
 
         if config is not None:

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -79,7 +79,7 @@ def load(xr_da):
             ),
             end="",
         )
-        da_computed = xr_da.compute()
+        da_computed = xr_da.load()
         print("complete!")
         return da_computed  # Load data into memory and return
 

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -79,7 +79,7 @@ def load(xr_da):
             ),
             end="",
         )
-        da_computed = xr_da.load()
+        da_computed = xr_da.compute()
         print("complete!")
         return da_computed  # Load data into memory and return
 


### PR DESCRIPTION
# Description of PR

This PR adds data warnings for when users pick large amounts of data that will take long periods to run operations.

**Summary of changes and related issue**

Adding data warnings for data retrieved over 1GB in size. Data over 5GB given more emphatic message. Data over 10GB given a sever warning.

**Relevant motivation and context**

User can download very large datasets without knowing the consequences of doing so as far as run time on even the simplest of operations. As warning before retrieval is not ideal due to different paths to access the data it seemed warranted to put a warning after data retrieval but before trying to load into memory. 

**Dependencies required for this change?**

None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [x] Tested on HUB with various data returns of different sizes.

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

