### PR TITLE
Improve visualizations in the first panel of wl.visualize

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -791,7 +791,12 @@ def GCM_PostageStamps_MAIN_compute(wl_viz):
             if _check_single_spatial_dims(data_to_plot):
                 wl_plots = (
                     data_to_plot.hvplot.scatter(
-                        x="lon", y="lat", marker="s", s=150, frame_width=220
+                        x="lon",
+                        y="lat",
+                        marker="s",
+                        s=150,
+                        frame_width=220,
+                        hover_cols=data_to_plot.name,
                     )
                     .layout()
                     .cols(2)
@@ -876,10 +881,11 @@ def GCM_PostageStamps_MAIN_compute(wl_viz):
         else:
 
             # if there's only one data point, make a scatter plot
-            if len(data_to_plot.x.values) == 1 and len(data_to_plot.y.values) == 1:
+            if _check_single_spatial_dims(data_to_plot):
                 wl_plot = data_to_plot.hvplot.scatter(
                     x="lon",
                     y="lat",
+                    hover_cols=data_to_plot.name,
                     col_wrap="simulation",
                     clabel=data_to_plot.name + " (" + data_to_plot.attrs["units"] + ")",
                     marker="s",


### PR DESCRIPTION
# Improve visualizations in the first panel ("maps of individual simulations") in wl.visualize()

I improved the visualizations for the first panel in ```wl.visualize()```. I improved the colormap, addressing this old [issue](https://github.com/cal-adapt/climakitae/issues/299) Naomi raised. I also added a colorbar and reasonable plot titles. For data with more than 4 simulations, a single plot is shown with a dropdown widget for toggling between simulations. For data with 4 or fewer simulations, postage stamp maps are created. 

I also added the ability for a scatter plot to be generated for data that is only a single grid cell. It's not that informative, but at least it shows you something, and doesn't throw an error :) 

**To test**: Run the warming_levels.ipynb notebook up until ```wl.visualize()``` (section 1c in the notebook). Try a few different data options. 

**NOTE**: I wasn't able to get to the second tab-- the one with the stats-- before I headed out of town. I'll fix that one up when I return :D 

## Type of change
Subtle visualization improvements 
None of the below applicable
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**
n/a
- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

