### PR TITLE
Update station test 

### DIFF
--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -159,7 +159,11 @@ class TestAppropriateStringErrorReturnedIfBadInputGetData:
     def test_error_raised_for_reallllyyyy_bad_input_station_data(self):
         """If the function can't even make a reasonable guess as to the user's guess, it should throw a ValueError"""
         # Error message we expect to be printed by the function
-        expected_print_message = "ERROR: Selector parameter 'DataParameters.data_type' does not accept 'Station'; valid options include: '[Gridded, Stations]' \nReturning None\n"
+        # This is just the first line of the print message
+        # Cut after new line because the actual message is really long. It lists all the available stations.
+        expected_print_message = (
+            "Input station='the US international space station' is not a valid option."
+        )
 
         # NOTE: function PRINTS this message-- it does not return it as an error
         # Because of this, we have to use sys to capture the print message
@@ -169,13 +173,13 @@ class TestAppropriateStringErrorReturnedIfBadInputGetData:
             variable="Air Temperature at 2m",
             resolution="9 km",
             timescale="hourly",
-            data_type="Station",
+            data_type="Stations",
             stations="the US international space station",  # Not a good weather station input... silly user!
         )
 
         sys.stdout = save
 
-        assert capture.getvalue() == expected_print_message
+        assert capture.getvalue().split("\n")[0] == expected_print_message
 
     def test_error_raised_string_input_warming_level(self):
         """Warming level should be a float input! Make sure the function prints the appropriate error message"""

--- a/tests/data_interface/test_get_data.py
+++ b/tests/data_interface/test_get_data.py
@@ -169,13 +169,18 @@ class TestAppropriateStringErrorReturnedIfBadInputGetData:
         # Because of this, we have to use sys to capture the print message
         capture = io.StringIO()
         save, sys.stdout = sys.stdout, capture
-        ds = get_data(
-            variable="Air Temperature at 2m",
-            resolution="9 km",
-            timescale="hourly",
-            data_type="Stations",
-            stations="the US international space station",  # Not a good weather station input... silly user!
-        )
+        try:
+            ds = get_data(
+                variable="Air Temperature at 2m",
+                resolution="9 km",
+                timescale="hourly",
+                data_type="Stations",
+                stations="the US international space station",  # Not a good weather station input... silly user!
+            )
+        except Exception:
+            # This function raises a Value Error AND prints a message (before raising the error)
+            # Just ignore the error
+            pass
 
         sys.stdout = save
 


### PR DESCRIPTION
## Summary of changes and related issue
One of the tests for retrieving station data doesn’t make sense given the original intention I had for the test. The test should test: Does the function return a Value Error Bad Input if you give it a wonky station string (i.e. "the international space station”)? What it currently tests in main: Does the function raise an error if you put "Station" as the `data_type` instead of "Stations"? (not my intended behavior of the test) 

## Relevant motivation and context
Just noticed this. My bad. 

## How to test 
The test shall test itself (thanks GitHub CI!) 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
