### PR TITLE
Export: Add Zarr local/s3 support, Remove NetCDF s3 support

### DIFF
--- a/climakitae/__init__.py
+++ b/climakitae/__init__.py
@@ -1,5 +1,5 @@
 from climakitae.core.data_load import load
-from climakitae.core.data_export import export
+from climakitae.core.data_export import export, remove_zarr
 
 try:
     from importlib.metadata import version as _version
@@ -18,6 +18,7 @@ __all__ = (
     # Methods
     "load",
     "export",
+    "remove_zarr",
     # Constants
     "__version__",
 )

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -200,6 +200,16 @@ def _compression_encoding(data):
     return compdict
 
 
+def _convert_da_to_ds(data):
+    if isinstance(data, xr.core.dataarray.DataArray):
+        if not data.name:
+            # name it in order to call to_dataset on it
+            data.name = "data"
+        return data.to_dataset()
+    elif isinstance(data, xr.core.dataset.DataSet):
+        return data
+
+
 def _export_to_netcdf(data, save_name):
     """
     Export user-selected data to NetCDF format.
@@ -223,12 +233,7 @@ def _export_to_netcdf(data, save_name):
     print("Exporting specified data to NetCDF...")
 
     # Convert xr.DataArray to xr.Dataset so that compression can be utilized
-    _data = data
-    if isinstance(_data, xr.core.dataarray.DataArray):
-        if not _data.name:
-            # name it in order to call to_dataset on it
-            _data.name = "data"
-        _data = _data.to_dataset()
+    _data = _convert_da_to_ds(data)
 
     est_file_size = _estimate_file_size(_data, "NetCDF")
     disk_space = shutil.disk_usage(os.path.expanduser("~"))[2] / bytes_per_gigabyte
@@ -286,12 +291,7 @@ def _export_to_zarr(data, save_name, mode):
     print("Exporting specified data to Zarr...")
 
     # Convert xr.DataArray to xr.Dataset so that compression can be utilized
-    _data = data
-    if isinstance(_data, xr.core.dataarray.DataArray):
-        if not _data.name:
-            # name it in order to call to_dataset on it
-            _data.name = "data"
-        _data = _data.to_dataset()
+    _data = _convert_da_to_ds(data)
 
     est_file_size = _estimate_file_size(_data, "Zarr")
     disk_space = shutil.disk_usage(os.path.expanduser("~"))[2] / bytes_per_gigabyte

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -297,9 +297,8 @@ def _export_to_netcdf(data, save_name, mode):
                     "or specify a new file name here."
                 )
             )
-        #encoding = _fillvalue_encoding(_data) | _compression_encoding(_data)
-        encoding = _compression_encoding(_data)
-        _data.to_netcdf(path, encoding=encoding)
+        encoding = _fillvalue_encoding(_data) | _compression_encoding(_data)
+        _data.to_netcdf(path, format="NETCDF4" engine="netcdf4", encoding=encoding)
         print(
             (
                 "Saved! You can find your file in the panel to the left"
@@ -312,8 +311,8 @@ def _export_to_netcdf(data, save_name, mode):
 
         with fsspec.open(path, "wb") as fp:
             print("Saving file to S3 scratch bucket without compression...")
-            #encoding = _fillvalue_encoding(_data)
-            _data.to_netcdf(fp)
+            encoding = _fillvalue_encoding(_data)
+            _data.to_netcdf(fp, format="NETCDF4", engine="netcdf4", encoding=encoding)
 
             download_url = _create_presigned_url(
                 bucket_name=export_s3_bucket,

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -27,7 +27,29 @@ xr.set_options(keep_attrs=True)
 bytes_per_gigabyte = 1024 * 1024 * 1024
 
 
-def remove_zarr(dir_path):
+def remove_zarr(filename):
+    """Remove Zarr directory structure helper function. As Zarr format is a directory
+    tree it is not easily removed using JupyterHUB GUI. This function simply deletes
+    an entire directory tree.
+
+    Parameters
+    ----------
+    filename : str
+        Output Zarr file name (without file extension, i.e. "my_filename" instead
+        of "my_filename.zarr").
+    """
+    if type(filename) is not str:
+        raise Exception(
+            (
+                "Please pass a string"
+                " (any characters surrounded by quotation marks)"
+                " for your file name."
+            )
+        )
+    filename = filename.split(".")[0]
+
+    dir_path = filename + ".zarr"
+
     try:
         shutil.rmtree(dir_path)
         print(f"Zarr dataset '{dir_path}' deleted successfully.")

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -316,7 +316,7 @@ def _export_to_zarr(data, save_name, mode):
 
     _warn_large_export(est_file_size)
 
-    _add_metadata(_data)
+    #_add_metadata(_data)
 
     _update_encoding(_data)
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -369,9 +369,9 @@ def _export_to_zarr(data, save_name):
     def _write_zarr_to_s3(display_path, path, save_name, data):
         print("Saving file to S3 scratch bucket as Zarr...")
         encoding = _fillvalue_encoding(data)
-        chunks = {k: v[0] for k, v in _data.chunks.items()}
-        _data = _data.chunk(chunks)
-        _data.to_zarr(path, encoding=encoding)
+        chunks = {k: v[0] for k, v in data.chunks.items()}
+        data = data.chunk(chunks)
+        data.to_zarr(path, encoding=encoding)
 
         print(
             (

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -298,7 +298,7 @@ def _export_to_netcdf(data, save_name, mode):
                 )
             )
         encoding = _fillvalue_encoding(_data) | _compression_encoding(_data)
-        _data.to_netcdf(path, format="NETCDF4" engine="netcdf4", encoding=encoding)
+        _data.to_netcdf(path, format="NETCDF4", engine="netcdf4", encoding=encoding)
         print(
             (
                 "Saved! You can find your file in the panel to the left"

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -812,6 +812,9 @@ def export(data, filename="dataexport", format="NetCDF", mode="local"):
 
     save_name = filename + extension_dict[req_format]
 
+    if (mode == "s3") and (req_format != "zarr"):
+        raise Exception('To export to AWS S3 you must use the format="Zarr" option.')
+
     # now here is where exporting actually begins
     # we will have different functions for each file type
     # to keep things clean-ish

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -206,7 +206,7 @@ def _convert_da_to_ds(data):
             # name it in order to call to_dataset on it
             data.name = "data"
         return data.to_dataset()
-    elif isinstance(data, xr.core.dataset.DataSet):
+    elif isinstance(data, xr.core.dataset.Dataset):
         return data
 
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -346,7 +346,7 @@ def _export_to_zarr(data, save_name, mode):
                 (
                     f"File {save_name} exists. "
                     "Please either delete that file from the work space "
-                    "or specify a new file name here."
+                    "or specify a new file name."
                 )
             )
         _write_zarr(path, _data)
@@ -368,9 +368,7 @@ def _export_to_zarr(data, save_name, mode):
                 raise
         else:
             # The object does exist
-            bucket = s3.Bucket(export_s3_bucket)
-            bucket.objects.filter(Prefix=prefix + "/").delete()
-            _write_zarr_to_s3(display_path, path, save_name, _data)
+            raise Exception(f"File {save_name} exists. Specify a new file name.")
     else:
         raise Exception("Correct mode not specified. Use either 'local' or 's3'.")
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -369,6 +369,8 @@ def _export_to_zarr(data, save_name):
     def _write_zarr_to_s3(display_path, path, save_name, data):
         print("Saving file to S3 scratch bucket as Zarr...")
         encoding = _fillvalue_encoding(data)
+        chunks = {k: v[0] for k, v in _data.chunks.items()}
+        _data = _data.chunk(chunks)
         _data.to_zarr(path, encoding=encoding)
 
         print(

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -27,6 +27,16 @@ xr.set_options(keep_attrs=True)
 bytes_per_gigabyte = 1024 * 1024 * 1024
 
 
+def remove_zarr(dir_path):
+    try:
+        shutil.rmtree(dir_path)
+        print(f"Zarr dataset '{dir_path}' deleted successfully.")
+    except FileNotFoundError:
+        print(f"Zarr dataset '{dir_path}' not found.")
+    except OSError as e:
+        print(f"Error deleting Zarr dataset '{dir_path}': {e}")
+
+
 def _add_metadata(data):
     ds_attrs = data.attrs
 
@@ -87,56 +97,6 @@ def _warn_large_export(file_size, file_size_threshold=5):
             + str(round(file_size, 2))
             + " GB. This might take a while!"
         )
-
-
-# def _update_attributes(data):
-#     """
-#     Update data attributes to prevent issues when exporting them to NetCDF.
-
-#     Convert list and None attributes to strings. If `time` is a coordinate of
-#     `data`, remove any of its `units` attribute. Attributes include global data
-#     attributes as well as that of coordinates and data variables.
-
-#     Parameters
-#     ----------
-#     data: xarray.Dataset
-
-#     Returns
-#     -------
-#     None
-
-#     Notes
-#     -----
-#     These attribute updates resolve errors raised when using the scipy engine
-#     to write NetCDF files to S3.
-#     """
-
-#     def _list_n_none_to_string(dic):
-#         """Convert list and None to string.
-
-#         Parameters
-#         ----------
-#         dic: dict
-
-#         Returns
-#         -------
-#         dict
-#         """
-#         for k, v in dic.items():
-#             if isinstance(v, list):
-#                 dic[k] = str(v)
-#             if v is None:
-#                 dic[k] = ""
-#         return dic
-
-#     data.attrs = _list_n_none_to_string(data.attrs)
-#     for coord in data.coords:
-#         data[coord].attrs = _list_n_none_to_string(data[coord].attrs)
-#     if "time" in data.coords and "units" in data["time"].attrs:
-#         del data["time"].attrs["units"]
-
-#     for data_var in data.data_vars:
-#         data[data_var].attrs = _list_n_none_to_string(data[data_var].attrs)
 
 
 def _update_encoding(data):
