### PR TITLE
Bug fix: threshold tools nonfinite value bug when calculating 1-in-X precipitation events in arid regions

### DIFF
--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -114,13 +114,13 @@ def get_block_maxima(
         if extremes_type == "max":
             # note: fillna is used to replace nans in timeseries with 0s in precipitation ONLY
             # todo: evaluate a solution for temperature and heat index (if needed)
-            if da.name == 'Precipitation (total)':
+            if da_series.name == 'Precipitation (total)':
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0)
                 print("2", da_series.values.max()) # testing
             else: 
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max()
         elif extremes_type == "min":
-            if da.name == "Precipitation (total)":
+            if da_series.name == "Precipitation (total)":
                 da_series = da_series.resample(time=f"{group_len}D", label="left").min().fillna(value=0)
             else:
                 da_series = da_series.resample(time=f"{group_len}D", label="left").min()

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -114,15 +114,28 @@ def get_block_maxima(
         if extremes_type == "max":
             # note: fillna is used to replace nans in timeseries with 0s in precipitation ONLY
             # TODO: evaluate nan in other variables, and more programmatic fix
-            if da_series.name == 'Precipitation (total)':
-                da_series = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0) # fill value of 0 will always be precip min, "safe" for max calculation if nan present
-            else: 
+            if da_series.name == "Precipitation (total)":
+                da_series = (
+                    da_series.resample(time=f"{group_len}D", label="left")
+                    .max()
+                    .fillna(value=0)
+                )  # fill value of 0 will always be precip min, "safe" for max calculation if nan present
+            else:
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max()
         elif extremes_type == "min":
             if da_series.name == "Precipitation (total)":
                 # "fix" in min is to set missing value to series max
-                da_series_fillmax = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0).values.max()
-                da_series = da_series.resample(time=f"{group_len}D", label="left").min().fillna(value=da_series_fillmax) # fill value set to precip max, "patch" for min calculation if nan present
+                da_series_fillmax = (
+                    da_series.resample(time=f"{group_len}D", label="left")
+                    .max()
+                    .fillna(value=0)
+                    .values.max()
+                )
+                da_series = (
+                    da_series.resample(time=f"{group_len}D", label="left")
+                    .min()
+                    .fillna(value=da_series_fillmax)
+                )  # fill value set to precip max, "patch" for min calculation if nan present
             else:
                 da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -98,7 +98,7 @@ def get_block_maxima(
             # In the case of "max" events, need to first identify the minimum value
             # in each window of the specified duration
             da_series = da_series.rolling(time=dur_len, center=False).min("time")
-            print(da_series.values) # testing
+            print(da_series.values.min()) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur_len, center=False).max("time")
 
