### PR TITLE
Enable non-GUI view and retrieval of derived variables/indices

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -2066,6 +2066,12 @@ def get_data(
     # Check if the user inputs make sense
     cat_dict = _check_if_good_input(cat_dict, cat_df)
 
+    # Check if it's an index
+    variable_id = (
+        var_df[var_df["display_name"] == cat_dict["variable"][0]].iloc[0].variable_id
+    )
+    variable_type = "Derived Index" if "_index" in variable_id else "Variable"
+
     # Settings for selections
     selections_dict = {
         "variable": cat_dict["variable"][0],
@@ -2080,6 +2086,7 @@ def get_data(
         "warming_level": warming_level,
         "warming_level_window": warming_level_window,
         "warming_level_months": warming_level_months,
+        "variable_type": variable_type,
         "time_slice": time_slice,
         "latitude": latitude,
         "longitude": longitude,
@@ -2121,9 +2128,10 @@ def get_data(
         selections.area_subset = selections_dict["area_subset"]
         selections.cached_area = selections_dict["cached_area"]
         selections.downscaling_method = selections_dict["downscaling_method"]
-        selections.variable = selections_dict["variable"]
         selections.resolution = selections_dict["resolution"]
         selections.timescale = selections_dict["timescale"]
+        selections.variable_type = selections_dict["variable_type"]
+        selections.variable = selections_dict["variable"]
         selections.units = selections_dict["units"]
 
         # Setting the values like this enables us to take advantage of the default settings in DataParameters without having to manually set defaults in this function

--- a/climakitae/data/variable_descriptions.csv
+++ b/climakitae/data/variable_descriptions.csv
@@ -1,71 +1,71 @@
-variable_id,downscaling_method,timescale,unit,display_name,extended_description,colormap,show
-t2,Dynamical,hourly,K,Air Temperature at 2m,Temperature of the air 2m above Earth's surface. This is the measure of air temperature used for most modeling applications.,ae_orange,TRUE
-prec,Dynamical,hourly,mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE
-rh_derived,Dynamical,hourly,[0 to 100],Relative humidity,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
-wind_speed_derived,Dynamical,hourly,m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE
-wind_direction_derived,Dynamical,hourly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention direction is defined as where wind originates from (i.e. North is 0/360 deg).,ae_orange,TRUE
-dew_point_derived_hrly,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
-u10,Dynamical,hourly,m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE
-v10,Dynamical,hourly,m s-1,North-South component of Wind at 10m,"Wind coming from the north, measured at 10m above Earth's surface. By convention, wind coming from the south is negative.",ae_diverging,TRUE
-psfc,Dynamical,hourly,Pa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE
-q2_derived,Dynamical,hourly,g/kg,Specific humidity at 2m,"The ratio of the mass of water vapor over the mass of total (moist) air, measured 2m above Earth's surface.",ae_blue,TRUE
-q2,Dynamical,hourly,kg kg-1,Water Vapor Mixing Ratio at 2m,"The ratio of the mass of water vapor over the mass of dry air, measured 2m above Earth's surface.",ae_blue,TRUE
-tsk,Dynamical,hourly,K,Surface skin temperature,"Temperature of the Earth's surface (i.e., ground surface).  Typically not used in most applications.",ae_orange,TRUE
-lwdnb,Dynamical,hourly,W/m2,Instantaneous downwelling longwave flux at bottom,Longwave radiation emitted by Earth's surface that is reflected back downwards by gasses and clouds. ,ae_orange,TRUE
-lwdnbc,Dynamical,hourly,W/m2,Instantaneous downwelling clear sky longwave flux at bottom,"Longwave radiation emitted by Earth's surface that is reflected back downwards by the atmosphere, excluding the effect of clouds.",ae_orange,TRUE
-lwupb,Dynamical,hourly,W/m2,Instantaneous upwelling longwave flux at bottom,Total amount of longwave radiation emitted by Earth's surface. ,ae_orange,TRUE
-lwupbc,Dynamical,hourly,W/m2,Instantaneous upwelling clear sky longwave flux at bottom,Total amount of longwave radiation emitted by Earth's surface excluding impacts of clouds. ,ae_orange,TRUE
-swddni,Dynamical,hourly,W/m2,Shortwave surface downward direct normal irradiance,"The portion of the total incoming solar radiation that is received perpendicular to the sun.",ae_orange,TRUE
-swddir,Dynamical,hourly,W/m2,Shortwave surface downward direct irradiance,"The portion of the total incoming solar radiation that is received directly at the Earth's surface (not scattered).",ae_orange,TRUE
-swddif,Dynamical,hourly,W/m2,Shortwave surface downward diffuse irradiance,"The portion of the total incoming solar radiation that has been scattered (by the atmosphere, clouds, etc.) before reaching the Earth's surface.",ae_orange,TRUE
-swdnb,Dynamical,hourly,W/m2,Instantaneous downwelling shortwave flux at bottom,"Shortwave radiation from the sun that reaches Earth's surface.",ae_orange,TRUE
-swdnbc,Dynamical,hourly,W/m2,Instantaneous downwelling clear sky shortwave flux at bottom,"Shortwave radiation from the sun that reaches Earth's surface, excluding impacts of clouds.",ae_orange,TRUE
-swupb,Dynamical,hourly,W/m2,Instantaneous upwelling shortwave flux at bottom,"Shortwave radiation from the sun that is reflected by Earth's surface, some of which may be reflected or absorbed by clouds (i.e. not emitted to space).",ae_orange,TRUE
-swupbc,Dynamical,hourly,W/m2,Instantaneous upwelling clear sky shortwave flux at bottom,Shortwave radiation from the sun that is reflected by Earth's surface back to space.,ae_orange,TRUE
-snownc,Dynamical,hourly,mm,Snowfall (snow and ice),"Portion of the total frozen precipitation, which consists of frozen rain, snow, sleet, graupel and ice pellets",ae_blue,TRUE
-rainc,Dynamical,hourly,mm,Precipitation (cumulus portion only),"Any form of precipitation (rain, snow, etc.) that is produced specifically by cumulus/cumulonimbus clouds. These are generally small clouds that bring heavy precipitation.",ae_blue,TRUE
-rainnc,Dynamical,hourly,mm,Precipitation (grid-scale portion only),"Any form of precipitation (rain, snow, etc.) captured by the model resolution (i.e. 45km). Small clouds (including cumulus clouds) typically are excluded from this.",ae_blue,TRUE
-runsb,Dynamical,hourly,mm/s,Subsurface runoff,"The rate at which  water that has infiltrated the ground surface travels underground until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE
-runsf,Dynamical,hourly,mm/s,Surface runoff,"The rate at which water travels over the ground surface until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE
-snow,Dynamical,hourly,kg m-2,Snow water equivalent,The amount of water on surface that would be present if all snow melted. ,ae_blue,FALSE
-t2,Dynamical,"daily, monthly",K,Air Temperature at 2m,Temperature of the air 2m above Earth's surface. This is the measure of air temperature used for most modeling applications.,ae_orange,TRUE
-prec,Dynamical,"daily, monthly",mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE
-rh,Dynamical,"daily, monthly",[0 to 100],Relative humidity,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
-dew_point_derived,Dynamical,"daily, monthly",K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE
-wspd10mean,Dynamical,"daily, monthly",m/s,Mean wind speed at 10m,The average wind speed (magnitude) at 10m above the Earth's surface. ,ae_orange,TRUE
-wspd10max,Dynamical,"daily, monthly",m/s,Maximum wind speed at 10m,The maximum wind speed at 10m above the Earth's surface. ,ae_orange,TRUE
-psfc,Dynamical,"daily, monthly",hPa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE
-q2,Dynamical,"daily, monthly",g/kg,Specific humidity at 2m,"The ratio of the mass of water vapor over the mass of total (moist) air, measured 2m above Earth's surface.",ae_blue,TRUE
-tskin,Dynamical,"daily, monthly",K,Surface skin temperature,Temperature of the Earth's surface (ground surface).,ae_orange,TRUE
-t2max,Dynamical,"daily, monthly",K,Maximum air temperature at 2m,The maximum air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
-t2min,Dynamical,"daily, monthly",K,Minimum air temperature at 2m,The minimum air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
-lw_dwn,Dynamical,"daily, monthly",W/m2,Instantaneous downwelling longwave flux at bottom,Longwave radiation emitted by Earth's surface that is reflected back downwards by clouds. ,ae_orange,TRUE
-sw_dwn,Dynamical,"daily, monthly",W/m2,Instantaneous downwelling shortwave flux at bottom,"Shortwave radiation from the sun that reaches Earth's surface, minus radiation reflected back to space by clouds or absorbed by the atmosphere.",ae_orange,TRUE
-sw_sfc,Dynamical,"daily, monthly",W/m2,Shortwave flux at the surface,Shortwave radiation from the sun that reaches Earth's surface. ,ae_orange,TRUE
-lw_sfc,Dynamical,"daily, monthly",W/m2,Longwave flux at the surface,Longwave radiation emitted by Earth's surface.,ae_orange,TRUE
-sh_sfc,Dynamical,"daily, monthly",W/m2,Sensible heat flux at the surface,"The movement of energy generated by a difference in temperatures between the surface and the atmosphere. By convention, positive sensible heat flux is directed from the surface up into the atmosphere. ",ae_diverging,TRUE
-lh_sfc,Dynamical,"daily, monthly",W/m2,Latent heat flux at the surface,"The movement of energy generated by evaporation or condensation between the surface and the atmosphere. By convention, positive latent heat flux is directed  from the surface up into the atmosphere. ",ae_diverging_r,TRUE
-gh_sfc,Dynamical,"daily, monthly",W/m2,Ground heat flux,"The energy gained or loss by the Earth's surface. By convention, positive ground heat flux is directed into the ground. ",ae_diverging,TRUE
-prec_snow,Dynamical,"daily, monthly",mm,Snowfall,Portion of the total precipitation in the form of snow. ,ae_blue,TRUE
-lwp,Dynamical,"daily, monthly",kg/m2,Liquid water path,"The total amount of liquid water present from ground to top of atmosphere, and is critical for assessing the influence of clouds on radiation.",ae_blue,TRUE
-etrans_sfc,Dynamical,"daily, monthly",mm/d,Evapotranspiration,"The physical process by which liquid water in ground/surface enters the atmosphere, including evaporation and plant transpiration. By convention, negative evapotranspiration is condensation, in which a liquid forms. ",ae_diverging_r,FALSE
-evap_sfc,Dynamical,"daily, monthly",mm/d,Evaporation,"The physical process by which a liquid is transformed to a gas. By convention, negative evaporation is condensation, in which a liquid forms. ",ae_diverging_r,TRUE
-prec_c,Dynamical,"daily, monthly",mm/d,Precipitation (convective only),"Any form of precipitation (rain, snow, etc.) that is produced specifically by convective clouds. These are generally small clouds that bring heavy, or severe, precipitation. ",ae_blue,FALSE
-iwp,Dynamical,"daily, monthly",kg/m2,Ice water path,The integral of ice water content through an ice cloud layer. IWP is critical for assessing optical properties of clouds and their influence on radiation. ,ae_blue,TRUE
-sfc_runoff,Dynamical,"daily, monthly",mm/d,Surface runoff,"The rate at which water travels over the ground surface until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE
-subsfc_runoff,Dynamical,"daily, monthly",mm/d,Subsurface runoff,"The rate at which  water that has infiltrated the ground surface travels underground until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE
-prec_max,Dynamical,"daily, monthly",mm/h,Maximum precipitation,The maximum precipitation rate in a single hour. ,ae_blue,TRUE
-snow,Dynamical,"daily, monthly",mm,Snow water equivalent,The amount of water that would be present if all snow melted. ,ae_blue,FALSE
-pr,Statistical,"daily, monthly",kg m-2 s-1,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE
-tasmax,Statistical,"daily, monthly",K,Maximum air temperature at 2m,The maximum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
-tasmin,Statistical,"daily, monthly",K,Minimum air temperature at 2m,The minimum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE
-uas,Statistical,"daily, monthly",m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE
-vas,Statistical,"daily, monthly",m s-1,North-South component of Wind at 10m,"Wind coming from the north, measured at 10m above Earth's surface. By convention, wind coming from the south is negative.",ae_diverging,TRUE
-huss,Statistical,"daily, monthly",kg/kg,Specific humidity at 2m,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
-hursmin,Statistical,"daily, monthly",percent,Minimum relative humidity,The minimum percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
-hursmax,Statistical,"daily, monthly",percent,Maximum relative humidity,The maximum percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE
-wspeed,Statistical,"daily, monthly",m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE
-rsds,Statistical,"daily, monthly",W/m2,Shortwave flux at the surface,Shortwave radiation from the sun that reaches Earth's surface. ,ae_orange,TRUE
-fosberg_index_derived,Dynamical,hourly,[0 to 100],Fosberg fire weather index,"Fire weather index using meteorological inputs (temperature, relative humidity, windspeed) to quantify fire risk. Large values imply a higher risk value.",ae_orange,TRUE
-effective_temp_index_derived,Dynamical,daily,K,Effective Temperature,The sum of half of yesterday's effective temperature and half of the current day's actual temperature. Accounts for previous day's temperature due to consumer behavior and perception of the weather. ,ae_orange,TRUE
-noaa_heat_index_derived,Dynamical,hourly,degF,NOAA Heat Index,"A measure of what the the temperature ""feels like"" to the human body. The returned values are for shady locations only. Based on a multiple regression analysis carried out by Lans P. Rothfusz and described in a 1990 National Weather Service (NWS) Technical Attachment (SR 90-23). ",ae_orange,TRUE
+variable_id,downscaling_method,timescale,unit,display_name,extended_description,colormap,show,dependencies
+t2,Dynamical,hourly,K,Air Temperature at 2m,Temperature of the air 2m above Earth's surface. This is the measure of air temperature used for most modeling applications.,ae_orange,TRUE,None
+prec,Dynamical,hourly,mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE,None
+rh_derived,Dynamical,hourly,[0 to 100],Relative humidity,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE,"t2, q2, psfc"
+wind_speed_derived,Dynamical,hourly,m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE,"u10, v10"
+wind_direction_derived,Dynamical,hourly,degrees,Wind direction at 10m,Wind direction at 10 meters above the Earth's surface. By meteorological convention direction is defined as where wind originates from (i.e. North is 0/360 deg).,ae_orange,TRUE,"u10, v10"
+dew_point_derived_hrly,Dynamical,hourly,K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE,"t2, q2, psfc"
+u10,Dynamical,hourly,m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE,None
+v10,Dynamical,hourly,m s-1,North-South component of Wind at 10m,"Wind coming from the north, measured at 10m above Earth's surface. By convention, wind coming from the south is negative.",ae_diverging,TRUE,None
+psfc,Dynamical,hourly,Pa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE,None
+q2_derived,Dynamical,hourly,g/kg,Specific humidity at 2m,"The ratio of the mass of water vapor over the mass of total (moist) air, measured 2m above Earth's surface.",ae_blue,TRUE,"t2, q2, psfc"
+q2,Dynamical,hourly,kg kg-1,Water Vapor Mixing Ratio at 2m,"The ratio of the mass of water vapor over the mass of dry air, measured 2m above Earth's surface.",ae_blue,TRUE,None
+tsk,Dynamical,hourly,K,Surface skin temperature,"Temperature of the Earth's surface (i.e., ground surface).  Typically not used in most applications.",ae_orange,TRUE,None
+lwdnb,Dynamical,hourly,W/m2,Instantaneous downwelling longwave flux at bottom,Longwave radiation emitted by Earth's surface that is reflected back downwards by gasses and clouds. ,ae_orange,TRUE,None
+lwdnbc,Dynamical,hourly,W/m2,Instantaneous downwelling clear sky longwave flux at bottom,"Longwave radiation emitted by Earth's surface that is reflected back downwards by the atmosphere, excluding the effect of clouds.",ae_orange,TRUE,None
+lwupb,Dynamical,hourly,W/m2,Instantaneous upwelling longwave flux at bottom,Total amount of longwave radiation emitted by Earth's surface. ,ae_orange,TRUE,None
+lwupbc,Dynamical,hourly,W/m2,Instantaneous upwelling clear sky longwave flux at bottom,Total amount of longwave radiation emitted by Earth's surface excluding impacts of clouds. ,ae_orange,TRUE,None
+swddni,Dynamical,hourly,W/m2,Shortwave surface downward direct normal irradiance,The portion of the total incoming solar radiation that is received perpendicular to the sun.,ae_orange,TRUE,None
+swddir,Dynamical,hourly,W/m2,Shortwave surface downward direct irradiance,The portion of the total incoming solar radiation that is received directly at the Earth's surface (not scattered).,ae_orange,TRUE,None
+swddif,Dynamical,hourly,W/m2,Shortwave surface downward diffuse irradiance,"The portion of the total incoming solar radiation that has been scattered (by the atmosphere, clouds, etc.) before reaching the Earth's surface.",ae_orange,TRUE,None
+swdnb,Dynamical,hourly,W/m2,Instantaneous downwelling shortwave flux at bottom,Shortwave radiation from the sun that reaches Earth's surface.,ae_orange,TRUE,None
+swdnbc,Dynamical,hourly,W/m2,Instantaneous downwelling clear sky shortwave flux at bottom,"Shortwave radiation from the sun that reaches Earth's surface, excluding impacts of clouds.",ae_orange,TRUE,None
+swupb,Dynamical,hourly,W/m2,Instantaneous upwelling shortwave flux at bottom,"Shortwave radiation from the sun that is reflected by Earth's surface, some of which may be reflected or absorbed by clouds (i.e. not emitted to space).",ae_orange,TRUE,None
+swupbc,Dynamical,hourly,W/m2,Instantaneous upwelling clear sky shortwave flux at bottom,Shortwave radiation from the sun that is reflected by Earth's surface back to space.,ae_orange,TRUE,None
+snownc,Dynamical,hourly,mm,Snowfall (snow and ice),"Portion of the total frozen precipitation, which consists of frozen rain, snow, sleet, graupel and ice pellets",ae_blue,TRUE,None
+rainc,Dynamical,hourly,mm,Precipitation (cumulus portion only),"Any form of precipitation (rain, snow, etc.) that is produced specifically by cumulus/cumulonimbus clouds. These are generally small clouds that bring heavy precipitation.",ae_blue,TRUE,None
+rainnc,Dynamical,hourly,mm,Precipitation (grid-scale portion only),"Any form of precipitation (rain, snow, etc.) captured by the model resolution (i.e. 45km). Small clouds (including cumulus clouds) typically are excluded from this.",ae_blue,TRUE,None
+runsb,Dynamical,hourly,mm/s,Subsurface runoff,"The rate at which  water that has infiltrated the ground surface travels underground until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE,None
+runsf,Dynamical,hourly,mm/s,Surface runoff,"The rate at which water travels over the ground surface until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE,None
+snow,Dynamical,hourly,kg m-2,Snow water equivalent,The amount of water on surface that would be present if all snow melted. ,ae_blue,FALSE,None
+t2,Dynamical,"daily, monthly",K,Air Temperature at 2m,Temperature of the air 2m above Earth's surface. This is the measure of air temperature used for most modeling applications.,ae_orange,TRUE,None
+prec,Dynamical,"daily, monthly",mm,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE,None
+rh,Dynamical,"daily, monthly",[0 to 100],Relative humidity,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE,None
+dew_point_derived,Dynamical,"daily, monthly",K,Dew point temperature,"The temperature the air needs to be cooled to, at constant pressure, in order to achieve a relative humidity of 100%.",ae_orange,TRUE,"t2, rh"
+wspd10mean,Dynamical,"daily, monthly",m/s,Mean wind speed at 10m,The average wind speed (magnitude) at 10m above the Earth's surface. ,ae_orange,TRUE,None
+wspd10max,Dynamical,"daily, monthly",m/s,Maximum wind speed at 10m,The maximum wind speed at 10m above the Earth's surface. ,ae_orange,TRUE,None
+psfc,Dynamical,"daily, monthly",hPa,Surface Pressure,Air pressure at Earth's surface.,ae_diverging,TRUE,None
+q2,Dynamical,"daily, monthly",g/kg,Specific humidity at 2m,"The ratio of the mass of water vapor over the mass of total (moist) air, measured 2m above Earth's surface.",ae_blue,TRUE,None
+tskin,Dynamical,"daily, monthly",K,Surface skin temperature,Temperature of the Earth's surface (ground surface).,ae_orange,TRUE,None
+t2max,Dynamical,"daily, monthly",K,Maximum air temperature at 2m,The maximum air temperature at 2m above the Earth's surface. ,ae_orange,TRUE,None
+t2min,Dynamical,"daily, monthly",K,Minimum air temperature at 2m,The minimum air temperature at 2m above the Earth's surface. ,ae_orange,TRUE,None
+lw_dwn,Dynamical,"daily, monthly",W/m2,Instantaneous downwelling longwave flux at bottom,Longwave radiation emitted by Earth's surface that is reflected back downwards by clouds. ,ae_orange,TRUE,None
+sw_dwn,Dynamical,"daily, monthly",W/m2,Instantaneous downwelling shortwave flux at bottom,"Shortwave radiation from the sun that reaches Earth's surface, minus radiation reflected back to space by clouds or absorbed by the atmosphere.",ae_orange,TRUE,None
+sw_sfc,Dynamical,"daily, monthly",W/m2,Shortwave flux at the surface,Shortwave radiation from the sun that reaches Earth's surface. ,ae_orange,TRUE,None
+lw_sfc,Dynamical,"daily, monthly",W/m2,Longwave flux at the surface,Longwave radiation emitted by Earth's surface.,ae_orange,TRUE,None
+sh_sfc,Dynamical,"daily, monthly",W/m2,Sensible heat flux at the surface,"The movement of energy generated by a difference in temperatures between the surface and the atmosphere. By convention, positive sensible heat flux is directed from the surface up into the atmosphere. ",ae_diverging,TRUE,None
+lh_sfc,Dynamical,"daily, monthly",W/m2,Latent heat flux at the surface,"The movement of energy generated by evaporation or condensation between the surface and the atmosphere. By convention, positive latent heat flux is directed  from the surface up into the atmosphere. ",ae_diverging_r,TRUE,None
+gh_sfc,Dynamical,"daily, monthly",W/m2,Ground heat flux,"The energy gained or loss by the Earth's surface. By convention, positive ground heat flux is directed into the ground. ",ae_diverging,TRUE,None
+prec_snow,Dynamical,"daily, monthly",mm,Snowfall,Portion of the total precipitation in the form of snow. ,ae_blue,TRUE,None
+lwp,Dynamical,"daily, monthly",kg/m2,Liquid water path,"The total amount of liquid water present from ground to top of atmosphere, and is critical for assessing the influence of clouds on radiation.",ae_blue,TRUE,None
+etrans_sfc,Dynamical,"daily, monthly",mm/d,Evapotranspiration,"The physical process by which liquid water in ground/surface enters the atmosphere, including evaporation and plant transpiration. By convention, negative evapotranspiration is condensation, in which a liquid forms. ",ae_diverging_r,FALSE,None
+evap_sfc,Dynamical,"daily, monthly",mm/d,Evaporation,"The physical process by which a liquid is transformed to a gas. By convention, negative evaporation is condensation, in which a liquid forms. ",ae_diverging_r,TRUE,None
+prec_c,Dynamical,"daily, monthly",mm/d,Precipitation (convective only),"Any form of precipitation (rain, snow, etc.) that is produced specifically by convective clouds. These are generally small clouds that bring heavy, or severe, precipitation. ",ae_blue,FALSE,None
+iwp,Dynamical,"daily, monthly",kg/m2,Ice water path,The integral of ice water content through an ice cloud layer. IWP is critical for assessing optical properties of clouds and their influence on radiation. ,ae_blue,TRUE,None
+sfc_runoff,Dynamical,"daily, monthly",mm/d,Surface runoff,"The rate at which water travels over the ground surface until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE,None
+subsfc_runoff,Dynamical,"daily, monthly",mm/d,Subsurface runoff,"The rate at which  water that has infiltrated the ground surface travels underground until it reaches a body of water (stream, river, etc.)",ae_blue,FALSE,None
+prec_max,Dynamical,"daily, monthly",mm/h,Maximum precipitation,The maximum precipitation rate in a single hour. ,ae_blue,TRUE,None
+snow,Dynamical,"daily, monthly",mm,Snow water equivalent,The amount of water that would be present if all snow melted. ,ae_blue,FALSE,None
+pr,Statistical,"daily, monthly",kg m-2 s-1,Precipitation (total),Total precipitation. Computed by summing total gridscale precipitation and total cumulus precipitation.,ae_blue,TRUE,None
+tasmax,Statistical,"daily, monthly",K,Maximum air temperature at 2m,The maximum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE,None
+tasmin,Statistical,"daily, monthly",K,Minimum air temperature at 2m,The minimum daily air temperature at 2m above the Earth's surface. ,ae_orange,TRUE,None
+uas,Statistical,"daily, monthly",m s-1,West-East component of Wind at 10m,"Wind coming from the west, measured at 10m above Earth's surface. By convention, wind coming from the east is negative.",ae_diverging,TRUE,None
+vas,Statistical,"daily, monthly",m s-1,North-South component of Wind at 10m,"Wind coming from the north, measured at 10m above Earth's surface. By convention, wind coming from the south is negative.",ae_diverging,TRUE,None
+huss,Statistical,"daily, monthly",kg/kg,Specific humidity at 2m,The percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE,None
+hursmin,Statistical,"daily, monthly",percent,Minimum relative humidity,The minimum percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE,None
+hursmax,Statistical,"daily, monthly",percent,Maximum relative humidity,The maximum percentage of water vapor (i.e. moisture) relative to the amount of water vapor needed to saturate the air at the current air temperature and pressure.,ae_blue,TRUE,None
+wspeed,Statistical,"daily, monthly",m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE,None
+rsds,Statistical,"daily, monthly",W/m2,Shortwave flux at the surface,Shortwave radiation from the sun that reaches Earth's surface. ,ae_orange,TRUE,None
+fosberg_index_derived,Dynamical,hourly,[0 to 100],Fosberg fire weather index,"Fire weather index using meteorological inputs (temperature, relative humidity, windspeed) to quantify fire risk. Large values imply a higher risk value.",ae_orange,TRUE,"t2, q2, psfc, u10"
+effective_temp_index_derived,Dynamical,daily,K,Effective Temperature,The sum of half of yesterday's effective temperature and half of the current day's actual temperature. Accounts for previous day's temperature due to consumer behavior and perception of the weather. ,ae_orange,TRUE,t2
+noaa_heat_index_derived,Dynamical,hourly,degF,NOAA Heat Index,"A measure of what the the temperature ""feels like"" to the human body. The returned values are for shady locations only. Based on a multiple regression analysis carried out by Lans P. Rothfusz and described in a 1990 National Weather Service (NWS) Technical Attachment (SR 90-23). ",ae_orange,TRUE,"t2, q2, psfc"

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -857,6 +857,20 @@ def _get_cat_subset(selections):
 
     method_list = downscaling_method_as_list(selections.downscaling_method)
 
+    # If the variable is a derived variable, get the catalog subset for the first variable dependency
+    if "_derived" in selections.variable_id[0]:
+        var_descrip_df = selections._variable_descriptions
+        first_dependency_var_id = (
+            var_descrip_df[var_descrip_df["variable_id"] == selections.variable_id[0]][
+                "dependencies"
+            ]
+            .values[0]
+            .split(",")[0]
+        )
+        variable_id = [first_dependency_var_id]
+    else:  # Otherwise, just use the variable id
+        variable_id = selections.variable_id
+
     # Get catalog keys
     # Convert user-friendly names to catalog names (i.e. "45 km" to "d01")
     activity_id = [downscaling_method_to_activity_id(dm) for dm in method_list]
@@ -864,7 +878,6 @@ def _get_cat_subset(selections):
     grid_label = resolution_to_gridlabel(selections.resolution)
     experiment_id = [scenario_to_experiment_id(x) for x in scenario_selections]
     source_id = selections.simulation
-    variable_id = selections.variable_id
 
     cat_subset = selections._data_catalog.search(
         activity_id=activity_id,

--- a/tests/data_interface/test_variable_descriptions_csv.py
+++ b/tests/data_interface/test_variable_descriptions_csv.py
@@ -1,0 +1,80 @@
+"""Test to see that variable descriptions csv is formatted appropriately 
+"""
+
+import pytest
+import intake
+import pandas as pd
+from climakitae.core.data_interface import DataInterface
+
+
+@pytest.fixture
+def var_descrip_df():
+    """Return variable descriptions DataFrame from DataInterface object"""
+    data_interface = DataInterface()
+    return data_interface.variable_descriptions
+
+
+def test_expected_column_names(var_descrip_df):
+    """Ensure that the column names are as expected by the code base"""
+    col_names = list(var_descrip_df.columns)
+    assert col_names == [
+        "variable_id",
+        "downscaling_method",
+        "timescale",
+        "unit",
+        "display_name",
+        "extended_description",
+        "colormap",
+        "show",
+        "dependencies",
+    ]
+
+
+def test_index_derived_substring_variable_id_for_derived_indices(var_descrip_df):
+    """Indices should have "_index_derived" (not just "_index") in their variable_id
+    Both of these substrings are used in the code base to identify the type of variable and modify the selection options based on that.
+    For example, a derived variable (that is not also an index) has variable_type = "Variable" in the DataInterface object
+    For example, a derived variable (that is ALSO an index) has variable_type = "Derived Index" in the DataInterface object
+    The logic has slight differences in the code base and must be preserved if we add more derived variables/indices
+    """
+
+    index_vars = var_descrip_df[var_descrip_df["variable_id"].str.contains("_index")]
+
+    def _check_substring(row):
+        return row.str.contains("_index_derived")
+
+    # All the index variables should contain the full substring "_index_derived", not just "_index"
+    contains_index_derived = all(
+        index_vars[["variable_id"]].apply(_check_substring, axis=1)
+    )
+
+    assert contains_index_derived == True
+
+
+def test_expected_dependency_column(var_descrip_df):
+    """Catalog variables should all have dependencies set to 'None'
+    Derived variables should have one or more dependency
+    Dependency refers to a variable dependency; i.e. a derived variable is dependent on one or more variables
+    """
+    derived_vars = var_descrip_df[
+        var_descrip_df["variable_id"].str.contains("_derived")
+    ]
+    catalog_vars = var_descrip_df[
+        ~var_descrip_df["variable_id"].str.contains("_derived")
+    ]
+
+    def _is_none(row):
+        return row == "None"
+
+    # None of the derived variables should have dependencies = "None"
+    derived_vars_none = any(
+        derived_vars[["dependencies"]].apply(_is_none, axis=1).values
+    )
+
+    # All of the catalog variables could have dependencies = "None"
+    catalog_vars_none = all(
+        catalog_vars[["dependencies"]].apply(_is_none, axis=1).values
+    )
+
+    assert derived_vars_none == False
+    assert catalog_vars_none == True


### PR DESCRIPTION
# Description of PR
Enable users to view and retrieve derived variables/indices without using the DataInterface GUI. This wasn't previously an option. 

### Summary of changes and related issue
- Derived variables/indices are now available for viewing using the existing function ```get_data_options()```
- Derived variables/indices are now available for retrieval using the existing function ```get_data()```
- Added a new column "dependencies" to the variable_descriptions.csv file, which is used to determine variable dependencies for the derived variables/indices. This helped me determine the correct subset/combo of options for each variable to return to the user. 
- Wrote some unit tests (hell yeah!!) 

### Relevant motivation and context
When I wrote the two functions ```get_data_options()``` and ```get_data()```, I didn't realize they didn't allow you to view/retrieve derived variables; you can only access the catalog variables. Calvin mentioned he needed to get the derived variables using the ```get_data()``` function, so I took the opportunity to improve the function. 

**NOTE**: This required a shocking amount of code... the logic in climakitae for accessing the correct subset/combination of options for each variable is really complex. 

These are the variable ("display") names of all the derived variables: 
- Relative humidity [hourly only-- daily/monthly is native in the catalog]
- Wind speed at 10m
- Wind direction at 10m
- Dew point temperature
- Specific humidity at 2m
- Dew point temperature
- Fosberg fire weather index
- Effective Temperature
- NOAA Heat Index

### How to test 
1) Run through the notebook ```climakitae_direct_data_download.ipynb``` to ensure that it still works correctly, since I modified the functions used in that notebook 
2) Try retrieving some derived variables/indices. For example: 

```
# See all the data combinations (i.e. different resolution, scenario, etc.) for the Fosberg fire weather index
get_data_options(variable = "Fosberg fire weather index")

# Retrieve data for the Fosberg fire weather index 
get_data(
    variable = "Fosberg fire weather index", 
    scenario = "Historical Climate", 
    timescale = "hourly", 
    resolution = "9 km",
    downscaling_method = "Dynamical", 
    time_slice = (1990,1991)
)

# See all the data combinations (i.e. different resolution, scenario, etc.) for Dew point temperature
get_data_options(variable = "Dew point temperature")

# Retrieve data for Dew point temperature 
get_data(
    variable = "Dew point temperature", 
    scenario = ["Historical Climate","SSP 2-4.5 -- Middle of the Road"], 
    timescale = "monthly", 
    resolution = "45 km",
    downscaling_method = "Dynamical",
    time_slice = (1990,2035)
)
```

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<br>

## Definition of Done Checklist

#### Practical
- [x] 80% unit test coverage
- [x] Documentation
  - [x] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [x] Documentation is pushed
- [x] Complex code commented
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Context of function is clearly provided
  - [x] Intent of function is provided
  - [x] How to test, so that it is not siloed on scientists and anyone can review
  - [x] Appropriate manual testing was completed
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Linting completed and resolved

#### Conceptual
- [x] Doesn't replicate existing functionality
- [x] Aligns with general coding standard of existing functions
- [x] Matches desired functinonality from users/scientists
