### PR TITLE
Creating Library Logger

### DIFF
--- a/climakitae/util/dev_logging.py
+++ b/climakitae/util/dev_logging.py
@@ -1,3 +1,30 @@
+"""
+Notes about this logger (Updated 5/1/24):
+
+This logger is to be used for developers who want to see a comprehensive view of the function call stacks of any functions
+within `climakitae`. In order to use this logger, you must do the following:
+
+    from climakitae.util.dev_logging import _enable_lib_logging, _disable_lib_logging
+    from climakitae import YOUR_MODULE_HERE
+
+    _enable_lib_logging(YOUR_MODULE_HERE)
+    # To disable it after you're done viewing the logger: _disable_lib_logging(YOUR_MODULE_HERE)
+
+Once you've enabled the logger, you should be able to view comprehensive call-stacks and runtimes for functions within that module,
+and other functions within submodules or subclasses within that module. The logger does its best to try and find all `climakitae` functions
+that are within this module or any sub-modules (while avoiding putting repeated wrappers), but it is best practice to wrap each module that
+you are interested in logging separately. I.e.:
+
+    _enable_lib_logging(YOUR_MODULE_HERE_1)
+    _enable_lib_logging(YOUR_MODULE_HERE_2)
+
+
+Some limitations of this logger include:
+    1. If you interrupt function calls that are wrapped with this logger, it will not reset the `indentation_level` of printed calls.
+    What would need to happen in order to resolve this is for you to disable and re-enable the library logger.
+
+"""
+
 import time
 import types
 import importlib
@@ -6,12 +33,12 @@ import importlib
 indentation_level = 0
 
 
-def log(func):
+def _log(func):
     """
     Wraps around existing functions, adding print statements upon execution and the amount of time it takes for execution. Allows function's call-stack to be viewed for all sub-functions that also have this wrapper.
     """
 
-    def wrapper(*args, **kwargs):
+    def _wrapper(*args, **kwargs):
         """Wraps timer and print statement around functions if `lib_log_enabled` is True, otherwise
         just return the function's result."""
         global indentation_level
@@ -26,12 +53,11 @@ def log(func):
             + f"Execution time for {func.__name__}: {end_time - start_time:.4g}"
         )
         return results
-        # return func(*args, **kwargs)
 
-    return wrapper
+    return _wrapper
 
 
-def enable_lib_logging(obj):
+def _enable_lib_logging(obj):
     """
     Adds the `log` wrapper to all functions and sub-classes within the given module or class.
 
@@ -57,7 +83,7 @@ def enable_lib_logging(obj):
 
                     # Only add loggers to functions within AE
                     if "climakitae" in res.__module__:
-                        setattr(obj, name, log(res))
+                        setattr(obj, name, _log(res))
 
                 # Check if the object is a class type, is not the literal string '__class__', and is created within climakitae.
                 elif (
@@ -66,12 +92,12 @@ def enable_lib_logging(obj):
                     and res.__module__[:10] == "climakitae"
                 ):
                     # Recursively add logging wrapper to any classes within the passed in module/class.
-                    enable_lib_logging(res)
+                    _enable_lib_logging(res)
     else:
         print("Error: Current object is not a module object.")
 
 
-def disable_lib_logging(module):
+def _disable_lib_logging(module):
     """
     Removes the `log` wrapper to all functions within the given module.
     """
@@ -79,21 +105,3 @@ def disable_lib_logging(module):
     # I have tried to reference a `__wrapped__` attribute on wrapped functions, but they don't seem to exist.
     importlib.reload(module)
     return
-
-
-# def enable_lib_logging():
-#     """
-#     Enables library logging.
-#     """
-#     global lib_log_enabled
-#     if not lib_log_enabled:
-#         lib_log_enabled = True
-
-
-# def disable_lib_logging():
-#     """
-#     Disables library logging.
-#     """
-#     global lib_log_enabled
-#     if lib_log_enabled:
-#         lib_log_enabled = False

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -64,20 +64,21 @@ def add_log_wrapper(obj):
         for name in dir(obj):
             res = getattr(obj, name)
 
+            # Do not add loggers to any innate functions
             if not name.startswith('__') and not name.endswith('__'):
 
                 print(f"Curr res name: {res}")
                 print(f"Curr name: {name}")
                 import pdb; pdb.set_trace()
 
-                # Do not add loggers to any functions not from climakitae
-                if res and 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
-                    if isinstance(res, types.FunctionType):
+                # Only add loggers to objects that are functions
+                if isinstance(res, types.FunctionType):
+                    
+                    # Only add loggers to functions within AE
+                    if 'climakitae' in res.__module__:
                         
-                        # Do not add loggers to innate functions
-                        if not name.startswith('__') and not name.endswith('__'):
-                            print(f"Name of obj getting attr'd: {name}")
-                            setattr(obj, name, log(res))
+                        print(f"Name of obj getting attr'd: {name}")
+                        setattr(obj, name, log(res))
                     
                     # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
                     elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -64,16 +64,14 @@ def add_log_wrapper(obj):
         for name in dir(obj):
             res = getattr(obj, name)
 
