### PR TITLE
Re-adding removed param from merge conflict

### DIFF
--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -540,7 +540,7 @@ def cava_data(
 
             if batch_mode:
                 separate_files = False
-                data_pts = batch_select(selections, locations)
+                data_pts = batch_select(selections, locations, "time")
 
             else:
 


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
Re-adding removed param from merge conflict. Was breaking `cava_data` but now it should be fixed.
