### PR TITLE
Making bug fix for WRF WL derived vars

### DIFF
--- a/climakitae/tools/indices.py
+++ b/climakitae/tools/indices.py
@@ -159,7 +159,8 @@ def fosberg_fire_index(t2_F, rh_percent, windspeed_mph):
     # Compute the index
     U = windspeed_mph
     # If the value falls out of [0-100] range clip the value
-    FFWI = np.clip((n * ((1 + U**2) ** 0.5)) / 0.3002, 0.0, 100.0)
+    tmp = (n * ((1 + U**2) ** 0.5)) / 0.3002
+    FFWI = tmp.clip(min=0.0, max=100.0)
 
     # Reassign coordinate attributes
     # For some reason, these get improperly assigned in the xr.where step

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -900,12 +900,12 @@ def drop_invalid_wrf_sims(ds):
         raise AttributeError(
             "Missing an `all_sims` dimension on the dataset. Create `all_sims` with .stack on `simulation` and `scenario`."
         )
-    
+
     # Checking for derived variables separately since we don't store their IDs in the catalog
     # Future derived variables that don't use `t2` will be broken because of this function.
     variable = ds.variable_id
-    if 'derived' in variable:
-        variable = 't2'
+    if "derived" in variable:
+        variable = "t2"
 
     # Find valid simulation from catalog
     df = intake.open_esm_datastore(data_catalog_url).df

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -900,6 +900,12 @@ def drop_invalid_wrf_sims(ds):
         raise AttributeError(
             "Missing an `all_sims` dimension on the dataset. Create `all_sims` with .stack on `simulation` and `scenario`."
         )
+    
+    # Checking for derived variables separately since we don't store their IDs in the catalog
+    # Future derived variables that don't use `t2` will be broken because of this function.
+    variable = ds.variable_id
+    if 'derived' in variable:
+        variable = 't2'
 
     # Find valid simulation from catalog
     df = intake.open_esm_datastore(data_catalog_url).df
@@ -907,7 +913,7 @@ def drop_invalid_wrf_sims(ds):
         (df["activity_id"] == "WRF")
         & (df["table_id"] == timescale_to_table_id(ds.frequency))
         & (df["grid_label"] == resolution_to_gridlabel(ds.resolution))
-        & (df["variable_id"] == ds.variable_id)
+        & (df["variable_id"] == variable)
         & (df["experiment_id"] != "historical")
         & (df["experiment_id"] != "reanalysis")
         & (df["source_id"] != "ensmean")


### PR DESCRIPTION
# Description of PR

### Summary of changes and related issue
Making WRF WL derived vars work again.

### Relevant motivation and context
This broke because of a change I made for filtering WRF WL simulations. Derived indices weren't accounted for, and now they are, in a very hot fix way. All derived indices currently use temperature, so that is the psuedo-variable we're using to replace the derived index variable when looking through the catalog for valid WRF WL simulations.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<br>

## Definition of Done Checklist

#### Practical
- [x] 80% unit test coverage
- [x] Documentation
  - [ ] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [ ] Documentation is pushed
- [x] Complex code commented
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Context of function is clearly provided
  - [ ] Intent of function is provided
  - [ ] How to test, so that it is not siloed on scientists and anyone can review
  - [ ] Appropriate manual testing was completed
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Linting completed and resolved

#### Conceptual
- [x] Doesn't replicate existing functionality
- [x] Aligns with general coding standard of existing functions
- [x] Matches desired functinonality from users/scientists
