### PR TITLE
Rotate wind vectors 

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -722,13 +722,13 @@ def _get_Uearth(selections):
     -------
     da: xr.DataArray
     """
-    # Load u10 data
-    selections.variable_id = ["u10"]
-    u10_da = _get_data_one_var(selections)
-
     # Load v10 data
     selections.variable_id = ["v10"]
     v10_da = _get_data_one_var(selections)
+
+    # Load u10 data
+    selections.variable_id = ["u10"]
+    u10_da = _get_data_one_var(selections)
 
     # Read in the appropriate file depending on the data resolution
     # This file contains sinalpha and cosalpha for the WRF grid
@@ -764,13 +764,11 @@ def _get_Vearth(selections):
     """
     # Load u10 data
     selections.variable_id = ["u10"]
-    # u10_da = _get_data_one_var(selections)
-    u10_da = _get_Uearth(selections)
+    u10_da = _get_data_one_var(selections)
 
     # Load v10 data
     selections.variable_id = ["v10"]
-    # v10_da = _get_data_one_var(selections)
-    v10_da = _get_Vearth(selections)
+    v10_da = _get_data_one_var(selections)
 
     # Read in the appropriate file depending on the data resolution
     # This file contains sinalpha and cosalpha for the WRF grid

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -1251,14 +1251,14 @@ def read_catalog_from_select(selections):
         selections.units = orig_unit_selection
 
     # Rotate wind vectors
-    # elif (
-    #     any(x in selections.variable_id for x in ["u10", "v10"])
-    #     and selections.downscaling_method == "Dynamical"
-    # ):
-    #     if "u10" in selections.variable_id:
-    #         da = _get_Uearth(selections)
-    #     elif "v10" in selections.variable_id:
-    #         da = _get_Vearth(selections)
+    elif (
+        any(x in selections.variable_id for x in ["u10", "v10"])
+        and selections.downscaling_method == "Dynamical"
+    ):
+        if "u10" in selections.variable_id:
+            da = _get_Uearth(selections)
+        elif "v10" in selections.variable_id:
+            da = _get_Vearth(selections)
 
     # Any other variable... i.e. not an index, derived var, or a WRF wind vector
     else:

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -733,7 +733,12 @@ def _get_Uearth(selections):
     # Read in the appropriate file depending on the data resolution
     # This file contains sinalpha and cosalpha for the WRF grid
     gridlabel = resolution_to_gridlabel(selections.resolution)
-    wrf_angles_ds = xr.open_zarr("s3://cadcat-tmp/wrfinput_{}.zarr/".format(gridlabel))
+    wrf_angles_ds = xr.open_zarr(
+        "s3://cadcat-tmp/wrf_angles_{}.zarr/".format(gridlabel)
+    )
+    wrf_angles_ds = _spatial_subset(
+        wrf_angles_ds, selections
+    )  # Clip to spatial subset of data
     sinalpha = wrf_angles_ds.SINALPHA
     cosalpha = wrf_angles_ds.COSALPHA
 
@@ -770,7 +775,12 @@ def _get_Vearth(selections):
     # Read in the appropriate file depending on the data resolution
     # This file contains sinalpha and cosalpha for the WRF grid
     gridlabel = resolution_to_gridlabel(selections.resolution)
-    wrf_angles_ds = xr.open_zarr("s3://cadcat-tmp/wrfinput_{}.zarr/".format(gridlabel))
+    wrf_angles_ds = xr.open_zarr(
+        "s3://cadcat-tmp/wrf_angles_{}.zarr/".format(gridlabel)
+    )
+    wrf_angles_ds = _spatial_subset(
+        wrf_angles_ds, selections
+    )  # Clip to spatial subset of data
     sinalpha = wrf_angles_ds.SINALPHA
     cosalpha = wrf_angles_ds.COSALPHA
 
@@ -826,12 +836,14 @@ def _get_wind_dir_derived(selections):
     selections.units = (
         "m s-1"  # Need to set units to required units for compute_wind_mag
     )
-    u10_da = _get_data_one_var(selections)
+    # u10_da = _get_data_one_var(selections)
+    u10_da = _get_Uearth(selections)
 
     # Load v10 data
     selections.variable_id = ["v10"]
     selections.units = "m s-1"
-    v10_da = _get_data_one_var(selections)
+    # v10_da = _get_data_one_var(selections)
+    v10_da = _get_Vearth(selections)
 
     # Derive the variable
     da = compute_wind_dir(u10=u10_da, v10=v10_da)
@@ -1241,14 +1253,14 @@ def read_catalog_from_select(selections):
         selections.units = orig_unit_selection
 
     # Rotate wind vectors
-    elif (
-        any(x in selections.variable_id for x in ["u10", "v10"])
-        and selections.downscaling_method == "Dynamical"
-    ):
-        if "u10" in selections.variable_id:
-            da = _get_Uearth(selections)
-        elif "v10" in selections.variable_id:
-            da = _get_Vearth(selections)
+    # elif (
+    #     any(x in selections.variable_id for x in ["u10", "v10"])
+    #     and selections.downscaling_method == "Dynamical"
+    # ):
+    #     if "u10" in selections.variable_id:
+    #         da = _get_Uearth(selections)
+    #     elif "v10" in selections.variable_id:
+    #         da = _get_Vearth(selections)
 
     # Any other variable... i.e. not an index, derived var, or a WRF wind vector
     else:

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -745,6 +745,9 @@ def _get_Uearth(selections):
     # Compute Uearth
     Uearth = u10_da * cosalpha - v10_da * sinalpha
 
+    # Add variable name
+    Uearth.name = selections.variable
+
     return Uearth
 
 
@@ -784,6 +787,9 @@ def _get_Vearth(selections):
 
     # Compute Uearth
     Vearth = v10_da * cosalpha + u10_da * sinalpha
+
+    # Add variable name
+    Vearth.name = selections.variable
 
     return Vearth
 


### PR DESCRIPTION
## Summary of changes and related issue
Programmatically rotate winds from WRF grid --> spherical earth. 

![download](https://github.com/user-attachments/assets/7e924cd9-27f7-4d9b-a005-5bfeab0dfee9)
![download-1](https://github.com/user-attachments/assets/a1f08240-f9bf-445e-8565-bf006a6da461)
![download-2](https://github.com/user-attachments/assets/fb84b1d2-fd8a-48f5-b25d-8cd3a01e14a3)
![download-3](https://github.com/user-attachments/assets/a31d73a8-43d4-4082-924d-dec30911d558)

## Relevant motivation and context
We need to rotate U and V to Earth-relative coordinates in order to properly derive wind direction and generally make comparisons against observations. Reference: https://www-k12.atmos.washington.edu/~ovens/wrfwinds.html
Ideally, this should NOT be done programmatically... we should update the zarrs and remove this code. At some point in the future. 

Affected variables: 
WRF hourly: 
- West-East component of Wind at 10m (i.e. "u10") 
- North-South component of Wind at 10m (i.e. "v10")
- Wind direction at 10m (derived from u10 & v10) 
- Wind speed at 10m (derived from u10 and v10) 

**WE NEED TO UPDATE THE GUIDANCE BUT I DON'T THINK I'M THE RIGHT PERSON TO DO THAT**

## How to test 
Run the notebook and files that Nicole will send you in the hub. You'll need to upload the unrotated data from the zip file as well. The notebook produces the figures from the top of the PR. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
