### PR TITLE
Add logic to limit SSP selection to only 3-7 for WRF for pilot

### DIFF
--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -293,6 +293,13 @@ def _check_params_get_name(
     # Map SSP names from user inputs to selections SSPs
     ssp_selected = [ssp_mapping[ssp] for ssp in ssp_data]
 
+    # Only allow for SSP3-7.0 for WRF data
+    if downscaling_method == "Dynamical" and approach == "time":
+        if len(ssp_selected) > 1 or ssp_selected[0] != "SSP 3-7.0 -- Business as Usual":
+            raise ValueError(
+                "Can only look at SSP 3-7.0 data for a time-based approach using WRF data."
+            )
+
     # Determining if passed in variable is a climate variable or a derived index
     if variable == "Air Temperature at 2m" or variable == "Precipitation (total)":
         variable_type = "Variable"


### PR DESCRIPTION
# Description of PR
Small condition change, since we are hard coding using 3 km and hourly data selections for WRF data in pilot.

**Summary of changes and related issue**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

