### PR TITLE
Debugging Beyond End of Century WL Behavior

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -280,6 +280,12 @@ def get_sliced_data(y, level, years, months=np.arange(1, 13), window=15, anom="Y
             - (expected_counts[y.frequency] - len(sliced)),
         )
 
+        # Add user warning if the total slice is missing any time that exceeds the 2100 year bound.
+        if len(sliced["time"]) < expected_counts[sliced.frequency]:
+            print(
+                f"Warming Level data for {sliced.simulation} is not completely available, since the warming level slice's center year is towards the end of the century. All other valid data is returned."
+            )
+
         # Removing data not in the desired months (in this new time dimension)
         sliced = sliced.sel(time=valid_months_mask)
 

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -283,7 +283,7 @@ def get_sliced_data(y, level, years, months=np.arange(1, 13), window=15, anom="Y
         # Add user warning if the total slice is missing any time that exceeds the 2100 year bound.
         if len(sliced["time"]) < expected_counts[sliced.frequency]:
             print(
-                f"Warming Level data for {sliced.simulation} is not completely available, since the warming level slice's center year is towards the end of the century. All other valid data is returned."
+                f"\nWarming Level data for {sliced.simulation[0]} is not completely available, since the warming level slice's center year is towards the end of the century. All other valid data is returned.\n"
             )
 
         # Removing data not in the desired months (in this new time dimension)


### PR DESCRIPTION
# Description of PR

**Summary of changes and related issue**
Addressing small bug with warming levels when slicing warming level data that goes beyond 2100. Currently, it creates smaller slices and centered the years incorrectly. Instead of -180 to 168 for a 30-year monthly WL that is centered around 2086 (so missing the last year), it creates a time index that is from -174 to 174 instead (wrong). 

This PR addresses this issue and centers the warming level slices correctly.

You can see this behavior by changing the default lat/lon params in `warming_levels.ipynb` to:
```
wl.wl_params.latitude=(34.0,34.03)
wl.wl_params.longitude=(-117.5,-117.45)
```

and checking out warming level slice 4.0. You can also see this behavior in a larger lat/lon subset, this just filters down the data to two gridcells so you can more easily see where the NaNs are for missing time-based data vs missing spatial data (due to how the xarray grids behave with our data).

**Relevant motivation and context**
Debug incorrect WL behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

