### PR TITLE
Separating WL calculate and viz

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -128,6 +128,8 @@ class WarmingLevels:
             self.sliced_data[level] = warm_slice
 
         self.gwl_snapshots = xr.concat(self.gwl_snapshots.values(), dim="warming_level")
+
+    def visualize(self):
         self.cmap = _get_cmap(self.wl_params)
         self.wl_viz = WarmingLevelVisualize(
             gwl_snapshots=self.gwl_snapshots,
@@ -136,12 +138,7 @@ class WarmingLevels:
             warming_levels=self.warming_levels,
         )
         self.wl_viz.compute_stamps()
-
-    def visualize(self):
-        if self.wl_viz:
-            return warming_levels_visualize(self.wl_viz)
-        else:
-            print("Please run 'calculate' first.")
+        return warming_levels_visualize(self.wl_viz)
 
 
 def relabel_axis(all_sims_dim):


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
This PR separates visualizing code from wl.calculate, allowing visualizations and calculations to be done separately.

**Relevant motivation and context**
We want to separate calculations and visualizations as we progress towards a GUI specific and calculations specific divergence between packages. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

