### PR TITLE
Change pandas date_range DateOffset to future proof

### DIFF
--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -744,7 +744,7 @@ def add_dummy_time_to_wl(wl_da):
     - The dummy time series starts from "2000-01-01".
     """
     # Creating map from frequency name to freq var needed for pandas date range
-    name_to_freq = {"hourly": "H", "daily": "D", "monthly": "M"}
+    name_to_freq = {"hourly": "h", "daily": "D", "monthly": "ME"}
 
     # Creating dummy timestamps
     timestamps = pd.date_range(


### PR DESCRIPTION
## Summary of changes and related issue

Change the `pandas` `DateOffset` attributes in `add_dummy_time_to_wl` to match the current `pandas` shorthand. This will get rid of the depreciation warning found in #507 

## Relevant motivation and context

Change before `pandas` deprecates `DateOffset` objects we have.

## How to test 

Run code found in #507 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ x ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
