### PR TITLE
Remove ill-formatted documentation

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -29,6 +29,10 @@ from climakitae.core.data_load import (
     read_catalog_from_select,
 )
 
+# Remove param's parameter descriptions from docstring because
+# ANSI escape sequences in them complicate their rendering
+param.parameterized.docstring_describe_params = False
+
 
 def _get_user_options(data_catalog, downscaling_method, timescale, resolution):
     """Using the data catalog, get a list of appropriate scenario and simulation options given a user's

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -32,6 +32,8 @@ from climakitae.core.data_load import (
 # Remove param's parameter descriptions from docstring because
 # ANSI escape sequences in them complicate their rendering
 param.parameterized.docstring_describe_params = False
+# Docstring signatures are also hard to read and therefore removed
+param.parameterized.docstring_signature = False
 
 
 def _get_user_options(data_catalog, downscaling_method, timescale, resolution):

--- a/climakitae/explore/amy.py
+++ b/climakitae/explore/amy.py
@@ -36,6 +36,9 @@ import logging  # Silence warnings
 
 logging.getLogger("param").setLevel(logging.CRITICAL)
 xr.set_options(keep_attrs=True)  # Keep attributes when mutating xr objects
+# Remove param's parameter descriptions from docstring because
+# ANSI escape sequences in them complicate their rendering
+param.parameterized.docstring_describe_params = False
 
 
 # =========================== HELPER FUNCTIONS: DATA RETRIEVAL ==============================

--- a/climakitae/explore/amy.py
+++ b/climakitae/explore/amy.py
@@ -39,6 +39,8 @@ xr.set_options(keep_attrs=True)  # Keep attributes when mutating xr objects
 # Remove param's parameter descriptions from docstring because
 # ANSI escape sequences in them complicate their rendering
 param.parameterized.docstring_describe_params = False
+# Docstring signatures are also hard to read and therefore removed
+param.parameterized.docstring_signature = False
 
 
 # =========================== HELPER FUNCTIONS: DATA RETRIEVAL ==============================

--- a/climakitae/explore/thresholds.py
+++ b/climakitae/explore/thresholds.py
@@ -17,6 +17,8 @@ from climakitae.explore.threshold_tools import (
 # Remove param's parameter descriptions from docstring because
 # ANSI escape sequences in them complicate their rendering
 param.parameterized.docstring_describe_params = False
+# Docstring signatures are also hard to read and therefore removed
+param.parameterized.docstring_signature = False
 
 
 # ============ Class and methods for the explore.thresholds() GUI ==============

--- a/climakitae/explore/thresholds.py
+++ b/climakitae/explore/thresholds.py
@@ -14,6 +14,11 @@ from climakitae.explore.threshold_tools import (
     exceedance_plot_subtitle,
 )
 
+# Remove param's parameter descriptions from docstring because
+# ANSI escape sequences in them complicate their rendering
+param.parameterized.docstring_describe_params = False
+
+
 # ============ Class and methods for the explore.thresholds() GUI ==============
 
 

--- a/climakitae/explore/timeseries.py
+++ b/climakitae/explore/timeseries.py
@@ -8,6 +8,8 @@ import pandas as pd
 # Remove param's parameter descriptions from docstring because
 # ANSI escape sequences in them complicate their rendering
 param.parameterized.docstring_describe_params = False
+# Docstring signatures are also hard to read and therefore removed
+param.parameterized.docstring_signature = False
 
 
 class TimeSeriesParameters(param.Parameterized):

--- a/climakitae/explore/timeseries.py
+++ b/climakitae/explore/timeseries.py
@@ -5,6 +5,10 @@ import panel as pn
 import hvplot.xarray
 import pandas as pd
 
+# Remove param's parameter descriptions from docstring because
+# ANSI escape sequences in them complicate their rendering
+param.parameterized.docstring_describe_params = False
+
 
 class TimeSeriesParameters(param.Parameterized):
     """Class of python Param to hold parameters for Time Series."""

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -51,6 +51,8 @@ xr.set_options(keep_attrs=True)  # Keep attributes when mutating xr objects
 # Remove param's parameter descriptions from docstring because
 # ANSI escape sequences in them complicate their rendering
 param.parameterized.docstring_describe_params = False
+# Docstring signatures are also hard to read and therefore removed
+param.parameterized.docstring_signature = False
 
 
 class WarmingLevels:

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -48,6 +48,9 @@ import logging
 
 logging.getLogger("param").setLevel(logging.CRITICAL)
 xr.set_options(keep_attrs=True)  # Keep attributes when mutating xr objects
+# Remove param's parameter descriptions from docstring because
+# ANSI escape sequences in them complicate their rendering
+param.parameterized.docstring_describe_params = False
 
 
 class WarmingLevels:


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
- Remove `param`’s parameter descriptions from docstring because ANSI escape sequences in them make them look wrong and difficult to read on Read the Docs. 
- Remove `param`'s docstring signatures because they are also hard to read.
See [this Trello card](https://trello.com/c/umgIWU6f) for an example. 

**Relevant motivation and context**
Improve presentation of the documentation.

## Type of change

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

Checked the preview: https://climakitae--394.org.readthedocs.build/en/394/

# Checklist:

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [not relevant] I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x]  I have added tests that prove my fix is effective or that my feature works
- [not relevant] New and existing unit tests pass locally with my changes
- [not relevant] Any dependent changes have been merged and published in downstream modules