@@ -316,7 +276,7 @@ def _export_to_zarr(data, save_name, mode):
 
     _warn_large_export(est_file_size)
 
-    #_add_metadata(_data)
+    _add_metadata(_data)
 
     _update_encoding(_data)
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -297,8 +297,9 @@ def _export_to_netcdf(data, save_name, mode):
                     "or specify a new file name here."
                 )
             )
-        encoding = _fillvalue_encoding(_data) | _compression_encoding(_data)
-        _data.to_netcdf(path, engine="h5netcdf", encoding=encoding)
+        #encoding = _fillvalue_encoding(_data) | _compression_encoding(_data)
+        encoding = _compression_encoding(_data)
+        _data.to_netcdf(path, encoding=encoding)
         print(
             (
                 "Saved! You can find your file in the panel to the left"
@@ -311,8 +312,8 @@ def _export_to_netcdf(data, save_name, mode):
 
         with fsspec.open(path, "wb") as fp:
             print("Saving file to S3 scratch bucket without compression...")
-            encoding = _fillvalue_encoding(_data)
-            _data.to_netcdf(fp, engine="h5netcdf", encoding=encoding)
+            #encoding = _fillvalue_encoding(_data)
+            _data.to_netcdf(fp)
 
             download_url = _create_presigned_url(
                 bucket_name=export_s3_bucket,

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -312,7 +312,7 @@ def _export_to_netcdf(data, save_name, mode):
         with fsspec.open(path, "wb") as fp:
             print("Saving file to S3 scratch bucket without compression...")
             encoding = _fillvalue_encoding(_data)
-            _data.to_netcdf(fp, format="NETCDF4", engine="netcdf4", encoding=encoding)
+            _data.to_netcdf(fp, format="NETCDF3_64BIT", engine="scipy", encoding=encoding)
 
             download_url = _create_presigned_url(
                 bucket_name=export_s3_bucket,

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -149,10 +149,13 @@ To save data as a file, use the :py:func:`climakitae.export()` method and input 
 
 We recommend NetCDF or Zarr, which suits data and outputs from the Analytics Engine well – they efficiently store large data containing multiple variables and dimensions. Metadata will be retained in these files.
 
+NetCDF or Zarr can be export locally (such as onto the JupyterHUB user partition). Optionally Zarr can be exported to an AWS S3 scratch bucket for storing very large exports.
+
 CSV can also store Analytics Engine data with any number of variables and dimensions. It works best for smaller data with fewer dimensions. The output file will be compressed to ensure efficient storage. Metadata will be preserved in a separate file.
 
 CSV stores data in tabular format. Rows will be indexed by the index coordinate(s) of the DataArray or Dataset (e.g. scenario, simulation, time). Columns will be formed by the data variable(s) and non-index coordinate(s). :: 
 
-   ck.export(data, "my_filename", "NetCDF")
-   ck.export(data, "my_filename2", "Zarr")
-   ck.export(data, "my_filename3", "CSV")
+   ck.export(data, filename="my_filename", format="NetCDF")
+   ck.export(data, filename="my_filename2", format="Zarr")
+   ck.export(data, filename="my_filename3", format="Zarr", mode="s3")
+   ck.export(data, filename="my_filename4", format="CSV")

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -145,12 +145,14 @@ To save data as a file, use the :py:func:`climakitae.export()` method and input 
 
 * data to export – an :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset` object, as output by e.g. :py:func:`selections.retrieve()`
 * output file name (without file extension)
-* file format ("NetCDF" or "CSV")
+* file format ("NetCDF", "Zarr", or "CSV")
 
-We recommend NetCDF, which suits data and outputs from the Analytics Engine well – it efficiently stores large data containing multiple variables and dimensions. Metadata will be retained in NetCDF files.
+We recommend NetCDF or Zarr, which suits data and outputs from the Analytics Engine well – they efficiently store large data containing multiple variables and dimensions. Metadata will be retained in these files.
 
-CSV can also store Analytics Engine data with any number of variables and dimensions. It works the best for smaller data with fewer dimensions. The output file will be compressed to ensure efficient storage. Metadata will be preserved in a separate file.
+CSV can also store Analytics Engine data with any number of variables and dimensions. It works best for smaller data with fewer dimensions. The output file will be compressed to ensure efficient storage. Metadata will be preserved in a separate file.
 
 CSV stores data in tabular format. Rows will be indexed by the index coordinate(s) of the DataArray or Dataset (e.g. scenario, simulation, time). Columns will be formed by the data variable(s) and non-index coordinate(s). :: 
 
    ck.export(data, "my_filename", "NetCDF")
+   ck.export(data, "my_filename2", "Zarr")
+   ck.export(data, "my_filename3", "CSV")


### PR DESCRIPTION
## Summary of changes and related issue

This PR adds Zarr export option on the HUB user partition and to s3 scratch bucket. It also removes NetCDF export to s3 as that is limited to <2GB.

It also adds `ck.remove_zarr` function to help users delete Zarr exports on the HUB (Zarr stores are a tree of directories and not easily deleted from the HUB GUI).

## Relevant motivation and context

Add Zarr support and fix broken export functions.

## How to test 

Export data to Zarr, NetCDF, CSV and reload on the HUB.

## Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
