### PR TITLE
Bug fix: vulnerability.py adding SSP import

### DIFF
--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -13,7 +13,7 @@ from climakitae.util.utils import (
 from climakitae.core.data_export import export
 from climakitae.core.data_interface import DataParameters
 from climakitae.core.data_load import load
-from climakitae.core.constants import WRF_BA_MODELS
+from climakitae.core.constants import WRF_BA_MODELS, SSPS
 from climakitae.explore import warming_levels
 from climakitae.explore.threshold_tools import (
     get_block_maxima,
@@ -280,8 +280,8 @@ class CavaParams(param.Parameterized):
         doc="Type of historical data",
     )
     ssp_data = param.ListSelector(
-        default=["SSP3-7.0"],
-        objects=["SSP2-4.5", "SSP3-7.0", "SSP5-8.5"],
+        default=["SSP 3-7.0"],
+        objects=["SSP 2-4.5", "SSP 3-7.0", "SSP 5-8.5"],
         doc="SSP data scenarios to use",
     )
     export_method = param.ObjectSelector(
@@ -390,7 +390,7 @@ class CavaParams(param.Parameterized):
 
         # Only allow for SSP 3-7.0 for WRF data
         if self.downscaling_method == "Dynamical" and self.approach == "Time":
-            if len(self.ssp_data) > 1 or self.ssp_data[0] != "SSP3-7.0":
+            if len(self.ssp_data) > 1 or self.ssp_data[0] != "SSP 3-7.0":
                 errors.append(
                     "Can only use SSP 3-7.0 data for a time-based approach using WRF data."
                 )
@@ -490,7 +490,7 @@ def cava_data(
     time_start_year=1981,  # default setting, optional
     time_end_year=2010,  # default setting, optional
     historical_data="Historical Climate",  # default for now
-    ssp_data=["SSP3-7.0"],  # default for now
+    ssp_data=["SSP 3-7.0"],  # default for now
     warming_level=1.5,  # default for now
     metric_calc="max",  # default for now
     heat_idx_threshold=None,
@@ -526,7 +526,7 @@ def cava_data(
     historical_data : str, optional
         Type of historical data, default is "Historical Climate".
     ssp_data : str, optional
-        Shared Socioeconomic Pathway data, default is "SSP3-7.0".
+        Shared Socioeconomic Pathway data, default is "SSP 3-7.0".
     metric_calc : str, optional
         Metric calculation type (e.g., 'mean', 'max', 'min') for supported metrics. Default is "max"
     heat_idx_threshold : float


### PR DESCRIPTION
# Description of PR
The `vulnerability.py` was missing the SSPS import from `core.constants.py`

### Summary of changes and related issue
Added the import, and added all relevant missing "spaces" to where SSPs are set as defaults. Will update the notebook for language as well. 

### Relevant motivation and context
`cava_data` function was breaking. 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Definition of Done Checklist

#### Practical
- [x] 80% unit test coverage
- [x] Documentation
  - [x] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [x] Documentation is pushed
- [x] Complex code commented
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Context of function is clearly provided
  - [x] Intent of function is provided
  - [x] How to test, so that it is not siloed on scientists and anyone can review
  - [x] Appropriate manual testing was completed
- [TO BE FIXED IN PR] Any notebooks known to utilize the affected functions are still working
- [x] Linting completed and resolved

#### Conceptual
- [ ] Doesn't replicate existing functionality
- [x] Aligns with general coding standard of existing functions
- [x] Matches desired functionality from users/scientists