@@ -114,7 +114,7 @@ def get_block_maxima(
         # select the max (min) in each group
         if extremes_type == "max":
             da_series = da_series.resample(time=f"{group_len}D", label="left").max()
-            print(da_series.values) # testing
+            print(da_series.values.max()) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
@@ -134,7 +134,7 @@ def get_block_maxima(
         # Now select the min (max) from the duration period
         if extremes_type == "max":
             da_series = da_series.rolling(time=dur2_len, center=False).min("time")
-            print(da_series.values) # testing
+            print(da_series.values.min()) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur2_len, center=False).max("time")
 
@@ -142,7 +142,7 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
-        print(bms.values) # testing
+        print(bms.values.max()) # testing
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -98,6 +98,7 @@ def get_block_maxima(
             # In the case of "max" events, need to first identify the minimum value
             # in each window of the specified duration
             da_series = da_series.rolling(time=dur_len, center=False).min("time")
+            print(da_series.values) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur_len, center=False).max("time")
 
@@ -113,6 +114,7 @@ def get_block_maxima(
         # select the max (min) in each group
         if extremes_type == "max":
             da_series = da_series.resample(time=f"{group_len}D", label="left").max()
+            print(da_series.values) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
@@ -132,6 +134,7 @@ def get_block_maxima(
         # Now select the min (max) from the duration period
         if extremes_type == "max":
             da_series = da_series.rolling(time=dur2_len, center=False).min("time")
+            print(da_series.values) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur2_len, center=False).max("time")
 
@@ -139,6 +142,7 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
+        print(bms.values) # testing
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,8 +112,8 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left", numeric_only=True).max()
-            print("2", da_series.values.max(), da_series.fillna(da_series.values.max().max())) # testing
+            da_series = da_series.resample(time=f"{group_len}D", label="left").max(numeric_only=True)
+            print("2", da_series.values.max()) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
@@ -140,7 +140,7 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True, min_count=1)
         bms.attrs["extremes type"] = "maxima"
-        print("4", bms.values.max(), bms.fillna(bms.values.max().max())) # testing
+        print("4", bms.values.max()) # testing
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,7 +112,7 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left").max(numeric_only=True)
+            da_series = da_series.resample(time=f"{group_len}D", label="left").max(min_count=1)
             print("2", da_series.values.max()) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,7 +112,7 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left", skipna=True).max().max()
+            da_series = da_series.resample(time=f"{group_len}D", label="left", skipna=True).max(skipna=True)
             print("2", da_series.values.max(), da_series.fillna(da_series.values.max().max())) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
@@ -138,7 +138,7 @@ def get_block_maxima(
 
     # Now select the most extreme value for each block in the series
     if extremes_type == "max":
-        bms = da_series.resample(time=f"{block_size}A", skipna=True).max(keep_attrs=True).max(keep_attrs=True)
+        bms = da_series.resample(time=f"{block_size}A", skipna=True).max(keep_attrs=True, skipna=True)
         bms.attrs["extremes type"] = "maxima"
         print("4", bms.values.max(), bms.fillna(bms.values.max().max())) # testing
     elif extremes_type == "min":

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -113,15 +113,14 @@ def get_block_maxima(
         # select the max (min) in each group
         if extremes_type == "max":
             # note: fillna is used to replace nans in timeseries with 0s in precipitation ONLY
-            # todo: evaluate a solution for temperature and heat index (if needed)
             if da_series.name == 'Precipitation (total)':
-                da_series = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0)
-                print("2", da_series.values.max()) # testing
+                da_series = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0) # fill value of 0 will always be precip min
+                print("LINE TO CHECK", da_series.values.max()) # testing
             else: 
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max()
         elif extremes_type == "min":
             if da_series.name == "Precipitation (total)":
-                da_series = da_series.resample(time=f"{group_len}D", label="left").min().fillna(value=0)
+                da_series = da_series.resample(time=f"{group_len}D", label="left").min().fillna(value=0) # evaluate best fillna fit here!
             else:
                 da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
@@ -148,7 +147,6 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
-        print("4", bms.values.max()) # testing
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -138,7 +138,7 @@ def get_block_maxima(
 
     # Now select the most extreme value for each block in the series
     if extremes_type == "max":
-        bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True, min_count=1)
+        bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True, skipna=True, min_count=1)
         bms.attrs["extremes type"] = "maxima"
         print("4", bms.values.max()) # testing
     elif extremes_type == "min":

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,7 +112,7 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left", skipna=True).max()
+            da_series = da_series.resample(time=f"{group_len}D", label="left", skipna=True).max().max()
             print("2", da_series.values.max(), da_series.fillna(da_series.values.max().max())) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
@@ -138,7 +138,7 @@ def get_block_maxima(
 
     # Now select the most extreme value for each block in the series
     if extremes_type == "max":
-        bms = da_series.resample(time=f"{block_size}A", skipna=True).max(keep_attrs=True)
+        bms = da_series.resample(time=f"{block_size}A", skipna=True).max(keep_attrs=True).max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
         print("4", bms.values.max(), bms.fillna(bms.values.max().max())) # testing
     elif extremes_type == "min":

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,10 +112,18 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left").fillna(value=0).max()
-            print("2", da_series.values.max()) # testing
+            # note: fillna is used to replace nans in timeseries with 0s in precipitation ONLY
+            # todo: evaluate a solution for temperature and heat index (if needed)
+            if variable == 'Precipitation (total)':
+                da_series = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0)
+                print("2", da_series.values.max()) # testing
+            else: 
+                da_series = da_series.resample(time=f"{group_len}D", label="left").max()
         elif extremes_type == "min":
-            da_series = da_series.resample(time=f"{group_len}D", label="left").min()
+            if variable == "Precipitation (total)":
+                da_series = da_series.resample(time=f"{group_len}D", label="left").min().fillna(value=0)
+            else:
+                da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
     if grouped_duration != None:
         if groupby == None:
