### PR TITLE
Fixes small typo in WL attribute

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -1266,7 +1266,7 @@ def _apply_warming_levels_approach(da, selections):
         )
     }
     warming_data["warming_level"].attrs = {
-        "description": "degrees Celcius above the historical baseline"
+        "description": "degrees Celsius above the historical baseline"
     }
     warming_data["all_sims"].attrs = {"description": "combined simulation and scenario"}
 
@@ -1305,7 +1305,7 @@ def _station_apply(selections, da, original_time_slice):
         Preprocess station data so that it can be more seamlessly integrated into the wrangling process
         Get name of station id and station name
         Rename data variable to the station name; this allows the return of a Dataset object, with each unique station as a data variable
-        Convert celcius to kelvin
+        Convert Celsius to Kelvin
         Assign descriptive attributes
         Drop unneccessary coordinates that can cause issues when bias correcting with the model data
 
@@ -1329,7 +1329,7 @@ def _station_apply(selections, da, original_time_slice):
         ].item()
         # Rename data variable to station name
         ds = ds.rename({"tas": station_name})
-        # Convert Celcius to Kelvin
+        # Convert Celsius to Kelvin
         ds[station_name] = ds[station_name] + 273.15
         # Assign descriptive attributes to the data variable
         ds[station_name] = ds[station_name].assign_attrs(


### PR DESCRIPTION
# Description of PR
The warming level attribute description had a small typo "Celcius". Fixed to "Celsius". 

### Summary of changes and related issue
Fixed a typo, and relevant other comments with typo. 

### Relevant motivation and context
Typo. 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Definition of Done Checklist
How to test:
Retrieve data at a desired warming level and check the warming level attribute description. For example:
```ds.warming_level```

#### Practical
- [N/A] 80% unit test coverage
- [N/A] Documentation
  - [N/A] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [N/A] Documentation is pushed
- [N/A] Complex code commented
- [x] Naming conventions followed
  - [N/A] Helper functions hidden with `_` before the name
- [N/A] Context of function is clearly provided
  - [N/A] Intent of function is provided
  - [x] How to test, so that it is not siloed on scientists and anyone can review
  - [x] Appropriate manual testing was completed
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Linting completed and resolved

#### Conceptual
- [x] Doesn't replicate existing functionality
- [x] Aligns with general coding standard of existing functions
- [x] Matches desired functionality from users/scientists