-            import pdb; pdb.set_trace()
-            
+            print(f"Curr res name: {res}")    
             # Do not add loggers to any functions not from climakitae
-            if res.__module__ == 'climakitae': # CALVIN- Move this line of logic elsewhere
+            if 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
                 if isinstance(res, types.FunctionType):
                     
                     # Do not add loggers to innate functions
                     if not name.startswith('__') and not name.endswith('__'):
-                        print(name)
-                        import pdb; pdb.set_trace()
+                        print(f"Name of obj getting attr'd: {name}")
                         setattr(obj, name, log(res))
                 
                 # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -1,31 +1,9 @@
 import time
 import types
-from functools import wraps
 import importlib
-
-# Define global variables to control logging
-lib_log_enabled = False  # For developers
 
 # Controls the amount of indentation for library logging
 indentation_level = 0
-
-
-def enable_lib_logging():
-    """
-    Enables library logging.
-    """
-    global lib_log_enabled
-    if not lib_log_enabled:
-        lib_log_enabled = True
-
-
-def disable_lib_logging():
-    """
-    Disables library logging.
-    """
-    global lib_log_enabled
-    if lib_log_enabled:
-        lib_log_enabled = False
 
 
 def log(func):
@@ -53,7 +31,7 @@ def log(func):
     return wrapper
 
 
-def add_log_wrapper(obj):
+def enable_lib_logging(obj):
     """
     Adds the `log` wrapper to all functions and sub-classes within the given module or class.
 
@@ -83,12 +61,12 @@ def add_log_wrapper(obj):
                     and res.__module__[:10] == "climakitae"
                 ):
                     # Recursively add logging wrapper to any classes within the passed in module/class.
-                    add_log_wrapper(res)
+                    enable_lib_logging(res)
     else:
         print("Error: Current object is not a module object.")
 
 
-def remove_log_wrapper(module):
+def disable_lib_logging(module):
     """
     Removes the `log` wrapper to all functions within the given module.
     """
@@ -96,3 +74,22 @@ def remove_log_wrapper(module):
     # I have tried to reference a `__wrapped__` attribute on wrapped functions, but they don't seem to exist.
     importlib.reload(module)
     return
+
+
+
+# def enable_lib_logging():
+#     """
+#     Enables library logging.
+#     """
+#     global lib_log_enabled
+#     if not lib_log_enabled:
+#         lib_log_enabled = True
+
+
+# def disable_lib_logging():
+#     """
+#     Disables library logging.
+#     """
+#     global lib_log_enabled
+#     if lib_log_enabled:
+#         lib_log_enabled = False

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -1,0 +1,99 @@
+import logging
+import inspect
+import functools
+import sys
+
+# Configure the logging system
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Define a global flag to control logging
+logging_enabled = False
+
+# Define a list of allowed module names
+allowed_modules = ['climakitae'] 
+
+current_logging_status = lambda: logging_enabled
+
+def enable_logging():
+    """
+    Enable logging for library functions, methods, and class instantiations.
+    """
+    global logging_enabled
+    logging_enabled = True
+    
+def disable_logging():
+    """
+    Disable logging for library functions, methods, and class instantiations.
+    """
+    global logging_enabled
+    logging_enabled = False
+    
+def log(func):
+    def wrapper(*args, **kwargs):
+        if logging_enabled:
+            print(f"Executing function: {func.__name__}")
+        return func(*args, **kwargs)
+    return wrapper
+
+
+
+# def log_function_execution(func):
+#     """
+#     Decorator function to log the name of the currently executing function or method if its module name starts with `climakitae`.
+#     """
+#     @functools.wraps(func)
+#     def wrapper(*args, **kwargs):
+#         if logging_enabled:
+#             # Get the module name of the function or method
+#             module_name = func.__module__
+
+#             # Check if the module name starts with 'climakitae'
+#             if module_name.startswith('climakitae'):
+#                 logging.info(f"Executing function or method: {func.__name__} in module: {module_name}")
+#         return func(*args, **kwargs)
+    
+#     # Return the wrapped function or method
+#     return wrapper
+
+# def log_class_instantiation(cls):
+#     """
+#     Decorator function to log the instantiation of a class if its module name starts with `climakitae`.
+#     """
+#     class WrappedClass(cls):
+#         def __new__(cls, *args, **kwargs):
+#             if logging_enabled:
+#                 # Get the module name of the class
+#                 module_name = cls.__module__
+#                 # Check if the module name starts with `climakitae`
+#                 if module_name.startswith('climakitae'):
+#                     logging.info(f"Instantiating class: {cls.__name__} in module: {module_name}")
+            
+#             # Create an instance of the class
+#             instance = super().__new__(cls)
+
+#             # Decorate functions/methods within the class
+#             for name, obj in inspect.getmembers(instance):
+#                 if inspect.isfunction(obj) or inspect.ismethod(obj):
+#                     setattr(instance, name, log_function_execution(obj))
+
+#             return instance
+    
+#     return WrappedClass
+
+# def apply_logging_to_library_functions_and_methods():
+#     """
+#     Apply logging wrapper to all functions, methods, and classes within allowed modules.
+#     """
+#     for module_name in allowed_modules:
+#         module = sys.modules[module_name]
+#         for name, obj in inspect.getmembers(module):
+#             if inspect.isfunction(obj) or inspect.ismethod(obj):
+#                 setattr(module, name, log_function_execution(obj))
+#             elif inspect.isclass(obj):
+#                 pass
+#                 # setattr(module, name, log_class_instantiation(obj))
+
+# # Apply logging to all functions, methods, and classes within `climakitae`
+# # apply_logging_to_library_functions_and_methods()
+
+

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -67,8 +67,9 @@ def add_log_wrapper(obj):
                  
                  # Only add loggers to custom-created functions
                  if not name.startswith('__') and not name.endswith('__'):
