### PR TITLE
"convert_to_local_time" failing on gridded data wrt Boundaries

### DIFF
--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -12,7 +12,6 @@ import intake
 from timezonefinder import TimezoneFinder
 from climakitae.core.paths import data_catalog_url, stations_csv_path
 from climakitae.core.constants import SSPS
-from climakitae.core.boundaries import Boundaries
 
 
 def downscaling_method_as_list(downscaling_method):

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -12,6 +12,7 @@ import intake
 from timezonefinder import TimezoneFinder
 from climakitae.core.paths import data_catalog_url, stations_csv_path
 from climakitae.core.constants import SSPS
+from climakitae.core.boundaries import Boundaries
 
 
 def downscaling_method_as_list(downscaling_method):
@@ -635,31 +636,30 @@ def convert_to_local_time(data, selections):  # , lat, lon) -> xr.Dataset:
 
     elif selections.data_type == "Gridded" and selections.area_subset != "none":
         # Find the avg. lat/lon coordinates from entire geometry within an area subset
-        from climakitae.core.boundaries import Boundaries
 
-        boundaries = Boundaries()
+        boundaries = selections._geographies
 
         # Making mapping for different geographies to different polygons
         mapping = {
             "CA counties": (
-                boundaries.geographies._ca_counties,
-                boundaries.geographies._get_ca_counties(),
+                boundaries._ca_counties,
+                boundaries._get_ca_counties(),
             ),
             "CA Electric Balancing Authority Areas": (
-                boundaries.geographies._ca_electric_balancing_areas,
-                boundaries.geographies._get_electric_balancing_areas(),
+                boundaries._ca_electric_balancing_areas,
+                boundaries._get_electric_balancing_areas(),
             ),
             "CA Electricity Demand Forecast Zones": (
-                boundaries.geographies._ca_forecast_zones,
-                boundaries.geographies._get_forecast_zones(),
+                boundaries._ca_forecast_zones,
+                boundaries._get_forecast_zones(),
             ),
             "CA Electric Load Serving Entities (IOU & POU)": (
-                boundaries.geographies._ca_utilities,
-                boundaries.geographies._get_ious_pous(),
+                boundaries._ca_utilities,
+                boundaries._get_ious_pous(),
             ),
             "CA watersheds": (
-                boundaries.geographies._ca_watersheds,
-                boundaries.geographies._get_ca_watersheds(),
+                boundaries._ca_watersheds,
+                boundaries._get_ca_watersheds(),
             ),
         }
 


### PR DESCRIPTION
Specifically in the annual_consumption_model / degree_days notebook, the second convert_to_local_time with gridded data is failing

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In [13], line 2
      1 # do simple timezone conversion instead
----> 2 data_dfz = convert_to_local_time(data_dfz, selections)

File ~/src/climakitae/climakitae/util/utils.py:640, in convert_to_local_time(data, selections)
    636 elif selections.data_type == "Gridded" and selections.area_subset != "none":
    637     # Find the avg. lat/lon coordinates from entire geometry within an area subset
    638     from climakitae.core.boundaries import Boundaries
--> 640     boundaries = Boundaries()
    642     # Making mapping for different geographies to different polygons
    643     mapping = {
    644         "CA counties": (
    645             boundaries.geographies._ca_counties,
   (...)
    663         ),
    664     }

TypeError: __init__() missing 1 required positional argument: 'boundary_catalog'
```

Data merged without formal review process because it was time sensitive