### PR TITLE
Fix indent in get_data test 

### DIFF
--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -32,46 +32,46 @@ class TestDerivedVariablesGetData:
                 "Data for Fosberg Fire Weather Index with Warming Levels approach could not be retrieved"
             )
 
-        def test_hourly_relative_humidity_warming_levels_approach_retrieval(self):
-            """Make sure that the hourly relative humidity (a derived variable) can be retrieved!
-            Previously raised an error in Nov 2024 (has since been fixed)
-            """
-            try:
-                ds = get_data(
-                    variable="Relative humidity",
-                    timescale="hourly",
-                    resolution="9 km",
-                    downscaling_method="Dynamical",
-                    area_subset="states",
-                    cached_area="CA",
-                    approach="Warming Level",
-                    warming_level=[3.0],
-                )
-            except:
-                pytest.fail(
-                    "Data for hourly Relative Humidity with a Warming Levels approach could not be retrieved"
-                )
+    def test_hourly_relative_humidity_warming_levels_approach_retrieval(self):
+        """Make sure that the hourly relative humidity (a derived variable) can be retrieved!
+        Previously raised an error in Nov 2024 (has since been fixed)
+        """
+        try:
+            ds = get_data(
+                variable="Relative humidity",
+                timescale="hourly",
+                resolution="9 km",
+                downscaling_method="Dynamical",
+                area_subset="states",
+                cached_area="CA",
+                approach="Warming Level",
+                warming_level=[3.0],
+            )
+        except:
+            pytest.fail(
+                "Data for hourly Relative Humidity with a Warming Levels approach could not be retrieved"
+            )
 
-        def test_hourly_relative_humidity_time_based_approach_retrieval(self):
-            """Make sure that the hourly relative humidity (a derived variable) can be retrieved!
-            Previously raised an error in Nov 2024 (has since been fixed)
-            """
-            try:
-                ds = get_data(
-                    variable="Relative humidity",
-                    timescale="hourly",
-                    resolution="9 km",
-                    downscaling_method="Dynamical",
-                    area_subset="states",
-                    cached_area="CA",
-                    approach="Time",
-                    time_slice=(1990, 1991),
-                    scenario="Historical Climate",
-                )
-            except:
-                pytest.fail(
-                    "Data for hourly Relative Humidity with a Time-based approach could not be retrieved"
-                )
+    def test_hourly_relative_humidity_time_based_approach_retrieval(self):
+        """Make sure that the hourly relative humidity (a derived variable) can be retrieved!
+        Previously raised an error in Nov 2024 (has since been fixed)
+        """
+        try:
+            ds = get_data(
+                variable="Relative humidity",
+                timescale="hourly",
+                resolution="9 km",
+                downscaling_method="Dynamical",
+                area_subset="states",
+                cached_area="CA",
+                approach="Time",
+                time_slice=(1990, 1991),
+                scenario="Historical Climate",
+            )
+        except:
+            pytest.fail(
+                "Data for hourly Relative Humidity with a Time-based approach could not be retrieved"
+            )
 
 
 class TestAppropriateStringErrorReturnedIfBadInputGetData:


### PR DESCRIPTION
## Summary of changes and related issue
Not all the tests were running because the indent was pushed too far to the right. This effects the Relative Humidity tests that follow the Fosberg Fire Weather Index test. 

The three tests are all running (and passing) now: 
<img width="967" alt="Screenshot 2025-01-16 at 10 38 35 AM" src="https://github.com/user-attachments/assets/d885d4ad-02da-4e6f-83d7-ce575555a6d0" />

## Relevant motivation and context
Eric found this bug when trying to debug something else. 

## How to test 
No need to test; the github CI should test it for us :) 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [] Tagged/notified 2 reviewers for this PR
