### PR TITLE
Change path to wind angle zarrs

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -739,7 +739,7 @@ def _get_Uearth(selections):
     # This file contains sinalpha and cosalpha for the WRF grid
     gridlabel = resolution_to_gridlabel(selections.resolution)
     wrf_angles_ds = xr.open_zarr(
-        "s3://cadcat-tmp/wrf_angles_{}.zarr/".format(gridlabel)
+        "s3://cadcat/tmp/era/wrf/wrf_angles_{}.zarr/".format(gridlabel)
     )
     wrf_angles_ds = _spatial_subset(
         wrf_angles_ds, selections


### PR DESCRIPTION
## Summary of changes and related issue
Change path to wind angle zarrs in AWS

## Relevant motivation and context
cadcat-tmp bucket auto-deletes after a week. I moved the zarrs to a tmp bucket that does **not** auto delete files. 

The notebook used to generate and upload these zarrs can be found in cae-archives here: https://github.com/cal-adapt/cae-archives/blob/master/data_processing/wrf_wind_vectors.ipynb

## How to test 
Try retrieving hourly wind data 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
