### PR TITLE
Adding 0.8 1.2 GWLs into cava_data options

### DIFF
--- a/climakitae/core/constants.py
+++ b/climakitae/core/constants.py
@@ -28,18 +28,15 @@ NON_WRF_BA_MODELS = [
 ]
 
 # WRF models that do not reach 0.8°C GWL
-WRF_NO_0PT8_GWL_MODELS = [
-    "WRF_EC-Earth3-Veg_r1i1p1f1",
-    "WRF_EC-Earth3-Veg", 
-    "WRF_EC-Earth3-Veg_r1i1p1f1_historical+ssp370"]
+WRF_NO_0PT8_GWL_MODELS = ["WRF_EC-Earth3-Veg_r1i1p1f1_historical+ssp370"]
 
 # LOCA models that do not reach 0.8°C GWL
 LOCA_NO_0PT8_GWL_MODELS = [
-    "LOCA_EC-Earth3_r4i1p1f1_ssp245",
-    "LOCA_EC-Earth3_r4i1p1f1_ssp370",
-    "LOCA_EC-Earth3_r4i1p1f1_ssp585",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_ssp245",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_ssp370",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_ssp585",
-    "LOCA_EC-Earth3-Veg_r5i1p1f1_ssp245",
+    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp245",
+    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp370",
+    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp585",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp245",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp370",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp585",
+    "LOCA_EC-Earth3-Veg_r5i1p1f1_historical+ssp245",
 ]

--- a/climakitae/core/constants.py
+++ b/climakitae/core/constants.py
@@ -28,9 +28,7 @@ NON_WRF_BA_MODELS = [
 ]
 
 # WRF models that do not reach 0.8°C GWL
