### PR TITLE
Changing plot type for LOCA visualizations shown in `warming_levels_approach.ipynb`

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -213,7 +213,6 @@ def get_sliced_data(y, level, years, window=15, anom="Yes"):
     Returns
     --------
     anomaly_da: xr.DataArray
-        Warming level anomalies at all warming levels for a scenario
     """
     gwl_times_subset = years.loc[process_item(y)]
 
@@ -837,14 +836,12 @@ def GCM_PostageStamps_STATS_compute(wl_viz):
             # Make plots
             any_single_dims = _check_single_spatial_dims(all_plot_data)
             if any_single_dims:
-                plot_type = "bar"
                 only_sims = area_average(stats)
                 all_plots = only_sims.hvplot.bar(
                     x="all_sims", xlabel="Simulation", ylabel=f"{units} of Warming"
                 ).opts(multi_level=False, show_legend=False)
 
             else:
-                plot_type = "image"
                 plot_list = []
                 for stat in stats:
                     plot = stat.drop(["warming_level"]).hvplot.image(
@@ -867,9 +864,9 @@ def GCM_PostageStamps_STATS_compute(wl_viz):
                 + str(warmlevel)
                 + "°C Warming Across Models"
             )  # Add title
-            if plot_type == "image":
+            if not any_single_dims:
                 warm_level_dict[warmlevel] = all_plots.cols(1)
-            elif plot_type == "bar":
+            else:
                 warm_level_dict[warmlevel] = all_plots
         # This means that there does not exist any simulations that reach this degree of warming (WRF models).
         else:


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
This PR includes changes for calculation and visualization separation (https://github.com/cal-adapt/climakitae/pull/379) and also makes a cleaner visualization for LOCA2 simulations in `wl_approach.ipynb`. Below are the before and after images representing LOCA2 simulations using the `WarmingLevelVisualize` class.

**This can be tested with https://github.com/cal-adapt/cae-notebooks/pull/103**

Before this PR:
![image](https://github.com/cal-adapt/climakitae/assets/33679281/12ae3a15-2fc5-4d99-8b5b-310f0c5b2882)

After this PR:
![image (15)](https://github.com/cal-adapt/climakitae/assets/33679281/ec60be9f-7414-4efc-9f20-0f2797ceebe9)


**Relevant motivation and context**
We want to create more interpretable graphics for notebook users.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

