### PR TITLE
handle list input for scenario

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1499,14 +1499,6 @@ def get_data_options(
         "resolution": _list(resolution),
     }
 
-    # For the non-None inputs, check if the inputs are good
-    # If they're not good, make a guess
-    # vals_w_non_nan_input = {key: value for key, value in d.items() if value != [None}
-    # print(vals_w_non_nan_input)
-    # vals_w_non_nan_input = _check_if_good_input(vals_w_non_nan_input, cat_df)
-    # d = vals_w_non_nan_input | d  # Add back in the keys with None values
-    # print(d)
-
     d = _check_if_good_input(d, cat_df)
 
     # Subset the catalog with the user's inputs

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1379,9 +1379,10 @@ def _check_if_good_input(d, cat_df):
     ):  # Loop through each key, value pair in the dictionary
         # Use the catalog to find the valid values in the list
         valid_options = np.unique(cat_df[key].values)
-        if (
-            val == None
-        ):  # If the user didn't input anything for that key, set the values to all the valid options
+        if val in [
+            [None],
+            None,
+        ]:  # If the user didn't input anything for that key, set the values to all the valid options
             d[key] = valid_options
             continue  # Don't finish the loop
         # If the input value is not in the valid options, see if you can help the user out
@@ -1479,20 +1480,32 @@ def get_data_options(
 
     # Raise error for bad input from user
     for user_input in [variable, downscaling_method, resolution, timescale]:
-        if (user_input is not None) and (type(user_input) not in [str, list]):
+        if (user_input is not None) and (type(user_input) != str):
             print("Function arguments require a single string value for your inputs")
             return None
+
+    def _list(x):
+        """Convert x to a list if its not a list"""
+        if type(x) == list:
+            return x
+        elif type(x) != list:
+            return [x]
+
     d = {
-        "variable": variable if type(variable) == list else [variable],
-        "timescale": timescale if type(timescale) == list else [timescale],
-        "downscaling_method": (
-            downscaling_method
-            if type(downscaling_method) == list
-            else [downscaling_method]
-        ),
-        "scenario": scenario if type(scenario) == list else [scenario],
-        "resolution": resolution if type(resolution) == list else [resolution],
+        "variable": _list(variable),
+        "timescale": _list(timescale),
+        "downscaling_method": _list(downscaling_method),
+        "scenario": _list(scenario),
+        "resolution": _list(resolution),
     }
+
+    # For the non-None inputs, check if the inputs are good
+    # If they're not good, make a guess
+    # vals_w_non_nan_input = {key: value for key, value in d.items() if value != [None}
+    # print(vals_w_non_nan_input)
+    # vals_w_non_nan_input = _check_if_good_input(vals_w_non_nan_input, cat_df)
+    # d = vals_w_non_nan_input | d  # Add back in the keys with None values
+    # print(d)
 
     d = _check_if_good_input(d, cat_df)
 

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1460,7 +1460,7 @@ def get_data_options(
         Default to None
     timescale: str, optional
         Default to None
-    scenario: str, optional
+    scenario: str or list, optional
         Default to None
     tidy: boolean, optional
         Format the pandas dataframe? This creates a DataFrame with a MultiIndex that makes it easier to parse the options.


### PR DESCRIPTION
# Description of PR

**See header below "How to test" for instructions on how to test this PR**

 When I wrote the new ```get_data``` function for the climatekitae_direct_data_download notebook (the functions that let you access/download data without the GUI), I wrote it such that you could only retrieve data for a single scenario (because it was way more simple programmatically). 

In working on the warming levels code, I realized we really need to be able to pull multiple scenarios, like the selections GUI does. So, in this update, I allow you to use a list as an input for the scenario object. 

## How to test

In the climakitae_direct_data_download notebook, try retrieving and viewing different data options using the following two functions: ```get_data_options``` and ```get_data```.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