-
+                    print(name)
                     import pdb; pdb.set_trace()
+                    
                     setattr(obj, name, log(res))
             
             # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -75,7 +75,7 @@ def log(func):
             indentation_level -= 1
             end_time = time.time()
             print(
-                "  " * indentation_level
+                "    " * indentation_level
                 + f"Execution time for {func.__name__}: {end_time - start_time:.4g}"
             )
             return results

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -65,7 +65,7 @@ def add_log_wrapper(obj):
             res = getattr(obj, name)
             
             # Do not add loggers to any functions not from climakitae
-            if res.__module__ == 'climakitae':
+            if res.__module__ == 'climakitae': # CALVIN- Move this line of logic elsewhere
                 if isinstance(res, types.FunctionType):
                     
                     # Do not add loggers to innate functions

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -63,18 +63,20 @@ def add_log_wrapper(obj):
     if isinstance(obj, types.ModuleType) or isinstance(obj, type):
         for name in dir(obj):
             res = getattr(obj, name)
-            if isinstance(res, types.FunctionType):
-                 
-                 # Only add loggers to custom-created functions
-                 if not name.startswith('__') and not name.endswith('__'):
-                    print(name)
-                    import pdb; pdb.set_trace()
-                    
-                    setattr(obj, name, log(res))
             
-            # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
-            elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':
-                add_log_wrapper(res)
+            # Do not add loggers to any functions not from climakitae
+            if res.__module__ == 'climakitae':
+                if isinstance(res, types.FunctionType):
+                    
+                    # Do not add loggers to innate functions
+                    if not name.startswith('__') and not name.endswith('__'):
+                        print(name)
+                        import pdb; pdb.set_trace()
+                        setattr(obj, name, log(res))
+                
+                # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
+                elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':
+                    add_log_wrapper(res)
     else:
         print("Error: Current object is not a module object.")
 

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -32,12 +32,11 @@ def log(func):
     """
     Wraps around existing functions, adding print statements upon execution and the amount of time it takes for execution. Allows function's call-stack to be viewed for all sub-functions that also have this wrapper.
     """
-    global lib_log_enabled
+    global lib_log_enabled, indentation_level
 
     def wrapper(*args, **kwargs):
         """Wraps timer and print statement around functions if `lib_log_enabled` is True, otherwise
         just return the function's result."""
-        global indentation_level
         if lib_log_enabled:
             start_time = time.time()
             print("    " * indentation_level + f"Executing function: {func.__name__}")

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -64,20 +64,23 @@ def add_log_wrapper(obj):
         for name in dir(obj):
             res = getattr(obj, name)
 
-            print(f"Curr res name: {res}")
-            import pdb; pdb.set_trace()
-            # Do not add loggers to any functions not from climakitae
-            if 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
-                if isinstance(res, types.FunctionType):
-                    
-                    # Do not add loggers to innate functions
-                    if not name.startswith('__') and not name.endswith('__'):
-                        print(f"Name of obj getting attr'd: {name}")
-                        setattr(obj, name, log(res))
+            if not name.startswith('__') and not name.endswith('__'):
+
+                print(f"Curr res name: {res}")
+                print(f"Curr name: {name}")
                 
-                # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
-                elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':
-                    add_log_wrapper(res)
+                # Do not add loggers to any functions not from climakitae
+                if 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
+                    if isinstance(res, types.FunctionType):
+                        
+                        # Do not add loggers to innate functions
+                        if not name.startswith('__') and not name.endswith('__'):
+                            print(f"Name of obj getting attr'd: {name}")
+                            setattr(obj, name, log(res))
+                    
+                    # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
+                    elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':
+                        add_log_wrapper(res)
     else:
         print("Error: Current object is not a module object.")
 

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -59,12 +59,12 @@ def add_log_wrapper(obj):
     """
     Adds the `log` wrapper to all functions within the given module.
     """
-    import pdb; pdb.set_trace()
     # Check if the module 
     if isinstance(obj, types.ModuleType) or isinstance(obj, type):
         for name in dir(obj):
             res = getattr(obj, name)
             if isinstance(res, types.FunctionType):
+                import pdb; pdb.set_trace()
                 setattr(obj, name, log(res))
             
             # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -68,7 +68,8 @@ def add_log_wrapper(obj):
 
                 print(f"Curr res name: {res}")
                 print(f"Curr name: {name}")
