### PR TITLE
Get station data using get_data() function

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -2104,11 +2104,14 @@ def get_data(
         timescale = "hourly"
         variable = "Air Temperature at 2m"
 
-        # Deal with scenario argument
+        # Deal with scenario and time_slice arguments
         # Handle various use-cases of user inputs/errors
         if scenario is None:
-            # Make scenario a list so we can append to it
-            scenario = []
+            if time_slice is None:
+                # Default
+                scenario = ["Historical Climate"]
+            else:
+                scenario = []
 
         if resolution == "3 km":
             # Neither SSP 2-4.5 nor SSP 5-8.5 are valid options for scenario... need to remove
@@ -2117,18 +2120,19 @@ def get_data(
                     error_message = f"{bad_scenario_choice} is not a valid scenario input for resolution = {resolution}"
                     print(_format_error_print_message(error_message))
                     return None
-
-        if (
-            any(value < 2015 for value in time_slice)
-            and ("Historical Climate") not in scenario
-        ):
-            # Add Historical Climate to scenario if the time scale includes historical period
-            scenario.append("Historical Climate")
-        if any(value >= 2015 for value in time_slice) and not any(
-            "SSP" in item for item in scenario
-        ):
-            # If the time scale includes the future period and no SSP data is selected, add SSP 3-7.0
-            scenario.append("SSP 3-7.0")
+        if time_slice is not None:
+            # Make sure time_slice and scenario match each other
+            # If time_slice is not assigned by the user, it will be auto-set by the DataInterface object
+            if any(value < 2015 for value in time_slice) and (
+                ("Historical Climate") not in scenario
+            ):
+                # Add Historical Climate to scenario if the time scale includes historical period
+                scenario.append("Historical Climate")
+            if any(value >= 2015 for value in time_slice) and not any(
+                "SSP" in item for item in scenario
+            ):
+                # If the time scale includes the future period and no SSP data is selected, add SSP 3-7.0
+                scenario.append("SSP 3-7.0")
 
         if stations is None:
             # Print a warning if the user wants to retrieve station data but they don't input a value for station

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -525,8 +525,8 @@ class DataParameters(param.Parameterized):
     downscaling_method: str
         whether to choose WRF or LOCA2 data or both ("Dynamical", "Statistical", "Dynamical+Statistical")
     data_type: str
-        whether to choose gridded or station based data ("Gridded", "Station")
-    station: list or strs
+        whether to choose gridded or station based data ("Gridded", "Stations")
+    stations: list or strs
         list of stations that can be filtered by cached_area
     _station_data_info: str
         informational statement when station data selected with data_type
@@ -623,8 +623,8 @@ class DataParameters(param.Parameterized):
         default="Dynamical",
         objects=["Dynamical", "Statistical", "Dynamical+Statistical"],
     )
-    data_type = param.Selector(default="Gridded", objects=["Gridded", "Station"])
-    station = param.ListSelector(objects=dict())
+    data_type = param.Selector(default="Gridded", objects=["Gridded", "Stations"])
+    stations = param.ListSelector(objects=dict())
     _station_data_info = param.String(
         default="", doc="Information about the bias correction process and resolution"
     )
@@ -717,7 +717,7 @@ class DataParameters(param.Parameterized):
 
         # Show derived index option?
         indices = True
-        if self.data_type == "station":
+        if self.data_type == "Stations":
             indices = False
         if self.downscaling_method != "Dynamical":
             indices = False
@@ -820,7 +820,7 @@ class DataParameters(param.Parameterized):
         """Update area average selection choices based on station vs. gridded data.
         There is no area average option if station data is selected. It will be shown as n/a.
         """
-        if self.data_type == "Station":
+        if self.data_type == "Stations":
             self.param["area_average"].objects = ["n/a"]
             self.area_average = "n/a"
         elif self.data_type == "Gridded":
@@ -851,7 +851,7 @@ class DataParameters(param.Parameterized):
             self.param["data_type"].objects = ["Gridded"]
             self.data_type = "Gridded"
         else:
-            self.param["data_type"].objects = ["Gridded", "Station"]
+            self.param["data_type"].objects = ["Gridded", "Stations"]
         if self.variable_type == "Derived Index":
 
             # Haven't built into the code to retrieve derive index for statistically downscaled data yet. Derived indices at the moment only work for hourly data.
@@ -860,7 +860,7 @@ class DataParameters(param.Parameterized):
 
             self.param["approach"].objects = ["Time", "Warming Level"]
 
-        elif "Station" in self.data_type:
+        elif "Stations" in self.data_type:
             self.param["downscaling_method"].objects = ["Dynamical"]
             self.downscaling_method = "Dynamical"
 
@@ -881,7 +881,7 @@ class DataParameters(param.Parameterized):
             self.param["resolution"].objects = ["3 km"]
             self.resolution = "3 km"
         else:
-            if self.data_type == "Station":
+            if self.data_type == "Stations":
                 self.param["resolution"].objects = ["3 km", "9 km"]
                 if self.resolution == "45 km":
                     self.resolution = "3 km"
@@ -898,7 +898,7 @@ class DataParameters(param.Parameterized):
         ## Remove derived index as an option if the current selections do not have any index options.
         indices = True
         # Cases where we currently don't have derived indices
-        if self.data_type == "station":
+        if self.data_type == "Stations":
             # Only air temp available for station data
             indices = False
         if self.downscaling_method != "Dynamical":
@@ -927,7 +927,7 @@ class DataParameters(param.Parameterized):
         """Update unique variable options"""
 
         # Station data is only available hourly
-        if self.data_type == "Station":
+        if self.data_type == "Stations":
             self.param["timescale"].objects = ["hourly"]
             self.timescale = "hourly"
             self.param["variable_type"].objects = ["Variable"]
@@ -956,7 +956,7 @@ class DataParameters(param.Parameterized):
             resolution=self.resolution,
         )
 
