### PR TITLE
Update Scenario Param trigger fix

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -996,21 +996,19 @@ class DataParameters(param.Parameterized):
         ]
         self.param["scenario_historical"].objects = scenario_historical_options
 
-        # test to check if list "a" is contained within list "b" as python doesn't have that out of the box
-        def _check_list_contained(a, b):
-
-            # convert list a to numpy array
-            a_arr = np.array(a)
-            # convert list b to numpy array
-            b_arr = np.array(b)
-
-            for i in range(len(b_arr)):
-                if np.array_equal(a_arr, b_arr[i : i + len(a_arr)]):
-                    return True
-            return False
+        # check if input historical scenarios match new available scenarios
+        # if no reanalysis scenario then return False
+        def _check_inputs(a, b):
+            chk = False
+            if len(b) < 2:
+                return chk
+            for i in a:
+                if i in a:
+                    chk = True
+            return chk
 
         # check if new selection has the historical scenario options and if not select the first new option
-        if _check_list_contained(_scenario_historical, scenario_historical_options):
+        if _check_inputs(_scenario_historical, scenario_historical_options):
             self.scenario_historical = _scenario_historical
         else:
             self.scenario_historical = [scenario_historical_options[0]]

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -969,6 +969,7 @@ class DataParameters(param.Parameterized):
         """
         # Set incoming scenario_historical
         _scenario_historical = self.scenario_historical
+        print(_scenario_historical)
 
         # Get scenario options in catalog format
         scenario_ssp_options = [

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -996,6 +996,7 @@ class DataParameters(param.Parameterized):
         ]
         self.param["scenario_historical"].objects = scenario_historical_options
 
+        # test to check if one list is contained within another as python doesn't have that out of the box
         def _check_list_contained(a, b):
 
             # convert list a to numpy array
@@ -1008,6 +1009,7 @@ class DataParameters(param.Parameterized):
                     return True
             return False
 
+        # check if new selection has the historical scenario options and if not select the first new option
         if _check_list_contained(_scenario_historical, scenario_historical_options):
             self.scenario_historical = _scenario_historical
         else:

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -997,14 +997,14 @@ class DataParameters(param.Parameterized):
         self.param["scenario_historical"].objects = scenario_historical_options
 
         def _check_list_contained(a, b):
-        
+
             # convert list a to numpy array
             a_arr = np.array(a)
             # convert list b to numpy array
             b_arr = np.array(b)
-        
+
             for i in range(len(b_arr)):
-                if np.array_equal(a_arr, b_arr[i:i+len(a_arr)]):
+                if np.array_equal(a_arr, b_arr[i : i + len(a_arr)]):
                     return True
             return False
 

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -996,7 +996,7 @@ class DataParameters(param.Parameterized):
         ]
         self.param["scenario_historical"].objects = scenario_historical_options
 
-        # test to check if one list is contained within another as python doesn't have that out of the box
+        # test to check if list "a" is contained within list "b" as python doesn't have that out of the box
         def _check_list_contained(a, b):
 
             # convert list a to numpy array

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1,5 +1,6 @@
 import os
 import xarray as xr
+import numpy as np
 import pandas as pd
 import geopandas as gpd
 from shapely.geometry import box, Polygon
@@ -969,7 +970,6 @@ class DataParameters(param.Parameterized):
         """
         # Set incoming scenario_historical
         _scenario_historical = self.scenario_historical
-        print(_scenario_historical)
 
         # Get scenario options in catalog format
         scenario_ssp_options = [
@@ -995,10 +995,23 @@ class DataParameters(param.Parameterized):
             if scen in historical_scenarios
         ]
         self.param["scenario_historical"].objects = scenario_historical_options
-        if _scenario_historical not in scenario_historical_options:
-            self.scenario_historical = [scenario_historical_options[0]]
-        else:
+
+        def _check_list_contained(a, b):
+        
+            # convert list a to numpy array
+            a_arr = np.array(a)
+            # convert list b to numpy array
+            b_arr = np.array(b)
+        
+            for i in range(len(b_arr)):
+                if np.array_equala(a_arr, b_arr[i:i+len(a_arr)]):
+                    return True
+            return False
+
+        if _check_list_contained(_scenario_historical, scenario_historical_options):
             self.scenario_historical = _scenario_historical
+        else:
+            self.scenario_historical = [scenario_historical_options[0]]
 
     @param.depends(
         "scenario_ssp",

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1,6 +1,5 @@
 import os
 import xarray as xr
-import numpy as np
 import pandas as pd
 import geopandas as gpd
 from shapely.geometry import box, Polygon

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -967,6 +967,9 @@ class DataParameters(param.Parameterized):
         """
         Update scenario options. Raise data warning if a bad selection is made.
         """
+        # Set incoming scenario_historical
+        _scenario_historical = self.scenario_historical
+
         # Get scenario options in catalog format
         scenario_ssp_options = [
             scenario_to_experiment_id(scen, reverse=True)
@@ -991,8 +994,10 @@ class DataParameters(param.Parameterized):
             if scen in historical_scenarios
         ]
         self.param["scenario_historical"].objects = scenario_historical_options
-        if self.scenario_historical not in scenario_historical_options:
+        if _scenario_historical not in scenario_historical_options:
             self.scenario_historical = [scenario_historical_options[0]]
+        else:
+            self.scenario_historical = _scenario_historical
 
     @param.depends(
         "scenario_ssp",

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1004,7 +1004,7 @@ class DataParameters(param.Parameterized):
             b_arr = np.array(b)
         
             for i in range(len(b_arr)):
-                if np.array_equala(a_arr, b_arr[i:i+len(a_arr)]):
+                if np.array_equal(a_arr, b_arr[i:i+len(a_arr)]):
                     return True
             return False
 


### PR DESCRIPTION
# Description of PR

This PR updates the `_update_scenario` param trigger to properly set the historical scenarios after changing the affected widgets.

**Summary of changes and related issue**

previously we tested if one list was in another (currently hist. scen. options vs. possible new options) using `in`. This apparently does not work as it was returning false when it was true. I therefore wrote a function that converts the lists into numpy arrays and compares them.

**Relevant motivation and context**

selections are being changed after parameters are being set and bring back incorrect data. Most obviously a problem when not using the GUI as you can't see that historical selections have changed.

**Dependencies required for this change?**

**Fixes # (issue), delete if not necessary**

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ x ] Tested by creating the code from scratch on HUB and by running branch on HUB and using `ck.Select`
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

