### PR TITLE
Unit conversion happening twice

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -596,8 +596,8 @@ def _merge_all(selections, data_dict):
     all_ssps = all_ssps[var_id]
 
     # Convert units:
-    all_ssps = _override_unit_defaults(all_ssps, var_id)
-    all_ssps = convert_units(da=all_ssps, selected_units=selections.units)
+    # all_ssps = _override_unit_defaults(all_ssps, var_id)
+    # all_ssps = convert_units(da=all_ssps, selected_units=selections.units)
 
     return all_ssps
 

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -595,10 +595,6 @@ def _merge_all(selections, data_dict):
     var_id = list(all_ssps.data_vars)[0]
     all_ssps = all_ssps[var_id]
 
-    # Convert units:
-    # all_ssps = _override_unit_defaults(all_ssps, var_id)
-    # all_ssps = convert_units(da=all_ssps, selected_units=selections.units)
-
     return all_ssps
 
 


### PR DESCRIPTION
# Description of PR

Looks like unit conversion was happening two times in the data retrieval code. An error was being raised for monthly precip data retrieval in the first conversion because the frequency attribute had not yet been added by that time in the workflow, raising an error for unit conversion. 

I'm not sure if this may raise other issues down the line. I tested a few conversions and it seems fine but maybe there are things I'm not thinking of. Time will tell...

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.**

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