-        if self.data_type == "Station":
+        if self.data_type == "Stations":
             # If station is selected, the only valid option is air temperature
             temp = "Air Temperature at 2m"
             self.param["variable"].objects = [temp]
@@ -1225,7 +1225,7 @@ class DataParameters(param.Parameterized):
     def _update_textual_description(self):
         if self.data_type == "Gridded":
             self._station_data_info = ""
-        elif self.data_type == "Station":
+        elif self.data_type == "Stations":
             self._station_data_info = self._info_about_station_data
 
     @param.depends(
@@ -1238,7 +1238,7 @@ class DataParameters(param.Parameterized):
     )
     def _update_station_list(self):
         """Update the list of weather station options if the area subset changes"""
-        if self.data_type == "Station":
+        if self.data_type == "Stations":
             overlapping_stations = _get_overlapping_station_names(
                 self._stations_gdf,
                 self.area_subset,
@@ -1250,15 +1250,15 @@ class DataParameters(param.Parameterized):
             )
             if len(overlapping_stations) == 0:
                 notice = "No stations available at this location"
-                self.param["station"].objects = [notice]
-                self.station = [notice]
+                self.param["stations"].objects = [notice]
+                self.stations = [notice]
             else:
-                self.param["station"].objects = overlapping_stations
-                self.station = overlapping_stations
+                self.param["stations"].objects = overlapping_stations
+                self.stations = overlapping_stations
         elif self.data_type == "Gridded":
             notice = "Set data type to 'Station' to see options"
-            self.param["station"].objects = [notice]
-            self.station = [notice]
+            self.param["stations"].objects = [notice]
+            self.stations = [notice]
 
     def retrieve(self, config=None, merge=True):
         """Retrieve data from catalog
@@ -1488,7 +1488,7 @@ def _get_var_name_from_table(variable_id, downscaling_method, timescale, var_df)
     return var_name
 
 
-def _get_closest_options(val, valid_options):
+def _get_closest_options(val, valid_options, cutoff=0.59):
     """If the user inputs a bad option, find the closest option from a list of valid options
 
     Parameters
@@ -1497,6 +1497,9 @@ def _get_closest_options(val, valid_options):
         User input
     valid_options: list
         Valid options for that key from the catalog
+    cutoff: a float in the range [0, 1]
+        See difflib.get_close_matches
+        Possibilities that don't score at least that similar to word are ignored.
 
     Returns
     -------
