### PR TITLE
Making arid regions `get_block_maxima` functionality generalized across variables

### DIFF
--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -183,8 +183,15 @@ def get_block_maxima(
     # time blocks from the returned blocks below, hence dropping NaN values along the time dimension. This way, they do not break other functions
     # that rely on `get_block_maxima`, like `get_ks_stat` or `get_return_value`
     if bms.isnull().sum() > 0:
-        print(f"Dropping null counts for blocks for {bms.name}")
-        bms = bms.dropna(dim="time")
+
+        # This checks if ALL of the values from `bms` are null, or if there are 0 events that occur (i.e. no precipitation counts within the DataArray).
+        if bms.isnull().sum().item() == bms.size:
+            raise ValueError(
+                "ERROR: The given `da_series` does not include any recorded values for this variable, and we cannot create block maximums off of an empty DataArray."
+            )
+        else:
+            print(f"Dropping null counts for blocks for {bms.name}")
+            bms = bms.dropna(dim="time")
 
     return bms
 

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -190,7 +190,7 @@ def get_block_maxima(
                 "ERROR: The given `da_series` does not include any recorded values for this variable, and we cannot create block maximums off of an empty DataArray."
             )
         else:
-            print(f"Dropping {bms.isnull().sum()} block maxima NaNs for {bms.name}")
+            print(f"Dropping {bms.isnull().sum()} block maxima NaNs for {bms.name}. Please guidance for more information. ")
             bms = bms.dropna(dim="time")
 
     return bms

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -190,7 +190,9 @@ def get_block_maxima(
                 "ERROR: The given `da_series` does not include any recorded values for this variable, and we cannot create block maximums off of an empty DataArray."
             )
         else:
-            print(f"Dropping {bms.isnull().sum()} block maxima NaNs for {bms.name}. Please guidance for more information. ")
+            print(
+                f"Dropping {bms.isnull().sum()} block maxima NaNs for {bms.name}. Please guidance for more information. "
+            )
             bms = bms.dropna(dim="time")
 
     return bms

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -190,7 +190,7 @@ def get_block_maxima(
                 "ERROR: The given `da_series` does not include any recorded values for this variable, and we cannot create block maximums off of an empty DataArray."
             )
         else:
-            print(f"Dropping null counts for blocks for {bms.name}")
+            print(f"Dropping {bms.isnull().sum()} block maxima NaNs for {bms.name}")
             bms = bms.dropna(dim="time")
 
     return bms

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -196,16 +196,6 @@ def _metric_agg(
                 )["return_value"]
                 return_vals.append(return_values)
 
-                # Scoping break points in return value calculation
-                # "Fix" for precipitation is in threshold_tools
-                # TODO: Assess presence of nans within data (and other variables) and develop programmatic fix
-                if return_values.isnull():
-                    print(
-                        'WARNING: Return value is NaN, indicating non-finite value returned by threshold tools AMS. Setting value to "0", which may not reflect an accurate distribution fit. Please notify AE team for assistance.'
-                    )
-                    return_values = 0.0
-                    continue
-
                 # Determining goodness-of-fit for the given distribution
                 d_statistic, p_value = [
                     float(v)


### PR DESCRIPTION
## Summary of changes and related issue
**Summary:** Changing `get_block_maxima` behavior to drop NaNs for any type of variable passed in. Tested against two locations for precipitation. See below for other ways to test this PR.

**Context:**

_Why did these NaNs appear in the first place?_ These values appear _particularly_ for the precipitation 1-in-X calculations used in the `cava_data` function because of the following line: https://github.com/cal-adapt/climakitae/blob/14cebc253cf4ab70d2f91cc4435e63037714a56d/climakitae/explore/vulnerability.py#L173  

where precipitation values are excluded from the DataArray if they are below 10e-10. This is done because we want to remove these little to no precipitation values from 1-in-X calculations, as we only want to count precipitation events where meaningful precipitation actually occurs. This results in a subsetted DataArray with dropped times to be passed into `get_block_maxima`, where `get_block_maxima` then fills in the missing times with NaNs to account for them being dropped. This later on results in an error being thrown in `cava_data` because for some regions, _there are NaNs for the entire year_ (no rain for the whole year). This then causes `get_return_value` and `get_ks_stat` to misbehave because they have NaN values passed into their arguments.

So, this behavior is addressed by dropping any potential NaNs at the end of the `get_block_maxima` function, so that these NaNs don't bleed into other functions down the line.

**Note:** Had we not dropped precipitation counts below 10e-10, none of this would have happened, as the entire precipitation DataArray would just get passed into `get_block_maxima` and <10e-10 yearly max precipitation counts would just exist in the block maximas. _However,_ that would not be the intended behavior of `cava_data`, since we want to only measure precipitation events where precipitation actually occurs. So, this PR fix is needed.

This also proves that this error has only existed for precipitation because we want to filter out 0 (and < 10e-10) counts from being counted as precipitation events. Now, if we want to do a similar filtering for other variables, that should be fine in the future, since this PR handles dropping NaNs from the block maximas regardless of which variable is passed in.

## Relevant motivation and context
We wanted to change this because we wanted to make this solution generalizable across variables.

## How to test 
Reviewers should test these changes by testing this branch in the `vulnerability_assessment.ipynb` notebook, and replacing the following cell:

```
data = cava_data(
    ## Set-up
    example_locs.iloc[:1], # select a single location
    downscaling_method="Dynamical",  # WRF data 
    approach="Time",
    time_start_year=2070,
    time_end_year=2090,
    wrf_bias_adjust=True, # return bias-adjusted WRF models
    
    ## 1-in-X event specific arguments
    variable="Precipitation (total)",
    metric_calc="max", # daily maximum precipitation
    one_in_x=100, # One-in-X
    distr="gev", # change distribution
    event_duration = (3, 'hour'), # change event duration
    units="inches", # change units
    
    ## Export
    export_method="both",
    file_format="NetCDF",
)
```

with 

```
import pandas as pd
examples = pd.DataFrame(
    data=((34.765625, -115.390625), (33.265625, -114.796875), (33.265625, -114.734375), (33.234375, -115.109375)),
    columns=['lat', 'lon'],
)
data = cava_data(
    ## Set-up
    examples, # select a single location
    downscaling_method="Statistical",  # LOCA data
    approach="Warming Level",
    # time_start_year=2070,
    # time_end_year=2090,
    warming_level=2.0,
    wrf_bias_adjust=True, # return bias-adjusted WRF models
    
    ## 1-in-X event specific arguments
    variable="Precipitation (total)",
    metric_calc="max", # daily maximum precipitation
    one_in_x=100, # One-in-X
    distr="gev", # change distribution
    event_duration = (1, 'day'), # change event duration
    units="inches", # change units
    
    ## Export
    export_method="both",
    file_format="NetCDF",
)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
 