@@ -138,7 +146,7 @@ def get_block_maxima(
 
     # Now select the most extreme value for each block in the series
     if extremes_type == "max":
-        bms = da_series.resample(time=f"{block_size}A").fillna(value=0).max(keep_attrs=True)
+        bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
         print("4", bms.values.max()) # testing
     elif extremes_type == "min":

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -114,7 +114,7 @@ def get_block_maxima(
         # select the max (min) in each group
         if extremes_type == "max":
             da_series = da_series.resample(time=f"{group_len}D", label="left").max()
-            print("2", da_series.values.max(), da_series.fillna(da_series.values.max())) # testing
+            print("2", da_series.values.max(), da_series.fillna(da_series.values.max().max())) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
@@ -142,7 +142,7 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
-        print("4", bms.values.max(), bms.fillna(bms.values.max())) # testing
+        print("4", bms.values.max(), bms.fillna(bms.values.max().max())) # testing
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -115,12 +115,12 @@ def get_block_maxima(
             # note: fillna is used to replace nans in timeseries with 0s in precipitation ONLY
             if da_series.name == 'Precipitation (total)':
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0) # fill value of 0 will always be precip min
-                print("LINE TO CHECK", da_series.values.max()) # testing
+                print("LINE TO CHECK", da_series, da_series.values.max()) # testing
             else: 
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max()
         elif extremes_type == "min":
             if da_series.name == "Precipitation (total)":
-                da_series = da_series.resample(time=f"{group_len}D", label="left").min().fillna(value=0) # evaluate best fillna fit here!
+                da_series = da_series.resample(time=f"{group_len}D", label="left").min().fillna(value=0) # evaluate best fillna fit here! find max and set value to be "safe"
             else:
                 da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
@@ -147,6 +147,7 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
+        print("TESETING: ", bms.values)
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -116,7 +116,6 @@ def get_block_maxima(
             # TODO: evaluate nan in other variables, and more programmatic fix
             if da_series.name == 'Precipitation (total)':
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0) # fill value of 0 will always be precip min, "safe" for max calculation if nan present
-                print("LINE TO CHECK", da_series.values.min(), da_series.values.max()) # testing
             else: 
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max()
         elif extremes_type == "min":
@@ -150,7 +149,6 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
-        print("TESTING: ", bms.values)
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -98,7 +98,7 @@ def get_block_maxima(
             # In the case of "max" events, need to first identify the minimum value
             # in each window of the specified duration
             da_series = da_series.rolling(time=dur_len, center=False).min("time")
-            print(da_series.values.min()) # testing
+            print("1", da_series.values.min(), da_series.values.min(skipna=True)) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur_len, center=False).max("time")
 
@@ -114,7 +114,7 @@ def get_block_maxima(
         # select the max (min) in each group
         if extremes_type == "max":
             da_series = da_series.resample(time=f"{group_len}D", label="left").max()
-            print(da_series.values.max()) # testing
+            print("2", da_series.values.max(), da_series.values.max(skipna=True)) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
@@ -134,7 +134,7 @@ def get_block_maxima(
         # Now select the min (max) from the duration period
         if extremes_type == "max":
             da_series = da_series.rolling(time=dur2_len, center=False).min("time")
-            print(da_series.values.min()) # testing
+            print("3", da_series.values.min(), da_series.values.min(skipna=True)) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur2_len, center=False).max("time")
 
@@ -142,7 +142,7 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
-        print(bms.values.max()) # testing
+        print("4", bms.values.max(), bms.values.max(skipna=True)) # testing
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -98,7 +98,7 @@ def get_block_maxima(
             # In the case of "max" events, need to first identify the minimum value
             # in each window of the specified duration
             da_series = da_series.rolling(time=dur_len, center=False).min("time")
-            print("1", da_series.values.min(), da_series.values.min(skipna=True)) # testing
+            print("1", da_series.values.min(), da_series.fillna(da_series.values.min())) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur_len, center=False).max("time")
 
@@ -114,7 +114,7 @@ def get_block_maxima(
         # select the max (min) in each group
         if extremes_type == "max":
             da_series = da_series.resample(time=f"{group_len}D", label="left").max()
-            print("2", da_series.values.max(), da_series.values.max(skipna=True)) # testing
+            print("2", da_series.values.max(), da_series.fillna(da_series.values.max())) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
@@ -134,7 +134,7 @@ def get_block_maxima(
         # Now select the min (max) from the duration period
         if extremes_type == "max":
             da_series = da_series.rolling(time=dur2_len, center=False).min("time")
-            print("3", da_series.values.min(), da_series.values.min(skipna=True)) # testing
+            print("3", da_series.values.min(), da_series.fillna(da_series.values.min())) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur2_len, center=False).max("time")
 
@@ -142,7 +142,7 @@ def get_block_maxima(
     if extremes_type == "max":
         bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
-        print("4", bms.values.max(), bms.values.max(skipna=True)) # testing
+        print("4", bms.values.max(), bms.fillna(bms.values.max())) # testing
     elif extremes_type == "min":
         bms = da_series.resample(time=f"{block_size}A").min(keep_attrs=True)
         bms.attrs["extremes type"] = "minima"

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,7 +112,7 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left").max(min_count=1)
+            da_series = da_series.resample(time=f"{group_len}D", label="left").max(skipna=True, min_count=1)
             print("2", da_series.values.max()) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -98,7 +98,6 @@ def get_block_maxima(
             # In the case of "max" events, need to first identify the minimum value
             # in each window of the specified duration
             da_series = da_series.rolling(time=dur_len, center=False).min("time")
-            print("1", da_series.values.min(), da_series.fillna(da_series.values.min())) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur_len, center=False).max("time")
 
@@ -113,7 +112,7 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left").max()
+            da_series = da_series.resample(time=f"{group_len}D", label="left", skipna=True).max()
             print("2", da_series.values.max(), da_series.fillna(da_series.values.max().max())) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
@@ -134,13 +133,12 @@ def get_block_maxima(
         # Now select the min (max) from the duration period
         if extremes_type == "max":
             da_series = da_series.rolling(time=dur2_len, center=False).min("time")
-            print("3", da_series.values.min(), da_series.fillna(da_series.values.min())) # testing
         elif extremes_type == "min":
             da_series = da_series.rolling(time=dur2_len, center=False).max("time")
 
     # Now select the most extreme value for each block in the series
     if extremes_type == "max":
-        bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True)
+        bms = da_series.resample(time=f"{block_size}A", skipna=True).max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
         print("4", bms.values.max(), bms.fillna(bms.values.max().max())) # testing
     elif extremes_type == "min":

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -114,13 +114,13 @@ def get_block_maxima(
         if extremes_type == "max":
             # note: fillna is used to replace nans in timeseries with 0s in precipitation ONLY
             # todo: evaluate a solution for temperature and heat index (if needed)
-            if variable == 'Precipitation (total)':
+            if da.name == 'Precipitation (total)':
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max().fillna(value=0)
                 print("2", da_series.values.max()) # testing
             else: 
                 da_series = da_series.resample(time=f"{group_len}D", label="left").max()
         elif extremes_type == "min":
-            if variable == "Precipitation (total)":
+            if da.name == "Precipitation (total)":
                 da_series = da_series.resample(time=f"{group_len}D", label="left").min().fillna(value=0)
             else:
                 da_series = da_series.resample(time=f"{group_len}D", label="left").min()

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,7 +112,7 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left").max(skipna=True, min_count=1)
+            da_series = da_series.resample(time=f"{group_len}D", label="left").fillna(value=0).max()
             print("2", da_series.values.max()) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
@@ -138,7 +138,7 @@ def get_block_maxima(
 
     # Now select the most extreme value for each block in the series
     if extremes_type == "max":
-        bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True, skipna=True, min_count=1)
+        bms = da_series.resample(time=f"{block_size}A").fillna(value=0).max(keep_attrs=True)
         bms.attrs["extremes type"] = "maxima"
         print("4", bms.values.max()) # testing
     elif extremes_type == "min":

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,7 +112,7 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            da_series = da_series.resample(time=f"{group_len}D", label="left", skipna=True).max(skipna=True)
+            da_series = da_series.resample(time=f"{group_len}D", label="left", numeric_only=True).max()
             print("2", da_series.values.max(), da_series.fillna(da_series.values.max().max())) # testing
         elif extremes_type == "min":
             da_series = da_series.resample(time=f"{group_len}D", label="left").min()
@@ -138,7 +138,7 @@ def get_block_maxima(
 
     # Now select the most extreme value for each block in the series
     if extremes_type == "max":
-        bms = da_series.resample(time=f"{block_size}A", skipna=True).max(keep_attrs=True, skipna=True)
+        bms = da_series.resample(time=f"{block_size}A").max(keep_attrs=True, min_count=1)
         bms.attrs["extremes type"] = "maxima"
         print("4", bms.values.max(), bms.fillna(bms.values.max().max())) # testing
     elif extremes_type == "min":

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -128,7 +128,7 @@ def _metric_agg(
             ):  # Can use xr.apply_ufunc, not just a for loop here
 
                 one_da = da.sel(simulation=sim)
-                print(f'Running on simulation: {sim}')
+                print(f"Running on simulation: {sim}")
 
                 # Removing small amounts of noise and 0-precip days from precipitation data
                 if variable == "Precipitation (total)":
@@ -146,7 +146,7 @@ def _metric_agg(
                     groupby = event_duration
                 elif event_duration[1] == "hour":
                     duration = event_duration
-                
+
                 ams = get_block_maxima(
                     one_da,
                     extremes_type=metric,
@@ -167,8 +167,10 @@ def _metric_agg(
                 # Scoping break points in return value calculation
                 # "Fix" for precipitation is in threshold_tools
                 # TODO: Assess presence of nans within data (and other variables) and develop programmatic fix
-                if return_values.isnull(): 
-                    print('WARNING: Return value is NaN, indicating non-finite value returned by threshold tools AMS. Setting value to "0", which may not reflect an accurate distribution fit. Please notify AE team for assistance.')
+                if return_values.isnull():
+                    print(
+                        'WARNING: Return value is NaN, indicating non-finite value returned by threshold tools AMS. Setting value to "0", which may not reflect an accurate distribution fit. Please notify AE team for assistance.'
+                    )
                     return_values = 0.0
                     continue
 
@@ -493,7 +495,7 @@ class CavaParams(param.Parameterized):
 
 def cava_data(
     input_locations,  # csv file
-    variable, 
+    variable,
     units=None,
     approach="Time",  # default
     downscaling_method="Dynamical",  # default

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -168,7 +168,11 @@ def _metric_agg(
                 )["return_value"]
                 return_vals.append(return_values)
 
-                print('return value: ', return_values) ## testing
+                if return_values.isnan(): 
+                    print('Return value is NaN.... SKIPPING!!!')
+                    continue
+                else:
+                    print('return value: ', return_values.values) ## testing
 
                 # Determining goodness-of-fit for the given distribution
                 d_statistic, p_value = [

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -128,7 +128,7 @@ def _metric_agg(
             ):  # Can use xr.apply_ufunc, not just a for loop here
 
                 one_da = da.sel(simulation=sim)
-                print(f'Running on simulation: {sim}') ## testing
+                print(f'Running on simulation: {sim}')
 
                 # Removing small amounts of noise and 0-precip days from precipitation data
                 if variable == "Precipitation (total)":
@@ -138,7 +138,6 @@ def _metric_agg(
                     one_da = one_da.sel(time=one_da.time.dt.month.isin(months))
 
                     one_da = one_da.where(one_da > 10e-10, drop=True)
-                    # print(f'Trace precip check pre get_block_maxima: {one_da.values}')
 
                 # Computing block maxima
                 groupby, duration = None, None
@@ -166,11 +165,13 @@ def _metric_agg(
                 )["return_value"]
                 return_vals.append(return_values)
 
+                # Scoping break points in return value calculation
+                # "Fix" for precipitation is in threshold_tools
+                # TODO: Assess presence of nans within data (and other variables) and develop programmatic fix
                 if return_values.isnull(): 
-                    print('Return value is NaN.... SKIPPING!!!')
+                    print('Warning: Return value is NaN, indicating non-finite value returned by threshold tools AMS. Setting value to "0", which may not reflect an accurate distribution fit. Please notify AE team for assistance.')
+                    return_values = 0.0
                     continue
-                else:
-                    print('return value: ', return_values.values) ## testing
 
                 # Determining goodness-of-fit for the given distribution
                 d_statistic, p_value = [
@@ -185,7 +186,7 @@ def _metric_agg(
                 p_val_print = (
                     format(p_value, ".3e") if p_value < 0.05 else round(p_value, 4)
                 )
-                to_print = f"\nThe simulation {sim} fitted with a {distr} distribution has a p-value of {p_val_print}."
+                to_print = f"The simulation {sim} fitted with a {distr} distribution has a p-value of {p_val_print}.\n"
 
                 if p_value < 0.05:
                     to_print += " Since the p-value is <0.05, the selected distribution does not fit the data well and therefore is not a good fit (see guidance)."

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -128,19 +128,19 @@ def _metric_agg(
             ):  # Can use xr.apply_ufunc, not just a for loop here
 
                 one_da = da.sel(simulation=sim)
-                print(f'Running on simulation: {sim}, size: {len(one_da)}') ## testing
+                print(f'Running on simulation: {sim}, size: {(one_da.size)}') ## testing
 
                 # Removing small amounts of noise and 0-precip days from precipitation data
                 if variable == "Precipitation (total)":
                     one_da = one_da.resample(time="1D").sum()
-                    print('resampling: ', len(one_da)) ## testing
+                    print('resampling: ', (one_da.size)) ## testing
 
                     # Resampling can cause initially filtered out dates to reappear. Re-filtered in case that occurs.
                     one_da = one_da.sel(time=one_da.time.dt.month.isin(months))
-                    print('filtering check: ', len(one_da)) ## testing
+                    print('filtering check: ', (one_da.size)) ## testing
 
                     one_da = one_da.where(one_da > 10e-10, drop=True)
-                    print('trace precip check: ', len(one_da)) ## testing
+                    print('trace precip check: ', (one_da.size)) ## testing
 
                 # Computing block maxima
                 groupby, duration = None, None
@@ -157,7 +157,7 @@ def _metric_agg(
                     check_ess=False,
                 ).squeeze()  # `get_return_value` is expecting a 1-D array
 
-                print('ams: ', len(ams)) ## testing
+                print('ams: ', ams.size) ## testing
 
                 # Calculating 1-in-X return value
                 return_values = get_return_value(
@@ -168,7 +168,7 @@ def _metric_agg(
                 )["return_value"]
                 return_vals.append(return_values)
 
-                print('return value: ', len(return_values)) ## testing
+                print('return value: ', return_values) ## testing
 
                 # Determining goodness-of-fit for the given distribution
                 d_statistic, p_value = [

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -129,15 +129,18 @@ def _metric_agg(
 
                 one_da = da.sel(simulation=sim)
                 print(f'Running on simulation: {sim}, size: {len(one_da)}') ## testing
-                
+
                 # Removing small amounts of noise and 0-precip days from precipitation data
                 if variable == "Precipitation (total)":
                     one_da = one_da.resample(time="1D").sum()
+                    print('resampling: ', len(one_da)) ## testing
 
                     # Resampling can cause initially filtered out dates to reappear. Re-filtered in case that occurs.
                     one_da = one_da.sel(time=one_da.time.dt.month.isin(months))
+                    print('filtering check: ', len(one_da)) ## testing
 
                     one_da = one_da.where(one_da > 10e-10, drop=True)
+                    print('trace precip check: ', len(one_da)) ## testing
 
                 # Computing block maxima
                 groupby, duration = None, None
@@ -154,6 +157,8 @@ def _metric_agg(
                     check_ess=False,
                 ).squeeze()  # `get_return_value` is expecting a 1-D array
 
+                print('ams: ', len(ams)) ## testing
+
                 # Calculating 1-in-X return value
                 return_values = get_return_value(
                     ams,
@@ -162,6 +167,8 @@ def _metric_agg(
                     distr=distr,
                 )["return_value"]
                 return_vals.append(return_values)
+
+                print('return value: ', len(return_values)) ## testing
 
                 # Determining goodness-of-fit for the given distribution
                 d_statistic, p_value = [

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -137,6 +137,7 @@ def _metric_agg(
                     # Resampling can cause initially filtered out dates to reappear. Re-filtered in case that occurs.
                     one_da = one_da.sel(time=one_da.time.dt.month.isin(months))
 
+                    # Remove trace precipitation, using a small finite limit
                     one_da = one_da.where(one_da > 10e-10, drop=True)
 
                 # Computing block maxima
@@ -154,8 +155,6 @@ def _metric_agg(
                     check_ess=False,
                 ).squeeze()  # `get_return_value` is expecting a 1-D array
 
-                print('ams: ', ams.values) ## testing
-
                 # Calculating 1-in-X return value
                 return_values = get_return_value(
                     ams,
@@ -169,7 +168,7 @@ def _metric_agg(
                 # "Fix" for precipitation is in threshold_tools
                 # TODO: Assess presence of nans within data (and other variables) and develop programmatic fix
                 if return_values.isnull(): 
-                    print('Warning: Return value is NaN, indicating non-finite value returned by threshold tools AMS. Setting value to "0", which may not reflect an accurate distribution fit. Please notify AE team for assistance.')
+                    print('WARNING: Return value is NaN, indicating non-finite value returned by threshold tools AMS. Setting value to "0", which may not reflect an accurate distribution fit. Please notify AE team for assistance.')
                     return_values = 0.0
                     continue
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -128,7 +128,8 @@ def _metric_agg(
             ):  # Can use xr.apply_ufunc, not just a for loop here
 
                 one_da = da.sel(simulation=sim)
-
+                print(f'Running on simulation: {sim}, size: {len(one_da)}') ## testing
+                
                 # Removing small amounts of noise and 0-precip days from precipitation data
                 if variable == "Precipitation (total)":
                     one_da = one_da.resample(time="1D").sum()
@@ -483,16 +484,16 @@ class CavaParams(param.Parameterized):
 
 def cava_data(
     input_locations,  # csv file
-    variable,  # must eventually accept temp, precip, or heat index
+    variable, 
     units=None,
-    approach="Time",  # default for now
-    downscaling_method="Dynamical",  # default for now
-    time_start_year=1981,  # default setting, optional
-    time_end_year=2010,  # default setting, optional
-    historical_data="Historical Climate",  # default for now
-    ssp_data=["SSP3-7.0"],  # default for now
-    warming_level=1.5,  # default for now
-    metric_calc="max",  # default for now
+    approach="Time",  # default
+    downscaling_method="Dynamical",  # default
+    time_start_year=1981,  # default, optional
+    time_end_year=2010,  # default, optional
+    historical_data="Historical Climate",  # default
+    ssp_data=["SSP3-7.0"],  # default
+    warming_level=1.5,  # default
+    metric_calc="max",  # default
     heat_idx_threshold=None,
     one_in_x=None,
     event_duration=(1, "day"),
@@ -500,7 +501,7 @@ def cava_data(
     season="all",  # default to all so no subsetting occurs unless called
     wrf_bias_adjust=True,
     export_method="both",  # raw, full calculate, both
-    separate_files=True,  # Toggle to determine whether or not the user wants to separate climate variable information into separate files
+    separate_files=True,  # toggle to determine whether or not the user wants to separate climate variable information into separate files
     file_format="NetCDF",
     batch_mode=False,
     distr="gev",

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -128,19 +128,17 @@ def _metric_agg(
             ):  # Can use xr.apply_ufunc, not just a for loop here
 
                 one_da = da.sel(simulation=sim)
-                print(f'Running on simulation: {sim}, size: {(one_da.size)}') ## testing
+                print(f'Running on simulation: {sim}') ## testing
 
                 # Removing small amounts of noise and 0-precip days from precipitation data
                 if variable == "Precipitation (total)":
                     one_da = one_da.resample(time="1D").sum()
-                    print('resampling: ', (one_da.size)) ## testing
 
                     # Resampling can cause initially filtered out dates to reappear. Re-filtered in case that occurs.
                     one_da = one_da.sel(time=one_da.time.dt.month.isin(months))
-                    print('filtering check: ', (one_da.size)) ## testing
 
                     one_da = one_da.where(one_da > 10e-10, drop=True)
-                    print('trace precip check: ', (one_da.size)) ## testing
+                    print(f'Trace precip check pre get_block_maxima: {one_da.values}')
 
                 # Computing block maxima
                 groupby, duration = None, None

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -157,7 +157,7 @@ def _metric_agg(
                     check_ess=False,
                 ).squeeze()  # `get_return_value` is expecting a 1-D array
 
-                print('ams: ', ams.size) ## testing
+                print('ams: ', ams.values) ## testing
 
                 # Calculating 1-in-X return value
                 return_values = get_return_value(

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -138,7 +138,7 @@ def _metric_agg(
                     one_da = one_da.sel(time=one_da.time.dt.month.isin(months))
 
                     one_da = one_da.where(one_da > 10e-10, drop=True)
-                    print(f'Trace precip check pre get_block_maxima: {one_da.values}')
+                    # print(f'Trace precip check pre get_block_maxima: {one_da.values}')
 
                 # Computing block maxima
                 groupby, duration = None, None
@@ -146,6 +146,8 @@ def _metric_agg(
                     groupby = event_duration
                 elif event_duration[1] == "hour":
                     duration = event_duration
+                
+                print(metric, groupby, duration)
 
                 ams = get_block_maxima(
                     one_da,

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -168,7 +168,7 @@ def _metric_agg(
                 )["return_value"]
                 return_vals.append(return_values)
 
-                if return_values.isnan(): 
+                if return_values.isnull(): 
                     print('Return value is NaN.... SKIPPING!!!')
                     continue
                 else:

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -147,8 +147,6 @@ def _metric_agg(
                 elif event_duration[1] == "hour":
                     duration = event_duration
                 
-                print(metric, groupby, duration)
-
                 ams = get_block_maxima(
                     one_da,
                     extremes_type=metric,


### PR DESCRIPTION
# Description of PR
IOU informed us that for specific arid/desert locations when running 1-in-100 precipitation event with LOCA produces a “non-finite value” error, which breaks the code and stops the run. The issue is caused by nan values being produced in the threshold_tools.get_block_maxima function, specifically in the groupby option for selecting max/min when calculating the ams series prior to calculating return values that is passed to vulnerability.cava_data._metric_agg(). 

This PR: 
- Implemented a patch fix just for precipitation by setting the NaN fill value to 0 in the max scenario (for max precip, 0 will always be the minimum – this is a semi-safe solution, but not 100% accurate), and by setting the NaN fill value to the precipitation max value in the min scenario (for min precip, we cannot set to 0 since that will be the minimum)
- Included a few warning statements, and in the case of other missing data for other variables,  set the return value to 0 so the code would continue running, but warned the user that this may not be accurate and to notify the team
   - I did not evaluate why there was a missing value in the annual time series. My hypothesis is that for one specific GWL year the removal of trace precipitation (10e-10) produced a full year of nans that persisted. 

What is needed next:
- A more thorough evaluation of missing values in the datarray series resampling and how to handle. 
- Ideally we should be able to skip over them and calculate the nanmax/nanmin rather than setting a fill value. 
- This should be tested in all of the resampling scenarios done in this function. Fix was only implemented for groupby options min and max.
- This needs to be tested in `cava_data` and in threshold_tools as a whole. 

What was attempted and failed:
- skipna(True), min_count=1, fillna(), nanmax, nanmin
- It appears that our version of xarray (2022.x.x) is preventing us from using some of the more modern fixes to this issue – should also be addressed and updated, if possible.

### Summary of changes and related issue
**How to test**
In the `vulnerability_assessment` notebook, test the following code on these locations:

You will need to create a pandas dataframe of these locations with `lat` and `lon` columns
34.765625, -115.390625
33.265625, -114.796875
33.265625, -114.734375
33.234375, -115.109375

```
data = cava_data(
    ## Set-up
    sce_locs,
    downscaling_method="Statistical",  # LOCA2 data
    approach="Warming Level", 
    warming_level=2.0,

    ## 1-in-X event specific arguments
    variable="Precipitation (total)",
    metric_calc="max", # daily maximum precipitation
    one_in_x=100, # One-in-X
    units="inches", # change units

    ## Export
    export_method="None",
    file_format="NetCDF"
    # batch_mode=True # batch mode for warming level still in development
)
```
Ensure that the `nonfinite value` warning does not come up and that the run completes. 

### Relevant motivation and context
This bug was breaking the `cava_data` run for LOCA data for 1-in-X precipitation events, specifically in arid regions. 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Definition of Done Checklist

#### Practical
- [N/A] 80% unit test coverage
- [N/A] Documentation
  - [N/A] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [N/A] Documentation is pushed
- [x] Complex code commented
- [x] Naming conventions followed
  - [N/A] Helper functions hidden with `_` before the name
- [x] Context of function is clearly provided
  - [x] Intent of function is provided
  - [x] How to test, so that it is not siloed on scientists and anyone can review
  - [x] Appropriate manual testing was completed
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Linting completed and resolved

#### Conceptual
- [ ] Doesn't replicate existing functionality
- [ ] Aligns with general coding standard of existing functions
- [x] Matches desired functionality from users/scientists
