### PR TITLE
mm/time unit bug

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -920,9 +920,6 @@ class DataParameters(param.Parameterized):
             self.variable_options_df["display_name"] == self.variable
         ]
         native_unit = var_info.unit.item()
-        if native_unit in ["mm/d", "mm/h"]:
-            # Show same unit options for all mm
-            native_unit = "mm"
         if (
             native_unit in self.unit_options_dict.keys()
         ):  # See if there's unit conversion options for native variable

--- a/climakitae/util/unit_conversions.py
+++ b/climakitae/util/unit_conversions.py
@@ -16,6 +16,8 @@ def get_unit_conversion_options():
         "m s-1": ["m s-1", "mph", "knots"],
         "[0 to 100]": ["[0 to 100]", "fraction"],
         "mm": ["mm", "inches"],
+        "mm/d": ["mm/d", "inches/d"],
+        "mm/h": ["mm/h", "inches/h"],
         "kg/kg": ["kg/kg", "g/kg"],
         "kg kg-1": ["kg kg-1", "g kg-1"],
         "kg m-2 s-1": ["kg m-2 s-1", "mm", "inches"],
@@ -71,7 +73,7 @@ def convert_units(da, selected_units):
 
     # Precipitation units
     elif native_units in ["mm", "mm/d", "mm/h"]:
-        if selected_units == "inches":
+        if selected_units in ["inches", "inches/h", "inches/d"]:
             da = da / 25.4
         elif selected_units == "kg m-2 s-1":
             da = da / 86400


### PR DESCRIPTION
# Description of PR

Fix bug in code that was causing an error if you tried to retrieve variables with units of mm/time (Evaporation and Maximum Precipitation) 

## How To Test 
Try retrieving the max precip and evaporation variables in different units. Confirm that you can retrieve the data without error and that the unit conversions look okay :D 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

