### PR TITLE
CSV file export size estimate and disk space protection

### DIFF
--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -52,6 +52,9 @@ def _estimate_file_size(data, format):
         est_file_size = data_size + buffer_size
 
     elif format == "CSV":
+        # Rough estimate of the number of chars per CSV line
+        # Will overestimate uncompressed size by 10-20%
+        chars_per_line = 150
 
         def multiply_tuple_elements(tuple):
             result = 1
@@ -60,7 +63,7 @@ def _estimate_file_size(data, format):
             return result
 
         est_file_size = (
-            multiply_tuple_elements(data.shape) * 150
+            multiply_tuple_elements(data.shape) * chars_per_line
         )  # 1st approximation of number of bytes per CSV row
     return est_file_size / bytes_per_gigabyte
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -58,13 +58,9 @@ def _estimate_file_size(data, format):
         chars_per_line = 150
 
         if isinstance(data, xr.core.dataarray.DataArray):
-            est_file_size = (
-                np.prod(data.shape) * chars_per_line
-            )
+            est_file_size = np.prod(data.shape) * chars_per_line
         elif isinstance(data, xr.core.dataarray.DataSet):
-            est_file_size = (
-                prod(data.dims.values()) * chars_per_line
-            )
+            est_file_size = prod(data.dims.values()) * chars_per_line
     return est_file_size / bytes_per_gigabyte
 
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -59,7 +59,7 @@ def _estimate_file_size(data, format):
 
         if isinstance(data, xr.core.dataarray.DataArray):
             est_file_size = np.prod(data.shape) * chars_per_line
-        elif isinstance(data, xr.core.dataarray.DataSet):
+        elif isinstance(data, xr.core.dataset.DataSet):
             est_file_size = prod(data.dims.values()) * chars_per_line
     return est_file_size / bytes_per_gigabyte
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -16,6 +16,7 @@ import pytz
 from timezonefinder import TimezoneFinder
 from importlib.metadata import version as _version
 from botocore.exceptions import ClientError
+from math import prod
 from climakitae.util.utils import read_csv_file
 from climakitae.core.paths import (
     variable_descriptions_csv_path,
@@ -56,15 +57,14 @@ def _estimate_file_size(data, format):
         # Will overestimate uncompressed size by 10-20%
         chars_per_line = 150
 
-        def multiply_tuple_elements(tuple):
-            result = 1
-            for item in tuple:
-                result *= item
-            return result
-
-        est_file_size = (
-            multiply_tuple_elements(data.shape) * chars_per_line
-        )  # 1st approximation of number of bytes per CSV row
+        if isinstance(data, xr.core.dataarray.DataArray):
+            est_file_size = (
+                np.prod(data.shape) * chars_per_line
+            )
+        elif isinstance(data, xr.core.dataarray.DataSet):
+            est_file_size = (
+                prod(data.dims.values()) * chars_per_line
+            )
     return est_file_size / bytes_per_gigabyte
 
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -68,7 +68,7 @@ def _estimate_file_size(data, format):
     return est_file_size / bytes_per_gigabyte
 
 
-def _warn_large_export(file_size, file_size_threshold=5):
+def _warn_large_export(file_size, file_size_threshold=5.0):
     if file_size > file_size_threshold:
         print(
             "WARNING: Estimated file size is "
@@ -600,6 +600,7 @@ def _export_to_csv(data, save_name):
         )
 
     print("Exporting specified data to CSV...")
+    _warn_large_export(est_file_size, 1.0)
 
     ftype = type(data)
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -67,7 +67,7 @@ def _estimate_file_size(data, format):
 def _warn_large_export(file_size, file_size_threshold=5.0):
     if file_size > file_size_threshold:
         print(
-            "WARNING: Estimated file size is "
+            "WARNING: Estimated uncompressed file size is "
             + str(round(file_size, 2))
             + " GB. This might take a while!"
         )

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -59,7 +59,7 @@ def _estimate_file_size(data, format):
 
         if isinstance(data, xr.core.dataarray.DataArray):
             est_file_size = np.prod(data.shape) * chars_per_line
-        elif isinstance(data, xr.core.dataset.DataSet):
+        elif isinstance(data, xr.core.dataset.Dataset):
             est_file_size = prod(data.dims.values()) * chars_per_line
     return est_file_size / bytes_per_gigabyte
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -58,7 +58,7 @@ def _estimate_file_size(data, format):
         chars_per_line = 150
 
         if isinstance(data, xr.core.dataarray.DataArray):
-            est_file_size = np.prod(data.shape) * chars_per_line
+            est_file_size = data.size * chars_per_line
         elif isinstance(data, xr.core.dataset.Dataset):
             est_file_size = prod(data.dims.values()) * chars_per_line
     return est_file_size / bytes_per_gigabyte
@@ -579,7 +579,7 @@ def _export_to_csv(data, save_name):
                 " GB free in the hub directory, which has 10 GB total space."
                 " Try smaller subsets of space, time, scenario, and/or"
                 " simulation; pick a coarser spatial or temporal scale;"
-                " or clean any exported datasets which you have already"
+                " or delete any exported datasets which you have already"
                 " downloaded or do not want."
             )
         )


### PR DESCRIPTION
# Description of PR

This PR adds a CSV file size estimate and helps protect file system from filling up. The file estimate is just a 1st approximation using 150 characters per line as a guess. It also removes the 0.85GB CSV file limit (let users decide if the file is too big for their use). We still warn of larger than Excel can handle and warning that large CSV export will take awhile.

**Summary of changes and related issue**

https://trello.com/c/5J8YQ2HI/569-ability-to-estimate-manage-file-sizes-csv

**Relevant motivation and context**

Protect HUB file system from filling up from CSV export.

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ x ] Tested on HUB for various sized CSV exports

# Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

