### PR TITLE
Adding full test coverage to `warming_levels.py` in utils

### DIFF
--- a/tests/warming/test_warming.py
+++ b/tests/warming/test_warming.py
@@ -1,0 +1,47 @@
+### Test Module for `warming_levels.py`
+
+import xarray as xr
+import pytest
+from climakitae.util.utils import read_csv_file
+from climakitae.core.paths import gwl_1850_1900_file
+from climakitae.util.warming_levels import (
+    _calculate_warming_level,
+    _get_sliced_data,
+)
+
+# Load warming level times from CSV
+gwl_times = read_csv_file(gwl_1850_1900_file, index_col=[0, 1, 2])
+
+
+def test_missing_all_sims_attribute(
+    test_dataarray_wl_20_summer_season_loca_3km_daily_temp,
+):
+    """Ensure AttributeError is raised when 'all_sims' is missing in DataArray dimensions."""
+    da_wrong = test_dataarray_wl_20_summer_season_loca_3km_daily_temp.rename(
+        {"simulation": "totally_wrong"}
+    )
+    with pytest.raises(AttributeError):
+        _calculate_warming_level(da_wrong, gwl_times, 2, range(1, 13), 15)
+
+
+def test_get_sliced_data_empty_output(
+    test_dataarray_time_2030_2035_wrf_3km_hourly_temp,
+):
+    """
+    Verify that `_get_sliced_data` returns an empty DataArray when no `center_time` is found.
+
+    `WRF_FGOALS-g3_r1i1p1f1` for `SSP 3-7.0` does not reach 4.0 warming, so we will use it to see if `_get_sliced_data` will just generate an empty DataArray for it.
+        Context for this behavior in `_get_sliced_data`: an empty DataArray is generated for this simulation in `_get_sliced_data` because `_get_sliced_data`
+        is called in a groupby call, requiring all objects it is called upon to return the same shape.
+    """
+    da = test_dataarray_time_2030_2035_wrf_3km_hourly_temp
+
+    # Selecting a simulation that does not reach 4.0 warming level
+    stacked_da = da.stack(all_sims=["scenario", "simulation"])
+    one_sim = stacked_da.sel(
+        all_sims=("Historical + SSP 3-7.0", "WRF_FGOALS-g3_r1i1p1f1")
+    )
+
+    # Call function and assert empty DataArray
+    res = _get_sliced_data(one_sim, 4, gwl_times, range(1, 13), 15)
+    assert res.isnull().all()


### PR DESCRIPTION
## Summary of changes and related issue
Guided by our test coverage sheet, this PR addresses the missing lines of code that are not fully tested within `warming_levels.py`.

## Relevant motivation and context
We want to increase our test coverage.

## How to test 
You can run `pytest .` in the `climakitae` folder after checking this branch out on the hub, or you can just view the Github actions in this PR and see that the tests (including this PR's) all run successfully.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
