### PR TITLE
Fix ck.load memory usage introduced by using ProgressBar

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -72,7 +72,6 @@ def load(xr_da):
         print("Available memory: {0}".format(readable_bytes(avail_mem)))
         print("Total memory of input data: {0}".format(readable_bytes(xr_data_nbytes)))
         raise MemoryError("Your input dataset is too large to read into memory!")
-
     else:
         with ProgressBar():
             print(
@@ -82,9 +81,7 @@ def load(xr_da):
                 end="",
             )
             print("\r")
-            da_computed = xr_da.load()
-        print("Complete!")
-        return da_computed  # Load data into memory and return
+            return xr_da.load()  # Load data into memory and return
 
 
 # ============================ Helper functions ================================

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -81,7 +81,7 @@ def load(xr_da):
                 end="",
             )
             print("\r")
-            return xr_da.load()  # Load data into memory and return
+            return xr_da.compute()  # Load data into memory and return
 
 
 # ============================ Helper functions ================================

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -80,7 +80,7 @@ def load(xr_da):
             end="",
         )
         print("\r")
-        return xr_da.compute()  # Load data into memory and return
+        return xr_da.load()  # Load data into memory and return
 
 
 # ============================ Helper functions ================================

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -73,15 +73,14 @@ def load(xr_da):
         print("Total memory of input data: {0}".format(readable_bytes(xr_data_nbytes)))
         raise MemoryError("Your input dataset is too large to read into memory!")
     else:
-        with ProgressBar():
-            print(
-                "Processing data to read {0} of data into memory... ".format(
-                    readable_bytes(xr_data_nbytes)
-                ),
-                end="",
-            )
-            print("\r")
-            return xr_da.compute()  # Load data into memory and return
+        print(
+            "Processing data to read {0} of data into memory... ".format(
+                readable_bytes(xr_data_nbytes)
+            ),
+            end="",
+        )
+        print("\r")
+        return xr_da.compute()  # Load data into memory and return
 
 
 # ============================ Helper functions ================================


### PR DESCRIPTION
This PR patches `ck.load` to remove the ProgressBar that was adding in #337 as the loading process has a memory spike without ProgressBar and then goes back to "normal" size but with ProgressBar the memory stays high.

See Issue #345 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [x] Tested on HUB with dataset near to memory max.
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [N/A] Any dependent changes have been merged and published in downstream modules

