### PR TITLE
Pypi requires README context type to be specified

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,13 @@ from setuptools import setup
 
 # read the contents of your README file
 from pathlib import Path
+
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 setup(
-    name='climakitae',
+    name="climakitae",
     # other arguments omitted
     long_description=long_description,
-    long_description_content_type='text/markdown'
+    long_description_content_type="text/markdown",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-setup()
+# read the contents of your README file
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
+setup(
+    name='climakitae',
+    # other arguments omitted
+    long_description=long_description,
+    long_description_content_type='text/markdown'
+)


### PR DESCRIPTION
## Summary of changes and related issue

Inform build process of the context type of README file for Pypi. When attempting to build got this error:

`The description failed to render in the default format of reStructuredText.`

Pypi now requires that `content-type` be set on the README uploaded:

https://github.com/pypi/warehouse/issues/5890

## Relevant motivation and context

Fixing this in future releases will allow for publishing on Pypi

## How to test 
[How should reviewers test the changes?] 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
