### PR TITLE
Pin black version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install Black with Colorama
+        run: pip install "black[colorama]==24.10.0"
+      - name: Run Black
+        run: black --check --verbose .
   build:
     name: linux-64
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary of changes and related issue
Need to pin a version of [black](https://github.com/psf/black) since the package had an update on Jan 28 of this year that is different from the older version climakitae uses. Need to check for the appropriate version of black. 

## Relevant motivation and context
Need to pass black tests-- you'll notice now that they aren't passing for any new code because. 

## How to test 
No need to test; GitHub Actions will test for us. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
