### PR TITLE
Adding helper function to remove incorrect WRF sims during WL approach

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -26,6 +26,7 @@ from climakitae.util.utils import (
     read_ae_colormap,
     area_average,
     scenario_to_experiment_id,
+    drop_invalid_wrf_sims,
 )
 from climakitae.core.paths import (
     gwl_1981_2010_file,
@@ -111,6 +112,11 @@ class WarmingLevels:
         # Postage data and anomalies
         self.catalog_data = self.wl_params.retrieve()
         self.catalog_data = self.catalog_data.stack(all_sims=["simulation", "scenario"])
+
+        # For WRF, dropping invalid simulations before doing any other computation
+        if self.wl_params.downscaling_method == "Dynamical":
+            self.catalog_data = drop_invalid_wrf_sims(self.catalog_data)
+
         if self.wl_params.anom == "Yes":
             self.gwl_times = read_csv_file(gwl_1981_2010_file, index_col=[0, 1, 2])
         else:

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -773,12 +773,12 @@ def drop_invalid_wrf_sims(ds):
         return ds
 
     valid_45km = [
-        ("Historical + SSP 2-4.5 -- Middle of the Road", "WRF_CESM2_r11i1p1f1"),
-        ("Historical + SSP 3-7.0 -- Business as Usual", "WRF_CNRM-ESM2-1_r1i1p1f2"),
-        ("Historical + SSP 3-7.0 -- Business as Usual", "WRF_EC-Earth3-Veg_r1i1p1f1"),
-        ("Historical + SSP 3-7.0 -- Business as Usual", "WRF_EC-Earth3_r1i1p1f1"),
-        ("Historical + SSP 3-7.0 -- Business as Usual", "WRF_FGOALS-g3_r1i1p1f1"),
-        ("Historical + SSP 5-8.5 -- Burn it All", "WRF_CESM2_r11i1p1f1"),
+        ("WRF_CESM2_r11i1p1f1", "Historical + SSP 2-4.5 -- Middle of the Road"),
+        ("WRF_CNRM-ESM2-1_r1i1p1f2", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_EC-Earth3-Veg_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_EC-Earth3_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_FGOALS-g3_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_CESM2_r11i1p1f1", "Historical + SSP 5-8.5 -- Burn it All"),
     ]
 
     valid_9km = [

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -742,3 +742,59 @@ def add_dummy_time_to_wl(wl_da):
     # can be computed on a DataArray with a time dimension
     wl_da = wl_da.assign_coords({wl_time_dim: timestamps}).rename({wl_time_dim: "time"})
     return wl_da
+
+
+def drop_invalid_wrf_sims(ds):
+    """
+    Drops invalid WRF simulations from the given dataset since there is an unequal number of simulations per SSP.
+
+    Parameters:
+    ds (xarray.Dataset): The dataset containing WRF simulations. The dataset must have a dimension `all_sims` that
+                         results from stacking `simulation` and `scenario`.
+
+    Returns:
+    xarray.Dataset: The dataset with only valid WRF simulations retained.
+
+    Raises:
+    AttributeError: If the dataset does not have an `all_sims` dimension.
+
+    Notes:
+    - For datasets with a resolution of '3 km', no simulations are dropped, and the original dataset is returned.
+    - For datasets with a resolution of '9 km', only specific valid simulations are retained.
+    - For datasets with a resolution of '45 km', only specific valid simulations are retained.
+    """
+    if "all_sims" not in ds.dims:
+        raise AttributeError(
+            "Missing an `all_sims` dimension on the dataset. Create `all_sims` with .stack on `simulation` and `scenario`."
+        )
+
+    # There are no simulations that need to be dropped at a `3 km` resolution, since the only simulations are in SSP 3-7.0.
+    if ds.resolution == "3 km":
+        return ds
+
+    valid_45km = [
+        ("Historical + SSP 2-4.5 -- Middle of the Road", "WRF_CESM2_r11i1p1f1"),
+        ("Historical + SSP 3-7.0 -- Business as Usual", "WRF_CNRM-ESM2-1_r1i1p1f2"),
+        ("Historical + SSP 3-7.0 -- Business as Usual", "WRF_EC-Earth3-Veg_r1i1p1f1"),
+        ("Historical + SSP 3-7.0 -- Business as Usual", "WRF_EC-Earth3_r1i1p1f1"),
+        ("Historical + SSP 3-7.0 -- Business as Usual", "WRF_FGOALS-g3_r1i1p1f1"),
+        ("Historical + SSP 5-8.5 -- Burn it All", "WRF_CESM2_r11i1p1f1"),
+    ]
+
+    valid_9km = [
+        ("WRF_CESM2_r11i1p1f1", "Historical + SSP 2-4.5 -- Middle of the Road"),
+        ("WRF_CESM2_r11i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_CESM2_r11i1p1f1", "Historical + SSP 5-8.5 -- Burn it All"),
+        ("WRF_CNRM-ESM2-1_r1i1p1f2", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_EC-Earth3-Veg_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_EC-Earth3_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_FGOALS-g3_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_MIROC6_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_MPI-ESM1-2-HR_r3i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_TaiESM1_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+    ]
+
+    if ds.resolution == "9 km":
+        return ds.sel(all_sims=valid_9km)
+    elif ds.resolution == "45 km":
+        return ds.sel(all_sims=valid_45km)

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -776,6 +776,7 @@ def drop_invalid_wrf_sims(ds):
         ("WRF_CESM2_r11i1p1f1", "Historical + SSP 2-4.5 -- Middle of the Road"),
         ("WRF_CNRM-ESM2-1_r1i1p1f2", "Historical + SSP 3-7.0 -- Business as Usual"),
         ("WRF_EC-Earth3-Veg_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
+        ("WRF_CESM2_r11i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
         ("WRF_EC-Earth3_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
         ("WRF_FGOALS-g3_r1i1p1f1", "Historical + SSP 3-7.0 -- Business as Usual"),
         ("WRF_CESM2_r11i1p1f1", "Historical + SSP 5-8.5 -- Burn it All"),


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
During a WL approach, the simulations are all stacked together, across models and SSPs. However, this causes simulations to appear that do not necessarily exist. The helper function in this PR is to address this issue, by dropping erroneous simulations from each spatial scale of WRF simulations WITHOUT having to load them all in and dropping NaN simulations.

Addresses #397 .

**Relevant motivation and context**
We want to drop erroneous simulations without having to load them all in.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

