### PR TITLE
Reverting simulation selection code to what it was before

### DIFF
--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -472,10 +472,17 @@ def cava_data(
             # This check is to see which simulations have these BC models as the root part of their simulation name, which is to accomodate for simulation names being the same across SSPs.
             data = data.sel(
                 simulation=[
-                    "WRF_EC-Earth3_r1i1p1f1",
-                    "WRF_MPI-ESM1-2-HR_r3i1p1f1",
-                    "WRF_TaiESM1_r1i1p1f1",
-                    "WRF_MIROC6_r1i1p1f1",
+                    sim
+                    for sim in data.simulation.values
+                    if any(
+                        s in sim
+                        for s in [
+                            "WRF_EC-Earth3_r1i1p1f1",
+                            "WRF_MPI-ESM1-2-HR_r3i1p1f1",
+                            "WRF_TaiESM1_r1i1p1f1",
+                            "WRF_MIROC6_r1i1p1f1",
+                        ]
+                    )
                 ]
             )
 


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
Causes an error when selecting for BC WRF models because the simulation names are longer than just the simulation itself with warming levels (also includes information about if the data came from an SSP/Historical Period).

**Relevant motivation and context**

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

