### PR TITLE
Fix small bug I introduced on accident regarding units

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -719,7 +719,14 @@ def _check_valid_unit_selection(selections):
     native_unit = selections.variable_options_df[
         selections.variable_options_df["variable_id"].isin(selections.variable_id)
     ].unit.item()
-    valid_units = get_unit_conversion_options()[native_unit]
+
+    try:
+        # See if there are more than one unit option for this variable
+        valid_units = get_unit_conversion_options()[native_unit]
+    except:
+        # If not, the only unit option is the native unit
+        valid_units = [native_unit]
+
     if selections.units not in valid_units:
         print("Units selected: {}".format(selections.units))
         print("Valid units: " + ", ".join(valid_units))


### PR DESCRIPTION
# Description of PR

Howdy, I accidentally introduced a small bug in my [last PR](https://github.com/cal-adapt/climakitae/pull/358). Basically, that PR accidentally made it so for variables with only a single unit option, an error was raised when you tried to retrieve the data. YIKES! Obviously not good behavior. I fixed that in this PR. To review, perhaps just review the code, or maybe try to retrieve a variable with only one unit option to make sure it all looks good. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [n/a] Test A
- [n/a] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