@@ -1516,7 +1519,7 @@ def _get_closest_options(val, valid_options):
     # For example, if they input "statistikal" instead of "Statistical", difflib will find "Statistical"
     # Change the cutoff to increase/decrease the flexibility of the function
     maybe_difflib_can_find_something = difflib.get_close_matches(
-        val, valid_options, cutoff=0.59
+        val, valid_options, cutoff=cutoff
     )
 
     if len(is_it_just_capitalized_wrong) > 0:
@@ -1597,7 +1600,8 @@ def _check_if_good_input(d, cat_df):
 
                 # Sad! No closest options found. Just set the key to all valid options
                 if closest_options is None:
-                    print("Valid options: " + ", ".join(valid_options))
+                    print("Valid options: \n- ", end="")
+                    print("\n- ".join(valid_options))
                     raise ValueError("Bad input")
 
                 # Just one option in the list
@@ -1715,7 +1719,7 @@ def get_subsetting_options(area_subset="all"):
     Parameters
     ----------
     area_subset: str
-        One of "all", "states", "CA counties", "CA Electricity Demand Forecast Zones", "CA watersheds", "CA Electric Balancing Authority Areas", "CA Electric Load Serving Entities (IOU & POU)"
+        One of "all", "states", "CA counties", "CA Electricity Demand Forecast Zones", "CA watersheds", "CA Electric Balancing Authority Areas", "CA Electric Load Serving Entities (IOU & POU)", "Stations"
         Defaults to "all", which shows all the geometry options with area_subset as a multiindex
 
     Returns
@@ -1750,6 +1754,9 @@ def get_subsetting_options(area_subset="all"):
         )[
             ["NAME", "geometry"]
         ],
+        "Stations": data_interface._stations_gdf.sort_values("station").rename(
+            columns={"station": "NAME"}
+        )[["NAME", "geometry"]],
     }
 
     # Confirm that input for argument "area_subset" is valid
@@ -1772,8 +1779,11 @@ def get_subsetting_options(area_subset="all"):
         df["area_subset"] = [name] * len(
             df
         )  # Add area subset as a column. Used to create multiindex if area_subset = "all"
-        df = df[df["NAME"].isin(list(boundary_dict[name].keys()))]
-        df_dict[name] = df  # Replace the DataFrame with the new, reduced DataFrame
+        if name == "Stations":  # This logic doesn't apply to weather stations
+            pass  # do nothing
+        else:  # Limit options
+            df = df[df["NAME"].isin(list(boundary_dict[name].keys()))]
+        df_dict[name] = df  # Replace the dictionary with the new, reduced dictionary
 
     if area_subset != "all":
         # Only return the desired area subset
