### PR TITLE
Remove resolution from _update_scenarios param trigger

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -962,7 +962,7 @@ class DataParameters(param.Parameterized):
             self.param["units"].objects = [native_unit]
             self.units = native_unit
 
-    @param.depends("resolution", "downscaling_method", "data_type", watch=True)
+    @param.depends("downscaling_method", "data_type", watch=True)
     def _update_scenarios(self):
         """
         Update scenario options. Raise data warning if a bad selection is made.


### PR DESCRIPTION
# Description of PR

This PR removes "resolution" param from `_update_scenarios` param trigger. Historical Reconstruction (reanalysis) is available for all resolutions of WRF according to `intake` query:
```
activity_id                                                        [WRF]
institution_id                                                    [UCLA]
source_id                                                         [ERA5]
experiment_id                                               [reanalysis]
member_id                                                             []
table_id                                                 [1hr, day, mon]
variable_id            [lwdnbc, lwdnb, lwupbc, lwupb, prec, psfc, q2,...
grid_label                                               [d01, d02, d03]
path                   [s3://cadcat/wrf/ucla/era5/historical/1hr/lwdn...
derived_variable_id                                                   []
dtype: object
```

**Summary of changes and related issue**

Removing "resolution" from trigger will keep Historical selections from resetting when resolution is changed. It will still reset when switched to Statistical or Station.

**Relevant motivation and context**

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ x ] Tested on HUB
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

