### PR TITLE
Add statsmodels package to requirements.txt to pin readthedocs build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ scipy==1.9.1
 shapely==1.8.4
 pygeos==0.13
 xclim==0.42.0
-
+statsmodels==0.14.1


### PR DESCRIPTION
# Description of PR

ReadtheDocs build is failing on `statsmodels` requirement from `xclim==0.42.0`. For some reason it is trying older and older versions to find compatiable `dask_expr` package. Attempting to pin `statsmodels==0.14.1` which was last successful build version.

**Summary of changes and related issue**

**Relevant motivation and context**

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

