### PR TITLE
Pin dask at 2022.9.1 for READTHEDOCS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 xarray==2022.6.0
+dask==2022.9.1
 cartopy==0.21.0
 dask-gateway==2023.1.1
 geopandas==0.11.1


### PR DESCRIPTION
# Description of PR

READTHEDOCS build is crashing. Looks like from logs that it is grabbing `2024.5.0` version. Need to pin `dask` at 2022.9.1.

**Summary of changes and related issue**

**Relevant motivation and context**

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