-                
+                import pdb; pdb.set_trace()
+
                 # Do not add loggers to any functions not from climakitae
                 if 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
                     if isinstance(res, types.FunctionType):

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -6,7 +6,6 @@ from functools import wraps
 import importlib
 
 # Define global variables to control logging
-app_log_enabled = False  # For users
 lib_log_enabled = False  # For developers
 
 # Controls the amount of indentation for library logging
@@ -32,7 +31,6 @@ class NewlineHandler(logging.Handler):
 # Create the extra handlers for new lines
 newline_handler = NewlineHandler()
 newline_handler.setLevel(logging.DEBUG)
-
 
 ### Functions to enable or disable logging in notebooks
 

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -13,20 +13,19 @@ def log(func):
     def wrapper(*args, **kwargs):
         """Wraps timer and print statement around functions if `lib_log_enabled` is True, otherwise
         just return the function's result."""
-        global lib_log_enabled, indentation_level
-        if lib_log_enabled:
-            start_time = time.time()
-            print("    " * indentation_level + f"Executing function: {func.__name__}")
-            indentation_level += 1
-            results = func(*args, **kwargs)
-            indentation_level -= 1
-            end_time = time.time()
-            print(
-                "    " * indentation_level
-                + f"Execution time for {func.__name__}: {end_time - start_time:.4g}"
-            )
-            return results
-        return func(*args, **kwargs)
+        global indentation_level
+        start_time = time.time()
+        print("    " * indentation_level + f"Executing function: {func.__name__}")
+        indentation_level += 1
+        results = func(*args, **kwargs)
+        indentation_level -= 1
+        end_time = time.time()
+        print(
+            "    " * indentation_level
+            + f"Execution time for {func.__name__}: {end_time - start_time:.4g}"
+        )
+        return results
+        # return func(*args, **kwargs)
 
     return wrapper
 

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -71,7 +71,7 @@ def add_log_wrapper(obj):
                 import pdb; pdb.set_trace()
 
                 # Do not add loggers to any functions not from climakitae
-                if 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
+                if not res.__module and 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
                     if isinstance(res, types.FunctionType):
                         
                         # Do not add loggers to innate functions

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -64,10 +64,10 @@ def add_log_wrapper(obj):
     if isinstance(obj, types.ModuleType) or isinstance(obj, type):
         for name in dir(obj):
             res = getattr(obj, name)
-            if isinstance(res, type):
-                add_log_wrapper(res)
-            elif isinstance(res, types.FunctionType):
+            if isinstance(res, types.FunctionType):
                 setattr(obj, name, log(res))
+            elif isinstance(res, type) and name != '__class__':
+                add_log_wrapper(res)
     else:
         print("Error: Current object is not a module object.")
 

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -11,29 +11,6 @@ lib_log_enabled = False  # For developers
 # Controls the amount of indentation for library logging
 indentation_level = 0
 
-# Instantiating loggers
-logger = logging.getLogger("Climakitae Back-end Debugger")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(message)s"))
-
-
-# Creating an additional logger for adding new lines around logger when enabling full library logger
-# (i.e. view logger lines as well as call stack and runtimes
-class NewlineHandler(logging.Handler):
-    def emit(self, record):
-        timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(record.created))
-        msg = self.format(record)
-        msg = f"\n{timestamp} - {record.name} - {msg}\n"
-        print(msg)
-
-
-# Create the extra handlers for new lines
-newline_handler = NewlineHandler()
-newline_handler.setLevel(logging.DEBUG)
-
-### Functions to enable or disable logging in notebooks
-
 
 def enable_lib_logging():
     """
@@ -42,9 +19,6 @@ def enable_lib_logging():
     global lib_log_enabled
     if not lib_log_enabled:
         lib_log_enabled = True
-        # app_log_enabled = False
-        # logger.addHandler(newline_handler)
-        # logger.removeHandler(handler)
 
 
 def disable_lib_logging():
@@ -54,14 +28,13 @@ def disable_lib_logging():
     global lib_log_enabled
     if lib_log_enabled:
         lib_log_enabled = False
-        # logger.removeHandler(newline_handler)
 
 
 def log(func):
     """
     Wraps around existing functions, adding print statements upon execution and the amount of time it takes for execution. Allows function's call-stack to be viewed for all sub-functions that also have this wrapper.
     """
-    global lib_log_enabled, logger
+    global lib_log_enabled
 
     def wrapper(*args, **kwargs):
         """Wraps timer and print statement around functions if `lib_log_enabled` is True, otherwise
@@ -88,8 +61,6 @@ def add_log_wrapper(module):
     """
     Adds the `log` wrapper to all functions within the given module.
     """
-    # TODO: Calvin- This function only works when it exists in a notebook, not here.
-    # I believe this has something to do with how modules are referenced in a notebook vs in the back-end.
     if isinstance(module, types.ModuleType):
         for name in dir(module):
             obj = getattr(module, name)
@@ -103,26 +74,7 @@ def remove_log_wrapper(module):
     """
     Removes the `log` wrapper to all functions within the given module.
     """
