### PR TITLE
Closest cell fix for `get_closest_gridcell` util function

### DIFF
--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -147,10 +147,7 @@ def get_closest_gridcell(data, lat, lon, print_coords=True):
     try:
         closest_gridcell = data.sel(x=x, y=y, method="nearest", tolerance=tolerance)
     except KeyError:
-        print(
-            "Input coordinates: (%.2f, %.2f)" % (lat, lon)
-            + " OUTSIDE of data extent by more than one cell"
-        )   
+        print(f"Input coordinates: ({lat:.2f}, {lon:.2f}) OUTSIDE of data extent by more than one cell. Returning None")
         return None
 
     # Output information

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -147,7 +147,9 @@ def get_closest_gridcell(data, lat, lon, print_coords=True):
     try:
         closest_gridcell = data.sel(x=x, y=y, method="nearest", tolerance=tolerance)
     except KeyError:
-        print(f"Input coordinates: ({lat:.2f}, {lon:.2f}) OUTSIDE of data extent by more than one cell. Returning None")
+        print(
+            f"Input coordinates: ({lat:.2f}, {lon:.2f}) OUTSIDE of data extent by more than one cell. Returning None"
+        )
         return None
 
     # Output information

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -125,6 +125,12 @@ def get_closest_gridcell(data, lat, lon, print_coords=True):
     --------
     xarray.DataArray.sel
     """
+
+    # Use data cellsize as tolerance for selecting nearest
+    # Using this method to guard against single row|col
+    # Assumes data is from climakitae retrieve
+    tolerance = int(data.resolution.split(" km")[0]) * 1000
+
     # Make Transformer object
     lat_lon_to_model_projection = pyproj.Transformer.from_crs(
         crs_from="epsg:4326",  # Lat/lon

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -142,7 +142,7 @@ def get_closest_gridcell(data, lat, lon, print_coords=True):
     x, y = lat_lon_to_model_projection.transform(lon, lat)
 
     # Get closest gridcell using tolerance
-    # If input point outside of dataset by greater than one 
+    # If input point outside of dataset by greater than one
     # grid cell, then None is returned
     try:
         closest_gridcell = data.sel(x=x, y=y, method="nearest", tolerance=tolerance)

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -141,8 +141,13 @@ def get_closest_gridcell(data, lat, lon, print_coords=True):
     # Convert coordinates to x,y
     x, y = lat_lon_to_model_projection.transform(lon, lat)
 
-    # Get closest gridcell
-    closest_gridcell = data.sel(x=x, y=y, method="nearest")
+    # Get closest gridcell using tolerance
+    # If input point outside of dataset by greater than one 
+    # grid cell, then None is returned
+    try:
+        closest_gridcell = data.sel(x=x, y=y, method="nearest", tolerance=tolerance)
+    except KeyError:
+        return None
 
     # Output information
     if print_coords:

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -147,6 +147,10 @@ def get_closest_gridcell(data, lat, lon, print_coords=True):
     try:
         closest_gridcell = data.sel(x=x, y=y, method="nearest", tolerance=tolerance)
     except KeyError:
+        print(
+            "Input coordinates: (%.2f, %.2f)" % (lat, lon)
+            + " OUTSIDE of data extent by more than one cell"
+        )   
         return None
 
     # Output information

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -118,7 +118,7 @@ def get_closest_gridcell(data, lat, lon, print_coords=True):
 
     Returns
     --------
-    xr.DataArray
+    xr.DataArray or None
         Grid cell closest to input lat,lon coordinate pair
 
     See also


### PR DESCRIPTION
# Description of PR

This PR changes the behavior of `get_closest_gridcell` by using a tolerance for how far it will search for a gridcell. The tolerance is derived from the dataset resolution attribute. If the input point is farther than one grid cell away from any of the input data it will return `None`.

**Summary of changes and related issue**

#388

**Relevant motivation and context**

See issue for motivation.

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ x ] Tested on HUB
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

