### PR TITLE
Enable retrieval using lat/lon bounds for get_data function

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1806,10 +1806,10 @@ def get_data(
         Default to "No".
     latitude: None or tuple of float, optional
         Tuple of valid latitude bounds
-        Default to None: spatial subset by shapefile
+        Default to entire domain 
     longitude: None or tuple of float, optional
         Tuple of valid longitude bounds
-        Default to None: spatial subset by shapefile
+        Default to entire domain 
     time_slice: tuple, optional
         Time range for retrieved data
         Only valid for approach = "Time"


### PR DESCRIPTION
# Description of PR
Enable user to retrieve data using ```get_data``` function for a lat/lon spatial subsetting. 

For example:

```
get_data(
    variable = "Precipitation (total)", 
    downscaling_method = "Dynamical", 
    resolution = "9 km", 
    timescale = "monthly", 
    scenario = "SSP 3-7.0 -- Business as Usual",
    latitude=(32.5),
    longitude=(-125.5, -114) 
)
```

### Summary of changes and related issue
Two new arguments were added: "latitude" and "longitude". Enables the user to input a tuple of lat/lon bounds to retrieve, analogous to what is done in the backend by the GUI

### Relevant motivation and context
We often retrieve data using a lat/lon bounding box. Added this feature so we could do that without using the GUI. 

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test
Try retrieving data using the "latitude" and "longitude" bounds. 

<br>

## Definition of Done Checklist

#### Practical
- [x] 80% unit test coverage
- [x] Documentation
  - [x] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [x] Documentation is pushed
- [x] Complex code commented
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Context of function is clearly provided
  - [x] Intent of function is provided
  - [x] How to test, so that it is not siloed on scientists and anyone can review
  - [x] Appropriate manual testing was completed
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Linting completed and resolved

#### Conceptual
- [x] Doesn't replicate existing functionality
- [x] Aligns with general coding standard of existing functions
- [x] Matches desired functinonality from users/scientists
