### PR TITLE
Fix bad refs in Warming.py

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -15,8 +15,6 @@ from climakitae.core.paths import gwl_1981_2010_file, gwl_1850_1900_file
 from climakitae.util.utils import (
     read_csv_file,
     scenario_to_experiment_id,
-    timescale_to_table_id,
-    resolution_to_gridlabel,
     _get_cat_subset,
 )
 
@@ -89,7 +87,7 @@ class WarmingLevels:
         self.catalog_data = self.catalog_data.stack(all_sims=["simulation", "scenario"])
 
         # Dropping invalid simulations that come up from stacking scenarios and simulations together
-        self.catalog_data = _drop_invalid_wl_sims(self.catalog_data, self.wl_params)
+        self.catalog_data = _drop_invalid_sims(self.catalog_data, self.wl_params)
 
         if self.wl_params.anom == "Yes":
             self.gwl_times = read_csv_file(gwl_1981_2010_file, index_col=[0, 1, 2])


### PR DESCRIPTION
# Description of PR

This PR is a quick fix for bad function ref and unused function imports in Warming.py

### Summary of changes and related issue
[What's changed in this PR?]

### Relevant motivation and context
[Why did you change this and what applicable context is needed to understand why this change is needed?]

### Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Definition of Done Checklist

#### Practical
- [ ] 80% unit test coverage
- [ ] Documentation
  - [ ] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [ ] Documentation is pushed
- [ ] Complex code commented
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Context of function is clearly provided
  - [ ] Intent of function is provided
  - [ ] How to test, so that it is not siloed on scientists and anyone can review
  - [ ] Appropriate manual testing was completed
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Linting completed and resolved

#### Conceptual
- [ ] Doesn't replicate existing functionality
- [ ] Aligns with general coding standard of existing functions
- [ ] Matches desired functionality from users/scientists