-    # TODO: Calvin - I can't seem to remove the decorator on the subfunctions.
-    # I am told to get each function's __wrapped__ attribute, but they don't exist on the objects.
-    # Currently, the only way to remove all log wrappers to a module is to 1. reload the module 2. restart the kernel.
-
-    # if isinstance(agnostic, types.ModuleType):
-    #     for name in dir(agnostic):
-    #         obj = getattr(agnostic, name)
-    #         if isinstance(obj, types.FunctionType):
-    #             # Check if the function is wrapped with 'log'
-    #             if hasattr(obj, '__wrapped__'):
-    #                 setattr(agnostic, name, obj.__wrapped__)
-
+    # Currently, in order to remove the logger from all decorated functions, you will need to reload the module.
+    # I have tried to reference a `__wrapped__` attribute on wrapped functions, but they don't seem to exist.
     importlib.reload(module)
     return
-
-
-def kill_loggers():
-    """
-    Kills all active handlers for current logger.
-    """
-    global logger
-    for handler in logger.handlers[:]:
-        logger.removeHandler(handler)

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -55,15 +55,19 @@ def log(func):
     return wrapper
 
 
-def add_log_wrapper(module):
+def add_log_wrapper(obj):
     """
     Adds the `log` wrapper to all functions within the given module.
     """
-    if isinstance(module, types.ModuleType):
-        for name in dir(module):
-            obj = getattr(module, name)
-            if isinstance(obj, types.FunctionType):
-                setattr(module, name, log(obj))
+    import pdb; pdb.set_trace()
+    # Check if the module 
+    if isinstance(obj, types.ModuleType) or isinstance(obj, type):
+        for name in dir(obj):
+            res = getattr(obj, name)
+            if isinstance(res, type):
+                add_log_wrapper(res)
+            elif isinstance(res, types.FunctionType):
+                setattr(obj, name, log(res))
     else:
         print("Error: Current object is not a module object.")
 

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -67,17 +67,11 @@ def add_log_wrapper(obj):
             # Do not add loggers to any innate functions
             if not name.startswith('__') and not name.endswith('__'):
 
-                # print(f"Curr res name: {res}")
-                # print(f"Curr name: {name}")
-                # import pdb; pdb.set_trace()
-
                 # Only add loggers to objects that are functions
                 if isinstance(res, types.FunctionType):
                     
                     # Only add loggers to functions within AE
                     if 'climakitae' in res.__module__:
-                        
-                        print(f"Name of obj getting attr'd: {name}")
                         setattr(obj, name, log(res))
                     
                 # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -42,7 +42,12 @@ def enable_lib_logging(obj):
     if isinstance(obj, types.ModuleType) or isinstance(obj, type):
         for name in dir(obj):
             res = getattr(obj, name)
-
+            
+            # Initial logic to prevent loggers from double wrapping functions
+            if "__name__" in dir(res):
+                if res.__name__ == 'wrapper':
+                    continue
+            
             # Do not add loggers to any built-in functions
             if not name.startswith("__") and not name.endswith("__"):
 

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -67,8 +67,8 @@ def add_log_wrapper(obj):
             # Do not add loggers to any innate functions
             if not name.startswith('__') and not name.endswith('__'):
 
-                print(f"Curr res name: {res}")
-                print(f"Curr name: {name}")
+                # print(f"Curr res name: {res}")
+                # print(f"Curr name: {name}")
                 import pdb; pdb.set_trace()
 
                 # Only add loggers to objects that are functions

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -72,7 +72,7 @@ def add_log_wrapper(obj):
                 import pdb; pdb.set_trace()
 
                 # Only add loggers to objects that are functions
-                if isinstance(res, types.FunctionType):
+                if isinstance(res, types.FunctionType) or :
                     
                     # Only add loggers to functions within AE
                     if 'climakitae' in res.__module__:
@@ -80,9 +80,9 @@ def add_log_wrapper(obj):
                         print(f"Name of obj getting attr'd: {name}")
                         setattr(obj, name, log(res))
                     
-                    # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
-                    elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':
-                        add_log_wrapper(res)
+                # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
+                elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':
+                    add_log_wrapper(res)
     else:
         print("Error: Current object is not a module object.")
 

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -57,29 +57,34 @@ def log(func):
 
 def add_log_wrapper(obj):
     """
-    Adds the `log` wrapper to all functions within the given module.
+    Adds the `log` wrapper to all functions and sub-classes within the given module or class.
+
+    Parameters
+    -----------
+    obj: types.ModuleType or type (module or class)
     """
-    # Check if the module
+    # Check if the passed in object is a module or a class
     if isinstance(obj, types.ModuleType) or isinstance(obj, type):
         for name in dir(obj):
             res = getattr(obj, name)
 
-            # Do not add loggers to any innate functions
+            # Do not add loggers to any built-in functions
             if not name.startswith("__") and not name.endswith("__"):
 
-                # Only add loggers to objects that are functions
+                # Only add loggers to objects that are function types
                 if isinstance(res, types.FunctionType):
 
                     # Only add loggers to functions within AE
                     if "climakitae" in res.__module__:
                         setattr(obj, name, log(res))
 