-WRF_NO_0PT8_GWL_MODELS = [
-    "WRF_EC-Earth3-Veg_r1i1p1f1_historical+ssp370"
-]
+WRF_NO_0PT8_GWL_MODELS = ["WRF_EC-Earth3-Veg_r1i1p1f1_historical+ssp370"]
 
 # LOCA models that do not reach 0.8°C GWL
 LOCA_NO_0PT8_GWL_MODELS = [

--- a/climakitae/core/constants.py
+++ b/climakitae/core/constants.py
@@ -32,11 +32,11 @@ WRF_NO_0PT8_GWL_MODELS = ["WRF_EC-Earth3-Veg_r1i1p1f1_historical+ssp370"]
 
 # LOCA models that do not reach 0.8°C GWL
 LOCA_NO_0PT8_GWL_MODELS = [
-    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp245",
-    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp370",
-    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp585",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp245",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp370",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp585",
-    "LOCA_EC-Earth3-Veg_r5i1p1f1_historical+ssp245",
+    "LOCA2_EC-Earth3_r4i1p1f1_historical+ssp245",
+    "LOCA2_EC-Earth3_r4i1p1f1_historical+ssp370",
+    "LOCA2_EC-Earth3_r4i1p1f1_historical+ssp585",
+    "LOCA2_EC-Earth3-Veg_r3i1p1f1_historical+ssp245",
+    "LOCA2_EC-Earth3-Veg_r3i1p1f1_historical+ssp370",
+    "LOCA2_EC-Earth3-Veg_r3i1p1f1_historical+ssp585",
+    "LOCA2_EC-Earth3-Veg_r5i1p1f1_historical+ssp245",
 ]

--- a/climakitae/core/constants.py
+++ b/climakitae/core/constants.py
@@ -28,7 +28,10 @@ NON_WRF_BA_MODELS = [
 ]
 
 # WRF models that do not reach 0.8°C GWL
-WRF_NO_0PT8_GWL_MODELS = ["WRF_EC-Earth3-Veg_r1i1p1f1"]
+WRF_NO_0PT8_GWL_MODELS = [
+    "WRF_EC-Earth3-Veg_r1i1p1f1",
+    "WRF_EC-Earth3-Veg", 
+    "WRF_EC-Earth3-Veg_r1i1p1f1_historical+ssp370"]
 
 # LOCA models that do not reach 0.8°C GWL
 LOCA_NO_0PT8_GWL_MODELS = [

--- a/climakitae/core/constants.py
+++ b/climakitae/core/constants.py
@@ -1,12 +1,17 @@
 # constants.py
 """This module defines constants across the codebase"""
 
+# global warming levels available on AE
 WARMING_LEVELS = [0.8, 1.2, 1.5, 2.0, 2.5, 3.0, 4.0]
+
+# shared socioeconomic pathways (IPCC)
 SSPS = [
     "SSP 2-4.5",
     "SSP 3-7.0",
     "SSP 5-8.5",
 ]
+
+# WRF models that have a-priori bias adjustment
 WRF_BA_MODELS = [
     "WRF_EC-Earth3_r1i1p1f1",
     "WRF_MPI-ESM1-2-HR_r3i1p1f1",
@@ -14,8 +19,26 @@ WRF_BA_MODELS = [
     "WRF_MIROC6_r1i1p1f1",
     "WRF_EC-Earth3-Veg_r1i1p1f1",
 ]
+
+# WRF models that do not have a-priori bias adjustment
 NON_WRF_BA_MODELS = [
     "WRF_FGOALS-g3_r1i1p1f1",
     "WRF_CNRM-ESM2-1_r1i1p1f2",
     "WRF_CESM2_r11i1p1f1",
+]
+
+# WRF models that do not reach 0.8°C GWL
+WRF_NO_0PT8_GWL_MODELS = [
+    "WRF_EC-Earth3-Veg_r1i1p1f1_historical+ssp370"
+]
+
+# LOCA models that do not reach 0.8°C GWL
+LOCA_NO_0PT8_GWL_MODELS = [
+    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp245",
+    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp370",
+    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp585",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp245",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp370",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp585",
+    "LOCA_EC-Earth3-Veg_r5i1p1f1_historical+ssp245",
 ]

--- a/climakitae/core/constants.py
+++ b/climakitae/core/constants.py
@@ -28,15 +28,15 @@ NON_WRF_BA_MODELS = [
 ]
 
 # WRF models that do not reach 0.8°C GWL
-WRF_NO_0PT8_GWL_MODELS = ["WRF_EC-Earth3-Veg_r1i1p1f1_historical+ssp370"]
+WRF_NO_0PT8_GWL_MODELS = ["WRF_EC-Earth3-Veg_r1i1p1f1"]
 
 # LOCA models that do not reach 0.8°C GWL
 LOCA_NO_0PT8_GWL_MODELS = [
-    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp245",
-    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp370",
-    "LOCA_EC-Earth3_r4i1p1f1_historical+ssp585",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp245",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp370",
-    "LOCA_EC-Earth3-Veg_r3i1p1f1_historical+ssp585",
-    "LOCA_EC-Earth3-Veg_r5i1p1f1_historical+ssp245",
+    "LOCA_EC-Earth3_r4i1p1f1_ssp245",
+    "LOCA_EC-Earth3_r4i1p1f1_ssp370",
+    "LOCA_EC-Earth3_r4i1p1f1_ssp585",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_ssp245",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_ssp370",
+    "LOCA_EC-Earth3-Veg_r3i1p1f1_ssp585",
+    "LOCA_EC-Earth3-Veg_r5i1p1f1_ssp245",
 ]

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -63,7 +63,7 @@ def _filter_ba_models(data, downscaling_method, wrf_bias_adjust, historical_data
                 if any(s in sim for s in WRF_BA_MODELS)
             ]
         )
-    print(f"Filtering WRF simulations for bias-adjusted simulations.")
+        print(f"Filtering WRF simulations for bias-adjusted simulations.")
     return data
 
 
@@ -667,7 +667,7 @@ def cava_data(
             data = _filter_ba_models(
                 data_pts, downscaling_method, wrf_bias_adjust, historical_data
             )
-
+            print(approach, warming_level)
             if approach == "Warming Level" and warming_level == 0.8:
                 # Filter out inappropriate models for historical GWL baseline
                 data = _filter_hist_gwl_models(
@@ -696,7 +696,7 @@ def cava_data(
                 data = _filter_ba_models(
                     data, downscaling_method, wrf_bias_adjust, historical_data
                 )
-
+                print(approach, warming_level)
                 if approach == "Warming Level" and warming_level == 0.8:
                     # Filter out inappropriate models for historical GWL baseline
                     data = _filter_hist_gwl_models(

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -69,13 +69,14 @@ def _filter_ba_models(data, downscaling_method, wrf_bias_adjust, historical_data
 def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
     """Filters the data to remove simulation(s) that do not reach 0.8°C in GWL selection"""
     if approach == "Warming Level" and warming_level == "0.8":
+        print('testing enter filter')
         # Filter for viable 0.8°C simulations
         if downscaling_method == "Dynamical":
             data = data.sel(
                 simulation=[
                     sim
                     for sim in data.simulation.values
-                    if any(s in sim for s in WRF_NO_0PT8_GWL_MODELS)
+                    if any(s in sim for s not in WRF_NO_0PT8_GWL_MODELS)
                 ]
             )
         elif downscaling_method == "Statistical":
@@ -83,7 +84,7 @@ def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
                 simulation=[
                     sim
                     for sim in data.simualtion.values
-                    if any(s in sim for s in LOCA_NO_0PT8_GWL_MODELS)
+                    if any(s in sim for s not in LOCA_NO_0PT8_GWL_MODELS)
                 ]
             )
         print(

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -72,17 +72,19 @@ def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
 
     # Filter for viable 0.8°C simulations
     if downscaling_method == "Dynamical":
-        print(data.simulation.values)
         data = data.sel(
             simulation=[
-                sim for sim in data.simulation.values if sim not in WRF_NO_0PT8_GWL_MODELS
+                sim
+                for sim in data.simulation.values
+                if sim not in WRF_NO_0PT8_GWL_MODELS
             ]
         )
-        print(data.simulation.values)
     elif downscaling_method == "Statistical":
         data = data.sel(
             simulation=[
-                sim for sim in data.simualtion.values if sim not in LOCA_NO_0PT8_GWL_MODELS
+                sim
+                for sim in data.simulation.values
+                if sim not in LOCA_NO_0PT8_GWL_MODELS
             ]
         )
     print(

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -697,7 +697,7 @@ def cava_data(
                     data, downscaling_method, wrf_bias_adjust, historical_data
                 )
 
-                if approach == "Warming Level" and warming_level == "0.8":
+                if approach == "Warming Level" and warming_level == 0.8:
                     # Filter out inappropriate models for historical GWL baseline
                     data = _filter_hist_gwl_models(
                         data, downscaling_method, approach, warming_level

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -13,7 +13,12 @@ from climakitae.util.utils import (
 from climakitae.core.data_export import export
 from climakitae.core.data_interface import DataParameters
 from climakitae.core.data_load import load
-from climakitae.core.constants import WRF_BA_MODELS, SSPS, WRF_NO_0PT8_GWL_MODELS, LOCA_NO_0PT8_GWL_MODELS
+from climakitae.core.constants import (
+    WRF_BA_MODELS,
+    SSPS,
+    WRF_NO_0PT8_GWL_MODELS,
+    LOCA_NO_0PT8_GWL_MODELS,
+)
 from climakitae.explore import warming_levels
 from climakitae.explore.threshold_tools import (
     get_block_maxima,
@@ -63,16 +68,27 @@ def _filter_ba_models(data, downscaling_method, wrf_bias_adjust, historical_data
 
 def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
     """Filters the data to remove simulation(s) that do not reach 0.8°C in GWL selection"""
-    if (
-        approach == "Warming Level"
-        and warming_level == "0.8"
-    ):
+    if approach == "Warming Level" and warming_level == "0.8":
         # Filter for viable 0.8°C simulations
         if downscaling_method == "Dynamical":
-            data = data.sel(simulation = [sim for sim in data.simulation.values if any(s in sim for s in WRF_NO_0PT8_GWL_MODELS)])
+            data = data.sel(
+                simulation=[
+                    sim
+                    for sim in data.simulation.values
+                    if any(s in sim for s in WRF_NO_0PT8_GWL_MODELS)
+                ]
+            )
         elif downscaling_method == "Statistical":
-            data = data.sel(simulation = [sim for sim in data.simualtion.values if any(s in sim for s in LOCA_NO_0PT8_GWL_MODELS)])
-        print(f"Not all {downscaling_method} simulations have data for {warming_level}°C. Removing invalid simulations. Please see Guidance materials for more information.") # guidance forthcoming
+            data = data.sel(
+                simulation=[
+                    sim
+                    for sim in data.simualtion.values
+                    if any(s in sim for s in LOCA_NO_0PT8_GWL_MODELS)
+                ]
+            )
+        print(
+            f"Not all {downscaling_method} simulations have data for {warming_level}°C. Removing invalid simulations. Please see Guidance materials for more information."
+        )  # guidance forthcoming
     return data
 
 
@@ -373,7 +389,7 @@ class CavaParams(param.Parameterized):
 
         # Validating warming level inputs
         if self.approach == "Warming Level" and self.warming_level not in [
-            0.8, 
+            0.8,
             1.2,
             1.5,
             2.0,

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -63,29 +63,29 @@ def _filter_ba_models(data, downscaling_method, wrf_bias_adjust, historical_data
                 if any(s in sim for s in WRF_BA_MODELS)
             ]
         )
+    print(f"Filtering WRF simulations for bias-adjusted simulations.")
     return data
 
 
 def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
     """Filters the data to remove simulation(s) that do not reach 0.8°C in GWL selection"""
-    if approach == "Warming Level" and warming_level == "0.8":
-        print('testing enter filter')
-        # Filter for viable 0.8°C simulations
-        if downscaling_method == "Dynamical":
-            data = data.sel(
-                simulation=[
-                    sim for sim in data.simulation.values if sim not in WRF_NO_0PT8_GWL_MODELS
-                ]
-            )
-        elif downscaling_method == "Statistical":
-            data = data.sel(
-                simulation=[
-                    sim for sim in data.simualtion.values if sim not in LOCA_NO_0PT8_GWL_MODELS
-                ]
-            )
-        print(
-            f"Not all {downscaling_method} simulations have data for {warming_level}°C. Removing invalid simulations. Please see Guidance materials for more information."
-        )  # guidance forthcoming
+    print('testing enter filter')
+    # Filter for viable 0.8°C simulations
+    if downscaling_method == "Dynamical":
+        data = data.sel(
+            simulation=[
+                sim for sim in data.simulation.values if sim not in WRF_NO_0PT8_GWL_MODELS
+            ]
+        )
+    elif downscaling_method == "Statistical":
+        data = data.sel(
+            simulation=[
+                sim for sim in data.simualtion.values if sim not in LOCA_NO_0PT8_GWL_MODELS
+            ]
+        )
+    print(
+        f"Not all {downscaling_method} simulations have data for {warming_level}°C. Removing invalid simulations. Please see Guidance materials for more information."
+    )  # guidance forthcoming
     return data
 
 
@@ -668,7 +668,7 @@ def cava_data(
                 data_pts, downscaling_method, wrf_bias_adjust, historical_data
             )
 
-            if approach == "Warming Level" and warming_level == "0.8":
+            if approach == "Warming Level" and warming_level == 0.8:
                 # Filter out inappropriate models for historical GWL baseline
                 data = _filter_hist_gwl_models(
                     data, downscaling_method, approach, warming_level

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -74,17 +74,13 @@ def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
         if downscaling_method == "Dynamical":
             data = data.sel(
                 simulation=[
-                    sim
-                    for sim in data.simulation.values
-                    if any(s in sim for s not in WRF_NO_0PT8_GWL_MODELS)
+                    sim for sim in data.simulation.values if sim not in WRF_NO_0PT8_GWL_MODELS
                 ]
             )
         elif downscaling_method == "Statistical":
             data = data.sel(
                 simulation=[
-                    sim
-                    for sim in data.simualtion.values
-                    if any(s in sim for s not in LOCA_NO_0PT8_GWL_MODELS)
+                    sim for sim in data.simualtion.values if sim not in LOCA_NO_0PT8_GWL_MODELS
                 ]
             )
         print(

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -13,7 +13,7 @@ from climakitae.util.utils import (
 from climakitae.core.data_export import export
 from climakitae.core.data_interface import DataParameters
 from climakitae.core.data_load import load
-from climakitae.core.constants import WRF_BA_MODELS, SSPS
+from climakitae.core.constants import WRF_BA_MODELS, SSPS, WRF_NO_0PT8_GWL_MODELS, LOCA_NO_0PT8_GWL_MODELS
 from climakitae.explore import warming_levels
 from climakitae.explore.threshold_tools import (
     get_block_maxima,
@@ -42,7 +42,7 @@ def _export_no_e(da, filename, format):
 
 
 def _filter_ba_models(data, downscaling_method, wrf_bias_adjust, historical_data):
-    """Filters the data for the bias adjusted simulations, if desired."""
+    """Filters the WRF data for the bias adjusted simulations, if desired."""
     if (
         downscaling_method == "Dynamical"
         and wrf_bias_adjust
@@ -58,6 +58,21 @@ def _filter_ba_models(data, downscaling_method, wrf_bias_adjust, historical_data
                 if any(s in sim for s in WRF_BA_MODELS)
             ]
         )
+    return data
+
+
+def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
+    """Filters the data to remove simulation(s) that do not reach 0.8°C in GWL selection"""
+    if (
+        approach == "Warming Level"
+        and warming_level == "0.8"
+    ):
+        # Filter for viable 0.8°C simulations
+        if downscaling_method == "Dynamical":
+            data = data.sel(simulation = [sim for sim in data.simulation.values if any(s in sim for s in WRF_NO_0PT8_GWL_MODELS)])
+        elif downscaling_method == "Statistical":
+            data = data.sel(simulation = [sim for sim in data.simualtion.values if any(s in sim for s in LOCA_NO_0PT8_GWL_MODELS)])
+        print(f"Not all {downscaling_method} simulations have data for {warming_level}°C. Removing invalid simulations. Please see Guidance materials for more information.") 
     return data
 
 
@@ -541,6 +556,8 @@ def cava_data(
         Type of historical data, default is "Historical Climate".
     ssp_data : str, optional
         Shared Socioeconomic Pathway data, default is "SSP 3-7.0".
+    warming_level : str, optional
+        Global warming levels, default is 1.5°C.
     metric_calc : str, optional
         Metric calculation type (e.g., 'mean', 'max', 'min') for supported metrics. Default is "max"
     heat_idx_threshold : float
@@ -638,6 +655,12 @@ def cava_data(
                 data_pts, downscaling_method, wrf_bias_adjust, historical_data
             )
 
+            if approach == "Warming Level" and warming_level == "0.8":
+                # Filter out inappropriate models for historical GWL baseline
+                data = _filter_hist_gwl_models(
+                    data, downscaling_method, approach, warming_level
+                )
+
         else:
             data_pts = []
             for idx, loc in input_locations.iterrows():
@@ -661,6 +684,11 @@ def cava_data(
                     data, downscaling_method, wrf_bias_adjust, historical_data
                 )
 
+                if approach == "Warming Level" and warming_level == "0.8":
+                    # Filter out inappropriate models for historical GWL baseline
+                    data = _filter_hist_gwl_models(
+                        data, downscaling_method, approach, warming_level
+                    )
                 data_pts.append(data)
 
         if historical_data == "Historical Reconstruction":

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -282,7 +282,7 @@ class CavaParams(param.Parameterized):
     )
     warming_level = param.ObjectSelector(
         default=1.5,
-        objects=[None, 1.5, 2.0, 2.5, 3.0],
+        objects=[None, 0.8, 1.2, 1.5, 2.0, 2.5, 3.0],
         doc="Warming level for analysis",
     )
     wrf_bias_adjust = param.Boolean(default=True, doc="Flag for WRF bias adjustment")
@@ -358,12 +358,14 @@ class CavaParams(param.Parameterized):
 
         # Validating warming level inputs
         if self.approach == "Warming Level" and self.warming_level not in [
+            0.8, 
+            1.2,
             1.5,
             2.0,
             2.5,
             3.0,
         ]:
-            errors.append("Warming level must be 1.5, 2.0, 2.5, or 3.0.")
+            errors.append("Warming level must be 0.8, 1.2, 1.5, 2.0, 2.5, or 3.0.")
 
         # Validating that only one of heat_idx_threshold, percentile, or one_in_x is passed
         if (
@@ -446,7 +448,7 @@ class CavaParams(param.Parameterized):
         elif self.approach == "Warming Level":
             wl_str = (
                 str(int(self.warming_level))
-                if self.warming_level not in [1.5, 2.5]
+                if self.warming_level not in [0.8, 1.2, 1.5, 2.5]
                 else str(self.warming_level).replace(".", "pt")
             )
             approach_str = f"{wl_str}degreeWL"

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -72,7 +72,7 @@ def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
             data = data.sel(simulation = [sim for sim in data.simulation.values if any(s in sim for s in WRF_NO_0PT8_GWL_MODELS)])
         elif downscaling_method == "Statistical":
             data = data.sel(simulation = [sim for sim in data.simualtion.values if any(s in sim for s in LOCA_NO_0PT8_GWL_MODELS)])
-        print(f"Not all {downscaling_method} simulations have data for {warming_level}°C. Removing invalid simulations. Please see Guidance materials for more information.") 
+        print(f"Not all {downscaling_method} simulations have data for {warming_level}°C. Removing invalid simulations. Please see Guidance materials for more information.") # guidance forthcoming
     return data
 
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -63,20 +63,22 @@ def _filter_ba_models(data, downscaling_method, wrf_bias_adjust, historical_data
                 if any(s in sim for s in WRF_BA_MODELS)
             ]
         )
-        print(f"Filtering WRF simulations for bias-adjusted simulations.")
+        print(f"Filtering WRF data for bias-adjusted simulations.")
     return data
 
 
 def _filter_hist_gwl_models(data, downscaling_method, approach, warming_level):
     """Filters the data to remove simulation(s) that do not reach 0.8°C in GWL selection"""
-    print('testing enter filter')
+
     # Filter for viable 0.8°C simulations
     if downscaling_method == "Dynamical":
+        print(data.simulation.values)
         data = data.sel(
             simulation=[
                 sim for sim in data.simulation.values if sim not in WRF_NO_0PT8_GWL_MODELS
             ]
         )
+        print(data.simulation.values)
     elif downscaling_method == "Statistical":
         data = data.sel(
             simulation=[
@@ -667,7 +669,7 @@ def cava_data(
             data = _filter_ba_models(
                 data_pts, downscaling_method, wrf_bias_adjust, historical_data
             )
-            print(approach, warming_level)
+
             if approach == "Warming Level" and warming_level == 0.8:
                 # Filter out inappropriate models for historical GWL baseline
                 data = _filter_hist_gwl_models(
@@ -696,7 +698,7 @@ def cava_data(
                 data = _filter_ba_models(
                     data, downscaling_method, wrf_bias_adjust, historical_data
                 )
-                print(approach, warming_level)
+
                 if approach == "Warming Level" and warming_level == 0.8:
                     # Filter out inappropriate models for historical GWL baseline
                     data = _filter_hist_gwl_models(

--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -48,7 +48,7 @@ class WarmingLevels:
 
     def __init__(self, **params):
         self.wl_params = WarmingLevelChoose()
-        # self.warming_levels = ["1.5", "2.0", "3.0", "4.0"]
+        # self.warming_levels = ["0.8", "1.2", "1.5", "2.0", "3.0", "4.0"]
 
     def find_warming_slice(self, level, gwl_times):
         """
@@ -79,6 +79,7 @@ class WarmingLevels:
         # manually reset to all SSPs, in case it was inadvertently changed by
         # temporarily have ['Dynamical','Statistical'] for downscaling_method
         self.wl_params.scenario_ssp = SSPS
+
         # Postage data and anomalies
         self.catalog_data = self.wl_params.retrieve()
         self.catalog_data = self.catalog_data.stack(all_sims=["simulation", "scenario"])
@@ -170,7 +171,7 @@ def clean_warm_data(warm_data):
     return warm_data
 
 
-def get_sliced_data(y, level, years, months=np.arange(1, 13), window=15, anom="Yes"):
+def get_sliced_data(y, level, years, months=np.arange(1, 13), window=15, anom="No"):
     """Calculating warming level anomalies.
 
     Parameters
@@ -288,7 +289,7 @@ class WarmingLevelChoose(DataParameters):
     anom = param.Selector(
         default="Yes",
         objects=["Yes", "No"],
-        doc="Return an anomaly \n(difference from historical reference period)?",
+        doc="Return a delta signal \n(difference from historical reference period)?",
     )
 
     def __init__(self, *args, **params):
@@ -303,7 +304,7 @@ class WarmingLevelChoose(DataParameters):
         self.variable = "Air Temperature at 2m"
 
         # Choosing specific warming levels
-        self.warming_levels = ["1.5", "2.0", "3.0", "4.0"]
+        self.warming_levels = ["0.8", "1.2", "1.5", "2.0", "3.0", "4.0"]
         self.months = np.arange(1, 13)
 
         # Location defaults


### PR DESCRIPTION
# Description of PR
Adds historical GWLs as viable options into `cava_data` functionality in the `vulnerability_assessment.ipynb` notebook.  I also went ahead and changed the language of the `anom` parameter in `warming.py` to be clearer, but **did not modify the underlying code** as to **how** `anom` is calculated.

**IMPORTANT**: I added two new constants to constants.py of which models should not be returned if the warming level is selected as 0.8°C. This should be implemented more broadly across the code base for 0.8°C in general. 

**How to test**:
- Try to retrieve 0.8 and 1.2 as warming_level options in cava_data function **and** 
- Ensure that **for a 0.8°C GWL** for WRF EC-Earth3-Veg is not returned, and for LOCA EC-Earth3_r4i1ip1f1 all ssps, EC-Earth3-Veg_ri1p1f1 all ssps, and EC-Earth3-Veg_r5i1p1f1 ssp245 are not returned. 

Example: 
```
data = cava_data(
    ## Set-up
    example_locs.iloc[:1], # select a single location
    downscaling_method="Dynamical",  # WRF data
    approach="Warming Level",
    warming_level=0.8,
    wrf_bias_adjust=False, # return all WRF models
    
    ## Likely seasonal event specific arguments
    variable="Air Temperature at 2m", 
    metric_calc="max", # daily high temperature
    percentile=50, # likeliness percentile
    season="summer", # season
    units="degC", # change units
    
    ## Export
    export_method="None",
    file_format="NetCDF",
)
```
To check # of sims:
```
data['calc_data']
```

### Summary of changes and related issue
Requested by partners. 

### Relevant motivation and context
Requested by partners. 

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Definition of Done Checklist

#### Practical
- [x] 80% unit test coverage
- [x] Documentation
  - [x] All functions/adjusted functions documented in the [readthedocs](https://climakitae.readthedocs.io/en/latest/).
  - [x] Documentation is pushed
- [x] Complex code commented
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Context of function is clearly provided
  - [x] Intent of function is provided
  - [x] How to test, so that it is not siloed on scientists and anyone can review
  - [x] Appropriate manual testing was completed
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Linting completed and resolved

#### Conceptual
- [ ] Doesn't replicate existing functionality
- [x] Aligns with general coding standard of existing functions
- [x] Matches desired functionality from users/scientists
