### PR TITLE
Shift time dimension for troublesome loca2 sims

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -549,7 +549,9 @@ def _merge_all(selections, data_dict):
     # Two LOCA2 simulations have their hourly time coordinate shifted 12HR beyond the rest of the simulations
     # Here we reindex the time dimension to shift it by 12HR for the two troublesome simulations
     # This avoids the issue where every other day is set to NaN when you concat the datasets!
-    if selections.downscaling_method in ["Statistical", "Dynamical+Statistical"]:
+    if (selections.downscaling_method in ["Statistical", "Dynamical+Statistical"]) and (
+        selections.timescale == "daily"
+    ):
         troublesome_sims = ["HadGEM3-GC31-LL", "KACE-1-0-G"]
         for sim in troublesome_sims:
             for dset_name in list(data_dict):

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -546,7 +546,7 @@ def _merge_all(selections, data_dict):
         output data
 
     """
-    # Two LOCA2 simulations have their hourly time coordinate shifted 12HR beyond the rest of the simulations
+    # Two LOCA2 simulations report a daily timestamp coordinate at 12am (midnight) when the rest of the simulations report at 12pm (noon)
     # Here we reindex the time dimension to shift it by 12HR for the two troublesome simulations
     # This avoids the issue where every other day is set to NaN when you concat the datasets!
     if (selections.downscaling_method in ["Statistical", "Dynamical+Statistical"]) and (


### PR DESCRIPTION
# Description of PR

This PR shifts the time dimension by 12HR for two "troublesome" LOCA2 simulations, such that they match the time formatting of the other LOCA2 simulations. Since the data is daily, this shouldn't effect anything. 

It solves the issue of every other day in the daily retrieved LOCA2 data being set to NaN (!!!!), which is obviously not desired behavior. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

n/a

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