-                # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
+                # Check if the object is a class type, is not the literal string '__class__', and is created within climakitae.
                 elif (
                     isinstance(res, type)
                     and name != "__class__"
                     and res.__module__[:10] == "climakitae"
                 ):
+                    # Recursively add logging wrapper to any classes within the passed in module/class.
                     add_log_wrapper(res)
     else:
         print("Error: Current object is not a module object.")

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -32,11 +32,10 @@ def log(func):
     """
     Wraps around existing functions, adding print statements upon execution and the amount of time it takes for execution. Allows function's call-stack to be viewed for all sub-functions that also have this wrapper.
     """
-    global lib_log_enabled, indentation_level
-
     def wrapper(*args, **kwargs):
         """Wraps timer and print statement around functions if `lib_log_enabled` is True, otherwise
         just return the function's result."""
+        global lib_log_enabled, indentation_level
         if lib_log_enabled:
             start_time = time.time()
             print("    " * indentation_level + f"Executing function: {func.__name__}")

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -64,8 +64,12 @@ def add_log_wrapper(obj):
         for name in dir(obj):
             res = getattr(obj, name)
             if isinstance(res, types.FunctionType):
-                import pdb; pdb.set_trace()
-                setattr(obj, name, log(res))
+                 
+                 # Only add loggers to custom-created functions
+                 if not name.startswith('__') and not name.endswith('__'):
+
+                    import pdb; pdb.set_trace()
+                    setattr(obj, name, log(res))
             
             # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
             elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -72,7 +72,7 @@ def add_log_wrapper(obj):
                 import pdb; pdb.set_trace()
 
                 # Only add loggers to objects that are functions
-                if isinstance(res, types.FunctionType) or :
+                if isinstance(res, types.FunctionType):
                     
                     # Only add loggers to functions within AE
                     if 'climakitae' in res.__module__:

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -59,23 +59,27 @@ def add_log_wrapper(obj):
     """
     Adds the `log` wrapper to all functions within the given module.
     """
-    # Check if the module 
+    # Check if the module
     if isinstance(obj, types.ModuleType) or isinstance(obj, type):
         for name in dir(obj):
             res = getattr(obj, name)
 
             # Do not add loggers to any innate functions
-            if not name.startswith('__') and not name.endswith('__'):
+            if not name.startswith("__") and not name.endswith("__"):
 
                 # Only add loggers to objects that are functions
                 if isinstance(res, types.FunctionType):
-                    
+
                     # Only add loggers to functions within AE
-                    if 'climakitae' in res.__module__:
+                    if "climakitae" in res.__module__:
                         setattr(obj, name, log(res))
-                    
+
                 # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
-                elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':
+                elif (
+                    isinstance(res, type)
+                    and name != "__class__"
+                    and res.__module__[:10] == "climakitae"
+                ):
                     add_log_wrapper(res)
     else:
         print("Error: Current object is not a module object.")

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -69,7 +69,7 @@ def log(func):
         global indentation_level
         if lib_log_enabled:
             start_time = time.time()
-            print("  " * indentation_level + f"Executing function: {func.__name__}")
+            print("    " * indentation_level + f"Executing function: {func.__name__}")
             indentation_level += 1
             results = func(*args, **kwargs)
             indentation_level -= 1

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -64,7 +64,8 @@ def add_log_wrapper(obj):
         for name in dir(obj):
             res = getattr(obj, name)
 
-            print(f"Curr res name: {res}")    
+            print(f"Curr res name: {res}")
+            import pdb; pdb.set_trace()
             # Do not add loggers to any functions not from climakitae
             if 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
                 if isinstance(res, types.FunctionType):

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -71,7 +71,7 @@ def add_log_wrapper(obj):
                 import pdb; pdb.set_trace()
 
                 # Do not add loggers to any functions not from climakitae
-                if not res.__module__ and 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
+                if res.__module__ and 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
                     if isinstance(res, types.FunctionType):
                         
                         # Do not add loggers to innate functions

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -10,6 +10,7 @@ def log(func):
     """
     Wraps around existing functions, adding print statements upon execution and the amount of time it takes for execution. Allows function's call-stack to be viewed for all sub-functions that also have this wrapper.
     """
+
     def wrapper(*args, **kwargs):
         """Wraps timer and print statement around functions if `lib_log_enabled` is True, otherwise
         just return the function's result."""
@@ -42,12 +43,12 @@ def enable_lib_logging(obj):
     if isinstance(obj, types.ModuleType) or isinstance(obj, type):
         for name in dir(obj):
             res = getattr(obj, name)
-            
+
             # Initial logic to prevent loggers from double wrapping functions
             if "__name__" in dir(res):
-                if res.__name__ == 'wrapper':
+                if res.__name__ == "wrapper":
                     continue
-            
+
             # Do not add loggers to any built-in functions
             if not name.startswith("__") and not name.endswith("__"):
 
@@ -78,7 +79,6 @@ def disable_lib_logging(module):
     # I have tried to reference a `__wrapped__` attribute on wrapped functions, but they don't seem to exist.
     importlib.reload(module)
     return