@@ -1801,9 +1811,10 @@ def _format_error_print_message(error_message):
 
 def get_data(
     variable,
-    downscaling_method,
     resolution,
     timescale,
+    downscaling_method="Dynamical",
+    data_type="Gridded",
     approach="Time",
     scenario=None,
     units=None,
@@ -1814,6 +1825,7 @@ def get_data(
     cached_area=["entire domain"],
     area_average=None,
     time_slice=None,
+    stations=None,
     warming_level_window=None,
     warming_level_months=None,
 ):
@@ -1825,13 +1837,17 @@ def get_data(
     ----------
     variable: str
         String name of climate variable
-    downscaling_method: str, one of ["Dynamical", "Statistical", "Dynamical+Statistical"]
-        Downscaling method of the data:
-        WRF ("Dynamical"), LOCA2 ("Statistical"), or both "Dynamical+Statistical"
     resolution: str, one of ["3 km", "9 km", "45 km"]
         Resolution of data in kilometers
     timescale: str, one of ["hourly", "daily", "monthly"]
         Temporal frequency of dataset
+    downscaling_method: str, one of ["Dynamical", "Statistical", "Dynamical+Statistical"], optional
+        Downscaling method of the data:
+        WRF ("Dynamical"), LOCA2 ("Statistical"), or both "Dynamical+Statistical"
+        Default to "Dynamical"
+    data_type: str, one of ["Gridded", "Stations"], optional
+        Whether to choose gridded data or weather station data
+        Default to "Gridded"
     approach: one of ["Time", "Warming Level"], optional
         Default to "Time"
     scenario: str or list of str, optional
@@ -1859,17 +1875,21 @@ def get_data(
     time_slice: tuple, optional
         Time range for retrieved data
         Only valid for approach = "Time"
+    stations: list of str, optional
+        Which weather stations to retrieve data for
+        Only valid for data_type = "Stations"
+        Default to all stations
     warming_level: list of float, optional
         Must be one of the warming levels available in `clmakitae.core.constants`
-        Only valid for approach = "Warming Level"
+        Only valid for approach = "Warming Level" and data_type = "Stations"
     warming_level_window: int in range (5,25), optional
         Years around Global Warming Level (+/-) \n (e.g. 15 means a 30yr window)
-        Only valid for approach = "Warming Level"
+        Only valid for approach = "Warming Level" and data_type = "Stations"
     warming_level_months: list of int, optional
         Months of year for which to perform warming level computation
         Default to all months in a year: [1,2,3,4,5,6,7,8,9,10,11,12]
         For example, you may want to set warming_level_months=[12,1,2] to perform the analysis for the winter season.
-        Only valid for approach = "Warming Level"
+        Only valid for approach = "Warming Level" and data_type = "Stations"
 
     Returns
     -------
@@ -1880,6 +1900,70 @@ def get_data(
     Errors aren't raised by the function. Rather, an appropriate informative message is printed, and the function returns None. This is due to the fact that the AE Jupyter Hub raises a strange Pieces Mismatch Error for some bad inputs; instead, that error is ignored and a more informative error message is printed instead.
 
     """
+
+    def _check_valid_input_station(stations, station_options_all):
+        """Check that the user input a valid value for station
+        If invalid input, the function will "guess" a close-ish station using difflib
+        See _get_closest_option function for more info
+        If invalid input and no guesses found, the function will print an informative error message and raise a ValueError
+
+        Parameters
+        ----------
+        stations: list of str
+        station_options_all: list of string
+            All the possible station options
+            Can be retrieved from DataParameters()._stations_gdf.station.values
+
+        Returns
+        -------
+        stations: list of str
+
+        """
+        station_options_all = sorted(
+            station_options_all
+        )  # sorted() puts the list in alphabetical order
+
+        # Keep track of if error was raised and message was printed to user
+        # If more than one station prints errors to the console, print a space between each station
+        printed_warning = False
+
+        for i in range(len(stations)):  # Go through all the stations
+
+            station_i = stations[i]
+
+            if station_i not in station_options_all:
+                if printed_warning == True:
+                    print(
+                        "\n", end=""
+                    )  # Add a space between stations for better readability
+
+                # If the station isn't a valid option...
+                print("Input station='" + station_i + "' is not a valid option.")
+                closest_options = _get_closest_options(
+                    station_i, station_options_all
+                )  # See if theres any similar options
+
+                # Sad! No closest options found. Just set the key to all valid options
+                if closest_options is None:
+                    print("Valid options: \n- ", end="")
+                    print("\n- ".join(station_options_all))
+                    raise ValueError("Bad input")
+
+                # Just one option in the list
+                elif len(closest_options) == 1:
+                    print("Closest option: '" + closest_options[0] + "'")
+
+                elif len(closest_options) > 1:
+                    print("Closest options: \n- " + "\n- ".join(closest_options))
+
+                print("Outputting data for station='" + closest_options[0] + "'")
+                stations[i] = closest_options[
+                    0
+                ]  # Replace that value in the list with the best option :)
+
+                printed_warning = True
+
+        return stations
 
     # Internal functions
     def _error_handling_warming_level_inputs(wl, argument_name):
@@ -1996,8 +2080,56 @@ def get_data(
     ## --------- ERROR HANDLING ----------
     # Deal with bad or missing users inputs
 
+    # Station data error handling
+    if data_type == "Stations":
+
+        # dictionary with { argument name : [valid option, user input]}
+        d = {
+            "downscaling_method": ["Dynamical", downscaling_method],
+            "timescale": ["hourly", timescale],
+            "variable": ["Air Temperature at 2m", variable],
+            "scenario": [
+                [None, ["Historical Climate"], "Historical Climate"],
+                scenario,
+            ],  # Either input is valid for scenario since it's not a required function argument, None is a valid input
+        }
+        # Go through the users inputs
+        # See if they match the required value for that argument
+        # If not, print a warning to the user.
+        for key, vals in zip(d.keys(), d.values()):
+            if key != "scenario":
+                if vals[0] != vals[1]:
+                    print(
+                        "Weather station data can only be retrieved for {0}={1} \nYour input: {2} \nRetrieving data for {0}={1}".format(
+                            key, vals[0], vals[1]
+                        )
+                    )
+            if key == "scenario":
+                if vals[1] not in vals[0]:
+                    print(
+                        "Weather station data can only be retrieved for {0}={1} \nYour input: {2} \nRetrieving data for {0}={1}".format(
+                            key, "Historical Climate", vals[1]
+                        )
+                    )
+
+        scenario = ["Historical Climate"]
+        downscaling_method = "Dynamical"
+        timescale = "hourly"
+        variable = "Air Temperature at 2m"
+
+        if stations is None:
+            # Print a warning if the user wants to retrieve station data but they don't input a value for station
+            # The function will return all the stations by default
+            print(
+                "WARNING: You haven't set a particular station/s to retrieve data for; the function will default to retrieving all available stations in the domain"
+            )
+        if (stations is not None) and (type(stations) == str):
+            # Catch easy user mistake without raising an error: Inputting a string instead of a list of list
+            # I imagine this could happen if you just wanted to retrieve data for a single station
+            stations = [stations]
+
     # If lat/lon input, change cached_area and area_subset
-    if latitude is not None and longitude is not None:
+    if (latitude is not None) and (longitude is not None):
         area_subset = "lat/lon"
         cached_area = ["coordinate selection"]
 
@@ -2070,7 +2202,7 @@ def get_data(
     )
 
     if check_input_df is None:
-
+        # Does this print an informative error message? I think so but I'm not sure.
         return None
 
     # Merge with variable dataframe to get all the info about the data in one place
@@ -2107,6 +2239,7 @@ def get_data(
         "timescale": cat_dict["timescale"][0],
         "downscaling_method": cat_dict["downscaling_method"][0],
         "resolution": cat_dict["resolution"][0],
+        "data_type": data_type,
         "scenario": cat_dict["scenario"],
         "area_average": area_average,
         "area_subset": area_subset,
@@ -2119,6 +2252,7 @@ def get_data(
         "time_slice": time_slice,
         "latitude": latitude,
         "longitude": longitude,
+        "stations": stations,
     }
 
     scenario_ssp, scenario_historical = _get_scenario_ssp_scenario_historical(
@@ -2146,11 +2280,22 @@ def get_data(
         units if units is not None else var_df_query["unit"].item()
     )  # Set units if user doesn't set them manually
 
-    ## ------ CREATE SELECTIONS OBJECT AND SET EACH ATTRIBUTE -------
+    ## ------ CREATE SELECTIONS OBJECT --------
     selections = DataParameters()
 
+    # Error handling for stations
+    # If the user input a value for the station argument, check that it exists
+    # If it doesn't exist, see if you can find something close... if not, throw an error
+    # Need to do the error handling here since it requires the selections object
+    if data_type == "Stations" and stations is not None:
+        stations = _check_valid_input_station(
+            stations, selections._stations_gdf.station.values
+        )
+
+    ## ------- SET EACH ATTRIBUTE -------
+
     try:
-        selections.data_type = "Gridded"  # Haven't added option to get station data yet
+        selections.data_type = selections_dict["data_type"]
         selections.approach = selections_dict["approach"]
         selections.scenario_ssp = selections_dict["scenario_ssp"]
         selections.scenario_historical = selections_dict["scenario_historical"]
@@ -2178,6 +2323,8 @@ def get_data(
             selections.latitude = selections_dict["latitude"]
         if selections_dict["longitude"] is not None:
             selections.longitude = selections_dict["longitude"]
+        if selections_dict["stations"] is not None:
+            selections.stations = selections_dict["stations"]
     except ValueError as error_message:
         # The error message is really long
         # And sometimes has a confusing Attribute Error: Pieces mismatch that is hard to interpret

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -174,7 +174,7 @@ def area_subset_geometry(selections):
         area_subset: str
         cached_area: str
         """
-        if selections.data_type == "Station":
+        if selections.data_type == "Stations":
             area_subset = "none"
             cached_area = "entire domain"
         else:
@@ -1191,8 +1191,8 @@ def read_catalog_from_select(selections):
             raise ValueError("Please select as least one dataset.")
 
     # Raise error if station data selected, but no station is selected
-    if (selections.data_type == "Station") and (
-        selections.station in [[], ["No stations available at this location"]]
+    if (selections.data_type == "Stations") and (
+        selections.stations in [[], ["No stations available at this location"]]
     ):
         raise ValueError(
             "Please select at least one weather station, or retrieve gridded data."
@@ -1200,7 +1200,7 @@ def read_catalog_from_select(selections):
 
     # For station data, need to expand time slice to ensure the historical period is included
     # At the end, the data will be cut back down to the user's original selection
-    if selections.data_type == "Station":
+    if selections.data_type == "Stations":
         original_time_slice = selections.time_slice  # Preserve original user selections
         original_scenario_historical = selections.scenario_historical.copy()
         if "Historical Climate" not in selections.scenario_historical:
@@ -1275,7 +1275,7 @@ def read_catalog_from_select(selections):
     else:
         da = _get_data_one_var(selections)
 
-    if selections.data_type == "Station":
+    if selections.data_type == "Stations":
         # Bias-correct the station data
         da = _station_apply(selections, da, original_time_slice)
 
@@ -1397,7 +1397,7 @@ def _station_apply(selections, da, original_time_slice):
     """
     # Grab zarr data
     station_subset = selections._stations_gdf.loc[
-        selections._stations_gdf["station"].isin(selections.station)
+        selections._stations_gdf["station"].isin(selections.stations)
     ]
     filepaths = [
         "s3://cadcat/hadisd/HadISD_{}.zarr".format(s_id)

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -112,32 +112,9 @@ def get_block_maxima(
 
         # select the max (min) in each group
         if extremes_type == "max":
-            # note: fillna is used to replace nans in timeseries with 0s in precipitation ONLY
-            # TODO: evaluate nan in other variables, and more programmatic fix
-            if da_series.name == "Precipitation (total)":
-                da_series = (
-                    da_series.resample(time=f"{group_len}D", label="left")
-                    .max()
-                    .fillna(value=0)
-                )  # fill value of 0 will always be precip min, "safe" for max calculation if nan present
-            else:
-                da_series = da_series.resample(time=f"{group_len}D", label="left").max()
+            da_series = da_series.resample(time=f"{group_len}D", label="left").max()
         elif extremes_type == "min":
-            if da_series.name == "Precipitation (total)":
-                # "fix" in min is to set missing value to series max
-                da_series_fillmax = (
-                    da_series.resample(time=f"{group_len}D", label="left")
-                    .max()
-                    .fillna(value=0)
-                    .values.max()
-                )
-                da_series = (
-                    da_series.resample(time=f"{group_len}D", label="left")
-                    .min()
-                    .fillna(value=da_series_fillmax)
-                )  # fill value set to precip max, "patch" for min calculation if nan present
-            else:
-                da_series = da_series.resample(time=f"{group_len}D", label="left").min()
+            da_series = da_series.resample(time=f"{group_len}D", label="left").min()
 
     if grouped_duration != None:
         if groupby == None:
@@ -198,6 +175,25 @@ def get_block_maxima(
             "timeseries_type": f"block {extremes_type} series",
         }
     )
+
+    # Checking for null values within the blocks. This primarily occurs when values are filtered out before this function.
+    # A good example of this is when trying to find 1-in-X events with precipitation. Because we filter out small noise of precip events,
+    # (i.e. 10e-10), this results in a DataArray being passed into this function that has many fewer observed counts than the actual retrieve
+    # climate data has. In some cases, there can even be years where no precipitation occurs. In these cases, we want to make sure to drop those
+    # time blocks from the returned blocks below, hence dropping NaN values along the time dimension. This way, they do not break other functions
+    # that rely on `get_block_maxima`, like `get_ks_stat` or `get_return_value`
+    if bms.isnull().sum() > 0:
+
+        # This checks if ALL of the values from `bms` are null, or if there are 0 events that occur (i.e. no precipitation counts within the DataArray).
+        if bms.isnull().sum().item() == bms.size:
+            raise ValueError(
+                "ERROR: The given `da_series` does not include any recorded values for this variable, and we cannot create block maximums off of an empty DataArray."
+            )
+        else:
+            print(
+                f"Dropping {bms.isnull().sum()} block maxima NaNs for {bms.name}. Please guidance for more information. "
+            )
+            bms = bms.dropna(dim="time")
 
     return bms
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -196,16 +196,6 @@ def _metric_agg(
                 )["return_value"]
                 return_vals.append(return_values)
 
-                # Scoping break points in return value calculation
-                # "Fix" for precipitation is in threshold_tools
-                # TODO: Assess presence of nans within data (and other variables) and develop programmatic fix
-                if return_values.isnull():
-                    print(
-                        'WARNING: Return value is NaN, indicating non-finite value returned by threshold tools AMS. Setting value to "0", which may not reflect an accurate distribution fit. Please notify AE team for assistance.'
-                    )
-                    return_values = 0.0
-                    continue
-
                 # Determining goodness-of-fit for the given distribution
                 d_statistic, p_value = [
                     float(v)

--- a/climakitae/tools/batch.py
+++ b/climakitae/tools/batch.py
@@ -53,10 +53,3 @@ def batch_select(approach, selections, points, load_data=False, progress_bar=Tru
         cells_of_interest = load(cells_of_interest, progress_bar=progress_bar)
 
     return cells_of_interest
-
-
-def batch_analysis(sims, metric):
-    """
-    Runs an analysis against a loaded set of simulations.
-    """
-    return metric(sims)

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -1,5 +1,3 @@
-"""Miscellaneous utility functions."""
-
 import os
 import numpy as np
 import datetime
@@ -611,8 +609,8 @@ def convert_to_local_time(data, selections):  # , lat, lon) -> xr.Dataset:
         total_data = data
 
     # 3. Find the data's centerpoint through selections
-    if selections.data_type == "Station":
-        station_name = selections.station
+    if selections.data_type == "Stations":
+        station_name = selections.stations
 
         # Getting lat/lon of a specific station
         stations_df = read_csv_file(stations_csv_path)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ project = "Climakitae"
 copyright = "2024, Cal-Adapt Analytics Engine"
 author = "Cal-Adapt Analytics Engine Team"
 # The full version, including alpha/beta/rc tags
-release = "0.1.0"
+release = "1.1.0"
 
 # -- General configuration ---------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be

--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -1,5 +1,4 @@
-"""Test the get_data() function 
-"""
+"""Test the get_data() function"""
 
 import pytest
 import io
@@ -159,14 +158,24 @@ class TestAppropriateStringErrorReturnedIfBadInputGetData:
 
     def test_error_raised_for_reallllyyyy_bad_input_station_data(self):
         """If the function can't even make a reasonable guess as to the user's guess, it should throw a ValueError"""
-        with pytest.raises(ValueError):
-            ds = get_data(
-                variable="Air Temperature at 2m",
-                resolution="9 km",
-                timescale="hourly",
-                data_type="Station",
-                station="the US international space station",
-            )
+        # Error message we expect to be printed by the function
+        expected_print_message = "ERROR: Station not in parameter data_type's list of possible objects, valid options include [Gridded, Stations] \nReturning None\n"
+
+        # NOTE: function PRINTS this message-- it does not return it as an error
+        # Because of this, we have to use sys to capture the print message
+        capture = io.StringIO()
+        save, sys.stdout = sys.stdout, capture
+        get_data(
+            variable="Air Temperature at 2m",
+            resolution="9 km",
+            timescale="hourly",
+            data_type="Station",
+            stations="the US international space station",  # Not a good weather station input... silly user!
+        )
+
+        sys.stdout = save
+
+        assert capture.getvalue() == expected_print_message
 
     def test_error_raised_string_input_warming_level(self):
         """Warming level should be a float input! Make sure the function prints the appropriate error message"""

--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -7,6 +7,45 @@ import sys
 from climakitae.core.data_interface import get_data
 
 
+class TestStationDataRetrievalGetData:
+    """Test that the get_data function retrieves station data without error."""
+
+    def test_sandiego_station(self):
+        """Test that station data for a single station can be retrieved"""
+        try:
+            ds = get_data(
+                variable="Air Temperature at 2m",  # required argument
+                resolution="9 km",  # required argument. Options: "9 km" or "3 km"
+                timescale="hourly",  # required argument
+                data_type="Stations",  # required argument
+                stations="San Diego Lindbergh Field (KSAN)",  # optional argument. If no input, all weather stations are retrieved
+            )
+        except:
+            pytest.fail(
+                "Station data for San Diego Lindbergh Field using a 9km resolution could not be retrieved"
+            )
+
+    def test_multiple_weather_stations(self):
+        """Test retrieveing more than one station and with more complex function arguments"""
+        try:
+            get_data(
+                variable="Air Temperature at 2m",
+                resolution="3 km",
+                timescale="hourly",
+                data_type="Stations",
+                stations=[
+                    "San Francisco International Airport (KSFO)",
+                    "Oakland Metro International Airport (KOAK)",
+                ],
+                units="degF",
+                time_slice=(2000, 2005),
+            )
+        except:
+            pytest.fail(
+                "Station data from 2000-2005 for three Bay Area weather stations using a 3km resolution and a unit conversion to degF could not be retrieved"
+            )
+
+
 class TestDerivedVariablesGetData:
     """Test that derived variables/indices can be retrieved
     Some of the use cases below used to raise an error and have since been fixed.
@@ -76,6 +115,58 @@ class TestDerivedVariablesGetData:
 
 class TestAppropriateStringErrorReturnedIfBadInputGetData:
     """Test that an appropriate error message is printed to the user describing the issue and how to resolve it."""
+
+    def test_station_data_bad_variable_input(self):
+        """Test that the function raises the appropriate error message if you input a variable that is not Air Temperature at 2m"""
+
+        # Error message we expect to be printed by the function
+        expected_print_message = "Weather station data can only be retrieved for variable=Air Temperature at 2m \nYour input: Peanut Butter and Jellyfishes in the Sky \nRetrieving data for variable=Air Temperature at 2m\n"
+
+        # NOTE: function PRINTS this message-- it does not return it as an error
+        # Because of this, we have to use sys to capture the print message
+        capture = io.StringIO()
+        save, sys.stdout = sys.stdout, capture
+        ds = get_data(
+            variable="Peanut Butter and Jellyfishes in the Sky",
+            resolution="9 km",
+            timescale="hourly",
+            data_type="Stations",
+            stations="San Francisco International Airport (KSFO)",
+        )
+        sys.stdout = save
+
+        assert capture.getvalue() == expected_print_message
+
+    def test_station_data_bad_station_correct_guess(self):
+        """Test that the function can correctly 'guess' an appropriate weather station if the user inputs something that is close in name to an existing weather station in our catalog"""
+
+        expected_print_message = "Input station='San Francisco Airport' is not a valid option.\nClosest option: 'San Francisco International Airport (KSFO)'\nOutputting data for station='San Francisco International Airport (KSFO)'\n"
+
+        # NOTE: function PRINTS this message-- it does not return it as an error
+        # Because of this, we have to use sys to capture the print message
+        capture = io.StringIO()
+        save, sys.stdout = sys.stdout, capture
+        ds = get_data(
+            variable="Air Temperature at 2m",
+            resolution="9 km",
+            timescale="hourly",
+            data_type="Stations",
+            stations="San Francisco Airport",  # not the name of the station, but its close so the function should be able to guess
+        )
+        sys.stdout = save
+
+        assert capture.getvalue() == expected_print_message
+
+    def test_error_raised_for_reallllyyyy_bad_input_station_data(self):
+        """If the function can't even make a reasonable guess as to the user's guess, it should throw a ValueError"""
+        with pytest.raises(ValueError):
+            ds = get_data(
+                variable="Air Temperature at 2m",
+                resolution="9 km",
+                timescale="hourly",
+                data_type="Station",
+                station="the US international space station",
+            )
 
     def test_error_raised_string_input_warming_level(self):
         """Warming level should be a float input! Make sure the function prints the appropriate error message"""


### PR DESCRIPTION
## Summary of changes and related issue
Added the ability to retrieve station data using `get_data()` function. Also added the ability to see weather station options using `get_subsetting_options()`. 

## Relevant motivation and context
These functions were unfinished without station data. Plus, Victoria needs this functionality for some code she’s writing for an IOU. 

## How to test 
Run the notebook `climakitae_direct_data_download.ipynb` in the branch `get-station-data` in `cae-notebooks`. At the bottom of that notebook, there’s some code related to how to use the new functionality from this branch. Try retrieving some different stations, resolutions, etc. Make sure the error messages make sense when you put a bad input, and that the data that is retrieved matches what you input in the function arguments. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
