### PR TITLE
Optionally Load in Warming Level data

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -973,6 +973,9 @@ class DataParameters(param.Parameterized):
         """
         Update scenario options. Raise data warning if a bad selection is made.
         """
+        # Set incoming scenario_historical
+        _scenario_historical = self.scenario_historical
+
         # Get scenario options in catalog format
         scenario_ssp_options = [
             scenario_to_experiment_id(scen, reverse=True)
@@ -997,7 +1000,22 @@ class DataParameters(param.Parameterized):
             if scen in historical_scenarios
         ]
         self.param["scenario_historical"].objects = scenario_historical_options
-        if self.scenario_historical not in scenario_historical_options:
+
+        # check if input historical scenarios match new available scenarios
+        # if no reanalysis scenario then return False
+        def _check_inputs(a, b):
+            chk = False
+            if len(b) < 2:
+                return chk
+            for i in a:
+                if i in a:
+                    chk = True
+            return chk
+
+        # check if new selection has the historical scenario options and if not select the first new option
+        if _check_inputs(_scenario_historical, scenario_historical_options):
+            self.scenario_historical = _scenario_historical
+        else:
             self.scenario_historical = [scenario_historical_options[0]]
 
     @param.depends(

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -368,7 +368,7 @@ class WarmingLevelChoose(DataParametersWithPanes):
         self.cached_area = ["CA"]
 
         # Toggle whether or not data is loaded in as it is being computed
-        self.load_data = False
+        self.load_data = True
 
     @param.depends("downscaling_method", watch=True)
     def _anom_allowed(self):

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -368,6 +368,7 @@ class WarmingLevelChoose(DataParametersWithPanes):
         self.cached_area = ["CA"]
 
         # Toggle whether or not data is loaded in as it is being computed
+        # This may be set to False if you are interested in loading smaller chunks of data at a time, or with batch computing a series of warming level data points.
         self.load_data = True
 
     @param.depends("downscaling_method", watch=True)

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -147,7 +147,7 @@ class WarmingLevels:
             cmap=self.cmap,
             warming_levels=self.wl_params.warming_levels,
         )
-        # self.wl_viz.compute_stamps()
+        self.wl_viz.compute_stamps()
         return warming_levels_visualize(self.wl_viz)
 
 
@@ -411,7 +411,6 @@ class WarmingLevelVisualize(param.Parameterized):
         ],
         doc="Shared Socioeconomic Pathway.",
     )
-    print(1)
 
     def __init__(self, gwl_snapshots, wl_params, cmap, warming_levels):
         """
@@ -425,11 +424,6 @@ class WarmingLevelVisualize(param.Parameterized):
         self.gwl_snapshots = gwl_snapshots
         self.wl_params = wl_params
         self.warming_levels = warming_levels
-        
-        # Overriding `self.warmlevel` to be filled with dynamically populated values
-        self.param.warmlevel.objects = [float(wl) for wl in self.warming_levels]
-        self.warmlevel = float(warming_levels[0])
-        # self.param.warmlevel = float(warming_levels[0])
         self.cmap = cmap
         some_dims = self.gwl_snapshots.dims  # different names depending on WRF/LOCA
         some_dims = list(some_dims)

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -124,7 +124,7 @@ class WarmingLevels:
             self.wl_params.warming_levels, desc="Computing each warming level"
         ):
             warm_slice = self.find_warming_slice(level, self.gwl_times)
-            if self.load_data:
+            if self.wl_params.load_data:
                 warm_slice = load(warm_slice)
 
             # Dropping simulations that only have NaNs

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -384,6 +384,8 @@ class WarmingLevelChoose(DataParametersWithPanes):
 
 
 class WarmingLevelVisualize(param.Parameterized):
+    """Create Warming Levels panel GUI"""
+
     ## Intended to be accessed through WarmingLevels class.
     ## Allows the user to toggle between several data options.
     ## Produces dynamically updating gwl snapshot maps.
@@ -430,6 +432,8 @@ class WarmingLevelVisualize(param.Parameterized):
         some_dims.remove("warming_level")
         self.mins = self.gwl_snapshots.min(some_dims).compute()
         self.maxs = self.gwl_snapshots.max(some_dims).compute()
+
+    def compute_stamps(self):
         self.main_stamps = GCM_PostageStamps_MAIN_compute(self)
         self.stats_stamps = GCM_PostageStamps_STATS_compute(self)
 

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -368,7 +368,7 @@ class WarmingLevelChoose(DataParametersWithPanes):
         self.cached_area = ["CA"]
 
         # Toggle whether or not data is loaded in as it is being computed
-        # This may be set to False if you are interested in loading smaller chunks of data at a time, or with batch computing a series of warming level data points.
+        # This may be set to False if you are interested in loading smaller chunks of warming level data at a time, or in batch computing a series of warming level data points by creating all the xarray DataArrays first before loading them all in.
         self.load_data = True
 
     @param.depends("downscaling_method", watch=True)


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
Add functionality to optionally load in warming levels. This allows for lazy loading with xarray and for more data manipulation/subsetting before having to load data into memory.

**Relevant motivation and context**
We want to have the option to load in warming levels data or not. This can be toggled with the `wl.wl_params.load_data =True/False` parameter.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
In a notebook using warming levels.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

