### PR TITLE
Retrieve derived indices using a warming levels approach

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1672,7 +1672,11 @@ def get_data_options(
     # Raise error for bad input from user
     for user_input in [variable, downscaling_method, resolution, timescale]:
         if (user_input is not None) and (type(user_input) != str):
-            print("Function arguments require a single string value for your inputs")
+            print(
+                _format_error_print_message(
+                    "Function arguments require a single string value for your inputs"
+                )
+            )
             return None
 
     def _list(x):
@@ -1701,7 +1705,7 @@ def get_data_options(
         & (cat_df["scenario"].isin(d["scenario"]))
     ].reset_index(drop=True)
     if len(cat_subset) == 0:
-        print("No data found for your input values")
+        print("ERROR: No data found for your input values")
         return None
 
     if tidy:
@@ -1797,6 +1801,11 @@ def get_subsetting_options(area_subset="all"):
     return geoms_df
 
 
+def _format_error_print_message(error_message):
+    """Format error message using the same format"""
+    return "ERROR: {0} \nReturning None".format(error_message)
+
+
 def get_data(
     variable,
     downscaling_method,
@@ -1880,11 +1889,6 @@ def get_data(
     """
 
     # Internal functions
-
-    def _format_error_print_message(error_message):
-        """Format error message using the same format"""
-        return "ERROR: {0} \nReturning None".format(error_message)
-
     def _error_handling_warming_level_inputs(wl, argument_name):
         """Error handling for arguments: warming_level and warming_level_month
         Both require a list of either floats or ints
@@ -1988,7 +1992,9 @@ def get_data(
 
     # Get intake catalog and variable descriptions from DataInterface object
     data_interface = DataInterface()
-    var_df = data_interface.variable_descriptions
+    var_df = data_interface.variable_descriptions.rename(
+        columns={"variable": "display_name"}
+    )  # Rename column so that it can be merged with cat_df
     catalog = data_interface.data_catalog
     cat_df = _get_user_friendly_catalog(
         intake_catalog=catalog, variable_descriptions=var_df
@@ -2059,20 +2065,42 @@ def get_data(
     # A dictionary is used for all the inputs in selections because it enables better error handling and cleaner code when we set selections.thing = thing
     # It also makes parsing through the arguments easier
     # The inputs here need to be a list so that they can be parsed easier by the _check_if_good_input function when comparing with the valid catalog options to confirm the user input is valid
-    cat_dict = {
-        "variable": variable if type(variable) == list else [variable],
-        "timescale": timescale if type(timescale) == list else [timescale],
-        "downscaling_method": (
-            downscaling_method
-            if type(downscaling_method) == list
-            else [downscaling_method]
-        ),
-        "scenario": scenario if type(scenario) == list else [scenario],
-        "resolution": resolution if type(resolution) == list else [resolution],
-    }
+    scenario_user_input = scenario  # What the user originally input for scenario
 
-    # Check if the user inputs make sense
-    cat_dict = _check_if_good_input(cat_dict, cat_df)
+    check_input_df = get_data_options(
+        variable=variable,
+        downscaling_method=downscaling_method,
+        resolution=resolution,
+        timescale=timescale,
+        scenario=scenario,
+        tidy=False,
+    )
+
+    if check_input_df is None:
+
+        return None
+
+    # Merge with variable dataframe to get all the info about the data in one place
+    check_input_df = check_input_df.merge(var_df, how="left")
+
+    # Convert to a dictionary so it can be easily parsed by the function
+    cat_dict = check_input_df.to_dict(orient="list")
+    for key, values in cat_dict.items():
+        # Remove non-unique values
+        # This happens because we converted a pandas dataframe to a dictionary
+        cat_dict[key] = list(np.unique(values))
+
+    # _check_if_good_input will default fill the scenario options with EVERY possible option
+    # It will in most cases give a list of all the available SSPs and the two historical data options (Historical Climate AND Historical Reconstruction)
+    # I'd like the function to just default to Historical Climate + SSPs
+    # So, if the user input None for scenario, I just remove Historical Reconstruction from the list
+    if scenario_user_input == None:
+        if "Historical Reconstruction" in cat_dict["scenario"]:
+            cat_dict["scenario"] = [
+                item
+                for item in cat_dict["scenario"]
+                if item != "Historical Reconstruction"
+            ]
 
     # Check if it's an index
     variable_id = (

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1705,7 +1705,11 @@ def get_data_options(
         & (cat_df["scenario"].isin(d["scenario"]))
     ].reset_index(drop=True)
     if len(cat_subset) == 0:
-        print("ERROR: No data found for your input values")
+        print(
+            _format_error_print_message(
+                "No data found for your input values. Please modify your data request."
+            )
+        )
         return None
 
     if tidy:

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -859,7 +859,15 @@ class DataParameters(param.Parameterized):
             self.data_type = "Gridded"
         else:
             self.param["data_type"].objects = ["Gridded", "Station"]
-        if "Station" in self.data_type or self.variable_type == "Derived Index":
+        if self.variable_type == "Derived Index":
+
+            # Haven't built into the code to retrieve derive index for statistically downscaled data yet. Derived indices at the moment only work for hourly data.
+            self.param["downscaling_method"].objects = ["Dynamical"]
+            self.downscaling_method = "Dynamical"
+
+            self.param["approach"].objects = ["Time", "Warming Level"]
+
+        elif "Station" in self.data_type:
             self.param["downscaling_method"].objects = ["Dynamical"]
             self.downscaling_method = "Dynamical"
 

--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -45,7 +45,7 @@ class TestDerivedVariablesGetData:
                     area_subset="states",
                     cached_area="CA",
                     approach="Warming Level",
-                    warming_level=[3.0, 4.0],
+                    warming_level=[3.0],
                 )
             except:
                 pytest.fail(
@@ -65,6 +65,8 @@ class TestDerivedVariablesGetData:
                     area_subset="states",
                     cached_area="CA",
                     approach="Time",
+                    time_slice=(1990, 1991),
+                    scenario="Historical Climate",
                 )
             except:
                 pytest.fail(
@@ -72,7 +74,7 @@ class TestDerivedVariablesGetData:
                 )
 
 
-def TestAppropriateStringErrorReturnedIfBadInputGetData():
+class TestAppropriateStringErrorReturnedIfBadInputGetData:
     """Test that an appropriate error message is printed to the user describing the issue and how to resolve it."""
 
     def test_error_raised_string_input_warming_level(self):
@@ -81,7 +83,7 @@ def TestAppropriateStringErrorReturnedIfBadInputGetData():
         # Error message we expect to be printed by the function
         expected_print_message = "ERROR: Function argument warming_level requires a float/int or list of floats/ints input. Your input: <class 'str'> \nReturning None\n"
 
-        # NOTE: function PRINTS this message-- it does not return it as en error
+        # NOTE: function PRINTS this message-- it does not return it as an error
         # Because of this, we have to use sys to capture the print message
         capture = io.StringIO()
         save, sys.stdout = sys.stdout, capture
@@ -105,9 +107,9 @@ def TestAppropriateStringErrorReturnedIfBadInputGetData():
         """
 
         # Error message we expect to be printed by the function
-        expected_print_message = "ERROR: No data found for your input values\n"
+        expected_print_message = "ERROR: No data found for your input values. Please modify your data request. \nReturning None\n"
 
-        # NOTE: function PRINTS this message-- it does not return it as en error
+        # NOTE: function PRINTS this message-- it does not return it as an error
         # Because of this, we have to use sys to capture the print message
         capture = io.StringIO()
         save, sys.stdout = sys.stdout, capture
@@ -116,9 +118,10 @@ def TestAppropriateStringErrorReturnedIfBadInputGetData():
             timescale="hourly",
             resolution="9 km",
             downscaling_method="Dynamical",
+            scenario="Historical Climate",
             area_subset="states",
             cached_area="CA",
-            time_slice=(1980, 2010),
+            time_slice=(1990, 1991),
         )
         sys.stdout = save
 

--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -105,7 +105,7 @@ def TestAppropriateStringErrorReturnedIfBadInputGetData():
         """
 
         # Error message we expect to be printed by the function
-        expected_print_message = "ERROR: No data found for your input values"
+        expected_print_message = "ERROR: No data found for your input values\n"
 
         # NOTE: function PRINTS this message-- it does not return it as en error
         # Because of this, we have to use sys to capture the print message

--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -97,3 +97,29 @@ def TestAppropriateStringErrorReturnedIfBadInputGetData():
         sys.stdout = save
 
         assert capture.getvalue() == expected_print_message
+
+    def test_error_raised_bad_timescale_input(self):
+        """Test that an appropriate message is printed if bad input for timescale
+        Previously, this input would raise a confusing error!
+        Fixed in November 2024 to return a useful print message and None instead
+        """
+
+        # Error message we expect to be printed by the function
+        expected_print_message = "ERROR: No data found for your input values"
+
+        # NOTE: function PRINTS this message-- it does not return it as en error
+        # Because of this, we have to use sys to capture the print message
+        capture = io.StringIO()
+        save, sys.stdout = sys.stdout, capture
+        ds = get_data(
+            variable="Effective Temperature",
+            timescale="hourly",
+            resolution="9 km",
+            downscaling_method="Dynamical",
+            area_subset="states",
+            cached_area="CA",
+            time_slice=(1980, 2010),
+        )
+        sys.stdout = save
+
+        assert capture.getvalue() == expected_print_message

--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -28,7 +28,48 @@ class TestDerivedVariablesGetData:
                 warming_level=[3.0],
             )
         except:
-            pytest.fail("Data for Fosberg Fire Weather Index could not be retrieved")
+            pytest.fail(
+                "Data for Fosberg Fire Weather Index with Warming Levels approach could not be retrieved"
+            )
+
+        def test_hourly_relative_humidity_warming_levels_approach_retrieval(self):
+            """Make sure that the hourly relative humidity (a derived variable) can be retrieved!
+            Previously raised an error in Nov 2024 (has since been fixed)
+            """
+            try:
+                ds = get_data(
+                    variable="Relative humidity",
+                    timescale="hourly",
+                    resolution="9 km",
+                    downscaling_method="Dynamical",
+                    area_subset="states",
+                    cached_area="CA",
+                    approach="Warming Level",
+                    warming_level=[3.0, 4.0],
+                )
+            except:
+                pytest.fail(
+                    "Data for hourly Relative Humidity with a Warming Levels approach could not be retrieved"
+                )
+
+        def test_hourly_relative_humidity_time_based_approach_retrieval(self):
+            """Make sure that the hourly relative humidity (a derived variable) can be retrieved!
+            Previously raised an error in Nov 2024 (has since been fixed)
+            """
+            try:
+                ds = get_data(
+                    variable="Relative humidity",
+                    timescale="hourly",
+                    resolution="9 km",
+                    downscaling_method="Dynamical",
+                    area_subset="states",
+                    cached_area="CA",
+                    approach="Time",
+                )
+            except:
+                pytest.fail(
+                    "Data for hourly Relative Humidity with a Time-based approach could not be retrieved"
+                )
 
 
 def TestAppropriateStringErrorReturnedIfBadInputGetData():

--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -1,0 +1,58 @@
+"""Test the get_data() function 
+"""
+
+import pytest
+import io
+import sys
+from climakitae.core.data_interface import get_data
+
+
+class TestDerivedVariablesGetData:
+    """Test that derived variables/indices can be retrieved
+    Some of the use cases below used to raise an error and have since been fixed.
+    """
+
+    def test_ffwi_retrieval(self):
+        """Make sure that the fosberg fire weather index can be retrieved!
+        Previously raised an error in Nov 2024 (has since been fixed)
+        """
+        try:
+            ds = get_data(
+                variable="Fosberg fire weather index",
+                timescale="hourly",
+                resolution="9 km",
+                downscaling_method="Dynamical",
+                area_subset="states",
+                cached_area="CA",
+                approach="Warming Level",
+                warming_level=[3.0],
+            )
+        except:
+            pytest.fail("Data for Fosberg Fire Weather Index could not be retrieved")
+
+
+def TestAppropriateStringErrorReturnedIfBadInputGetData():
+    """Test that an appropriate error message is printed to the user describing the issue and how to resolve it."""
+
+    def test_error_raised_string_input_warming_level(self):
+        """Warming level should be a float input! Make sure the function prints the appropriate error message"""
+
+        # Error message we expect to be printed by the function
+        expected_print_message = "ERROR: Function argument warming_level requires a float/int or list of floats/ints input. Your input: <class 'str'> \nReturning None\n"
+
+        # NOTE: function PRINTS this message-- it does not return it as en error
+        # Because of this, we have to use sys to capture the print message
+        capture = io.StringIO()
+        save, sys.stdout = sys.stdout, capture
+        get_data(
+            variable="Precipitation (total)",
+            downscaling_method="Dynamical",
+            resolution="45 km",
+            timescale="monthly",
+            cached_area="San Bernardino County",
+            approach="Warming Level",
+            warming_level="20",
+        )
+        sys.stdout = save
+
+        assert capture.getvalue() == expected_print_message


### PR DESCRIPTION
# Description of PR
Retrieve derived indices using a warming levels approach. And, some unit tests. 

### Relevant motivation and context
I previously thought I had implemented this feature in PR #462 , but I forgot to enable the ability to retrieve the data using both a time-based and a warming level approach. 

### How to test 
Try to retrieve the Derived Indices (under the "Derived Indices" button in the GUI) using a Warming Level approach. Try with both the DataInterface GUI(i.e. `selections.show()`)  and with `get_data()`. 

The following are the derived variable options: 
- Fosberg fire weather index
- Effective Temperature
- NOAA Heat Index

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Definition of Done Checklist

#### Practical
- [x] 80% unit test coverage
- [x] Documentation
  - [x] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [x] Documentation is pushed
- [x] Complex code commented
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Context of function is clearly provided
  - [x] Intent of function is provided
  - [x] How to test, so that it is not siloed on scientists and anyone can review
  - [x] Appropriate manual testing was completed
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Linting completed and resolved

#### Conceptual
- [x] Doesn't replicate existing functionality
- [x] Aligns with general coding standard of existing functions
- [x] Matches desired functionality from users/scientists