-
 
 
 # def enable_lib_logging():

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -1,99 +1,130 @@
 import logging
-import inspect
-import functools
 import sys
+import time
+import types
+from functools import wraps
+import importlib
 
-# Configure the logging system
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+# Define global variables to control logging
+app_log_enabled = False  # For users
+lib_log_enabled = False  # For developers
 
-# Define a global flag to control logging
-logging_enabled = False
+# Controls the amount of indentation for library logging
+indentation_level = 0
 
-# Define a list of allowed module names
-allowed_modules = ['climakitae'] 
+# Instantiating loggers
+logger = logging.getLogger("Climakitae Back-end Debugger")
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(message)s"))
 
-current_logging_status = lambda: logging_enabled
 
-def enable_logging():
+# Creating an additional logger for adding new lines around logger when enabling full library logger
+# (i.e. view logger lines as well as call stack and runtimes
+class NewlineHandler(logging.Handler):
+    def emit(self, record):
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(record.created))
+        msg = self.format(record)
+        msg = f"\n{timestamp} - {record.name} - {msg}\n"
+        print(msg)
+
+
+# Create the extra handlers for new lines
+newline_handler = NewlineHandler()
+newline_handler.setLevel(logging.DEBUG)
+
+
+### Functions to enable or disable logging in notebooks
+
+
+def enable_lib_logging():
     """
-    Enable logging for library functions, methods, and class instantiations.
+    Enables library logging.
     """
-    global logging_enabled
-    logging_enabled = True
-    
-def disable_logging():
+    global lib_log_enabled
+    if not lib_log_enabled:
+        lib_log_enabled = True
+        # app_log_enabled = False
+        # logger.addHandler(newline_handler)
+        # logger.removeHandler(handler)
+
+
+def disable_lib_logging():
     """
-    Disable logging for library functions, methods, and class instantiations.
+    Disables library logging.
     """
-    global logging_enabled
-    logging_enabled = False
-    
+    global lib_log_enabled
+    if lib_log_enabled:
+        lib_log_enabled = False
+        # logger.removeHandler(newline_handler)
+
+
 def log(func):
+    """
+    Wraps around existing functions, adding print statements upon execution and the amount of time it takes for execution. Allows function's call-stack to be viewed for all sub-functions that also have this wrapper.
+    """
+    global lib_log_enabled, logger
+
     def wrapper(*args, **kwargs):
-        if logging_enabled:
-            print(f"Executing function: {func.__name__}")
+        """Wraps timer and print statement around functions if `lib_log_enabled` is True, otherwise
+        just return the function's result."""
+        global indentation_level
+        if lib_log_enabled:
+            start_time = time.time()
+            print("  " * indentation_level + f"Executing function: {func.__name__}")
+            indentation_level += 1
+            results = func(*args, **kwargs)
+            indentation_level -= 1
+            end_time = time.time()
+            print(
+                "  " * indentation_level
+                + f"Execution time for {func.__name__}: {end_time - start_time:.4g}"
+            )
+            return results
         return func(*args, **kwargs)
+
     return wrapper
 
 
-
-# def log_function_execution(func):
-#     """
-#     Decorator function to log the name of the currently executing function or method if its module name starts with `climakitae`.
-#     """
-#     @functools.wraps(func)
-#     def wrapper(*args, **kwargs):
-#         if logging_enabled:
-#             # Get the module name of the function or method
-#             module_name = func.__module__
-
-#             # Check if the module name starts with 'climakitae'
-#             if module_name.startswith('climakitae'):
-#                 logging.info(f"Executing function or method: {func.__name__} in module: {module_name}")
-#         return func(*args, **kwargs)
-    
-#     # Return the wrapped function or method
-#     return wrapper
-
-# def log_class_instantiation(cls):
-#     """
-#     Decorator function to log the instantiation of a class if its module name starts with `climakitae`.
-#     """
-#     class WrappedClass(cls):
-#         def __new__(cls, *args, **kwargs):
-#             if logging_enabled:
-#                 # Get the module name of the class
-#                 module_name = cls.__module__
-#                 # Check if the module name starts with `climakitae`
-#                 if module_name.startswith('climakitae'):
-#                     logging.info(f"Instantiating class: {cls.__name__} in module: {module_name}")
-            
-#             # Create an instance of the class
-#             instance = super().__new__(cls)
-
-#             # Decorate functions/methods within the class
-#             for name, obj in inspect.getmembers(instance):
-#                 if inspect.isfunction(obj) or inspect.ismethod(obj):
-#                     setattr(instance, name, log_function_execution(obj))
-
-#             return instance
-    
-#     return WrappedClass
-
-# def apply_logging_to_library_functions_and_methods():
-#     """
-#     Apply logging wrapper to all functions, methods, and classes within allowed modules.
-#     """
-#     for module_name in allowed_modules:
-#         module = sys.modules[module_name]
-#         for name, obj in inspect.getmembers(module):
-#             if inspect.isfunction(obj) or inspect.ismethod(obj):
-#                 setattr(module, name, log_function_execution(obj))
-#             elif inspect.isclass(obj):
-#                 pass
-#                 # setattr(module, name, log_class_instantiation(obj))
-
-# # Apply logging to all functions, methods, and classes within `climakitae`
-# # apply_logging_to_library_functions_and_methods()
+def add_log_wrapper(module):
+    """
+    Adds the `log` wrapper to all functions within the given module.
+    """
+    # TODO: Calvin- This function only works when it exists in a notebook, not here.
+    # I believe this has something to do with how modules are referenced in a notebook vs in the back-end.
+    if isinstance(module, types.ModuleType):
+        for name in dir(module):
+            obj = getattr(module, name)
+            if isinstance(obj, types.FunctionType):
+                setattr(module, name, log(obj))
+    else:
+        print("Error: Current object is not a module object.")
 
 
+def remove_log_wrapper(module):
+    """
+    Removes the `log` wrapper to all functions within the given module.
+    """
+    # TODO: Calvin - I can't seem to remove the decorator on the subfunctions.
+    # I am told to get each function's __wrapped__ attribute, but they don't exist on the objects.
+    # Currently, the only way to remove all log wrappers to a module is to 1. reload the module 2. restart the kernel.
+
+    # if isinstance(agnostic, types.ModuleType):
+    #     for name in dir(agnostic):
+    #         obj = getattr(agnostic, name)
+    #         if isinstance(obj, types.FunctionType):
+    #             # Check if the function is wrapped with 'log'
+    #             if hasattr(obj, '__wrapped__'):
+    #                 setattr(agnostic, name, obj.__wrapped__)
+
+    importlib.reload(module)
+    return
+
+
+def kill_loggers():
+    """
+    Kills all active handlers for current logger.
+    """
+    global logger
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -71,7 +71,7 @@ def add_log_wrapper(obj):
                 import pdb; pdb.set_trace()
 
                 # Do not add loggers to any functions not from climakitae
-                if not res.__module and 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
+                if not res.__module__ and 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
                     if isinstance(res, types.FunctionType):
                         
                         # Do not add loggers to innate functions

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -1,5 +1,3 @@
-import logging
-import sys
 import time
 import types
 from functools import wraps

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -71,7 +71,7 @@ def add_log_wrapper(obj):
                 import pdb; pdb.set_trace()
 
                 # Do not add loggers to any functions not from climakitae
-                if res.__module__ and 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
+                if res and 'climakitae' in res.__module__: # CALVIN- Move this line of logic elsewhere
                     if isinstance(res, types.FunctionType):
                         
                         # Do not add loggers to innate functions

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -63,6 +63,8 @@ def add_log_wrapper(obj):
     if isinstance(obj, types.ModuleType) or isinstance(obj, type):
         for name in dir(obj):
             res = getattr(obj, name)
+
+            import pdb; pdb.set_trace()
             
             # Do not add loggers to any functions not from climakitae
             if res.__module__ == 'climakitae': # CALVIN- Move this line of logic elsewhere

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -69,7 +69,7 @@ def add_log_wrapper(obj):
 
                 # print(f"Curr res name: {res}")
                 # print(f"Curr name: {name}")
-                import pdb; pdb.set_trace()
+                # import pdb; pdb.set_trace()
 
                 # Only add loggers to objects that are functions
                 if isinstance(res, types.FunctionType):

--- a/climakitae/util/logging.py
+++ b/climakitae/util/logging.py
@@ -66,7 +66,9 @@ def add_log_wrapper(obj):
             res = getattr(obj, name)
             if isinstance(res, types.FunctionType):
                 setattr(obj, name, log(res))
-            elif isinstance(res, type) and name != '__class__':
+            
+            # This check makes sure the object is a class type, is not the literal string '__class__', and is created within climakitae.
+            elif isinstance(res, type) and name != '__class__' and res.__module__[:10] == 'climakitae':
                 add_log_wrapper(res)
     else:
         print("Error: Current object is not a module object.")


### PR DESCRIPTION
# Description of PR
Creating a comprehensive logger for developers to view what is going on in the AE library. This PR allows developers to wrap functions within modules with a `log` function, which prints the runtime of the function and all the sub-functions of the function that exist within the same module. It additionally will log any other sub-modules reference within the current module (i.e. if you try to log DataInterface, it will also log functions within the DataParameters class).

**Summary of changes and related issue**
Addition of a library-facing logger in `climakitae.util.logging` to increase visibility of function execution and runtimes in the codebase.

**Relevant motivation and context**
This has been developed because it increases the visibility of what functions run at execution (good for tracking logic of the codebase, esp. useful for new developers), and demonstrates the run-time of all sub-functions being run within that module.

Example of its usage is below:
<img width="497" alt="image" src="https://github.com/cal-adapt/climakitae/assets/33679281/b775c8bf-d547-4ff3-8505-c55a3ee5652b">

(similar to showing the call stack of a function, but also shows the runtimes).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
# If you're interested in what's going on in the back-end for a specific module, you can `enable_lib_logging` and `disable_lib_logging` as you'd like!
from climakitae.explore import agnostic
from climakitae.util.logging import enable_lib_logging, disable_lib_logging
enable_app_logging(agnostic)
disable_app_logging(agnostic)
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

