### PR TITLE
Reformat codebase for Black 25.1.0

### DIFF
--- a/climakitae/explore/amy.py
+++ b/climakitae/explore/amy.py
@@ -1,5 +1,5 @@
 """
-Calculates the Average Meterological Year (AMY) and Severe Meteorological Year (SMY) for the Cal-Adapt: Analytics Engine using a standard climatological period (1981-2010) for the historical baseline, and uses a 30-year window around when a designated warming level is exceeded for the SSP3-7.0 future scenario for 1.5°C, 2°C, and 3°C. 
+Calculates the Average Meterological Year (AMY) and Severe Meteorological Year (SMY) for the Cal-Adapt: Analytics Engine using a standard climatological period (1981-2010) for the historical baseline, and uses a 30-year window around when a designated warming level is exceeded for the SSP3-7.0 future scenario for 1.5°C, 2°C, and 3°C.
 The AMY is comparable to a typical meteorological year, but not quite the same full methodology.
 """
 

--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Util for generating warming level reference data in ../data/ ###
 
 To run, type: <<python generate_gwl_tables.py>> in the command line and wait for printed model outputs showing progress.

--- a/climakitae/util/generate_gwl_tables_unc.py
+++ b/climakitae/util/generate_gwl_tables_unc.py
@@ -1,12 +1,12 @@
-""" 
-Util for generating warming level reference data file 
+"""
+Util for generating warming level reference data file
 "gwl_1981-2010ref_EC-Earth3_ssp370.csv" in ../data
 
-The CSV file is generated for use in ../explore/uncertainty.py. It contains, 
+The CSV file is generated for use in ../explore/uncertainty.py. It contains,
 for each ensemble member of EC-Earth3, the times when five major warming levels
 are reached under SSP3-7.0.
 
-To run, type: <<python generate_gwl_tables_unc.py>> in the command line and wait 
+To run, type: <<python generate_gwl_tables_unc.py>> in the command line and wait
 for printed model outputs showing progress.
 """
 

--- a/climakitae/util/generate_gwl_timing_table.py
+++ b/climakitae/util/generate_gwl_timing_table.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Util for generating estimated crossing years for global warming levels
 
 Outputs a csv file for reference in ../data/ ###

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared data and paths between multiple unit tests. """
+"""Shared data and paths between multiple unit tests."""
 
 import pytest
 import os

--- a/tests/create_test_dataarrays_single_cell.py
+++ b/tests/create_test_dataarrays_single_cell.py
@@ -5,8 +5,8 @@ Create test datasets for a single cell of hourly data, for all variations betwee
     2. Time
     3. LOCA
     4. WRF
-Notes: 
-[Nicole Keeney Dec 11, 2024]: I tried to use this script to regenerate the test files for the vulnerability unit tests, but could not get the script to reproduce the files using the appropriate strings. I needed to modify the scenario strings to remove "Business as Usual" from the string IDs. I ended up just manually altering the files. 
+Notes:
+[Nicole Keeney Dec 11, 2024]: I tried to use this script to regenerate the test files for the vulnerability unit tests, but could not get the script to reproduce the files using the appropriate strings. I needed to modify the scenario strings to remove "Business as Usual" from the string IDs. I ended up just manually altering the files.
 """
 
 import numpy as np

--- a/tests/create_test_dataset.py
+++ b/tests/create_test_dataset.py
@@ -1,6 +1,6 @@
-"""create_test_dataset.py 
+"""create_test_dataset.py
 
-This script uses functions from the data_loaders, core, and selectors modules to construct small datasets for testing. 
+This script uses functions from the data_loaders, core, and selectors modules to construct small datasets for testing.
 Depending on the number of variables you use to construct your dataset and the geographic subset you want, this script can take a while to run.
 
 """

--- a/tests/data_interface/test_variable_descriptions_csv.py
+++ b/tests/data_interface/test_variable_descriptions_csv.py
@@ -1,5 +1,4 @@
-"""Test to see that variable descriptions csv is formatted appropriately 
-"""
+"""Test to see that variable descriptions csv is formatted appropriately"""
 
 import pytest
 from climakitae.core.data_interface import DataInterface

--- a/tests/data_load/test_unit_error.py
+++ b/tests/data_load/test_unit_error.py
@@ -1,5 +1,5 @@
-"""Manually setting a bad/invalid unit in a DataParameters object should not allow you to retrieve data. 
-Test that an appropriate error is raised. 
+"""Manually setting a bad/invalid unit in a DataParameters object should not allow you to retrieve data.
+Test that an appropriate error is raised.
 """
 
 import pytest

--- a/tests/derived_variables/test_derived_variables.py
+++ b/tests/derived_variables/test_derived_variables.py
@@ -1,4 +1,4 @@
-"""This script tests that the functions used to compute derived variables perform as expected. """
+"""This script tests that the functions used to compute derived variables perform as expected."""
 
 import pytest
 import xarray as xr

--- a/tests/indices/test_indices.py
+++ b/tests/indices/test_indices.py
@@ -1,4 +1,4 @@
-"""This script tests that the functions used to derive indices perform as expected. """
+"""This script tests that the functions used to derive indices perform as expected."""
 
 import pytest
 import xarray as xr

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -1,6 +1,6 @@
 """
-This script contains tests on various Timeseries Tools options using monthly 
-data. For now, the tests only test that the various parameter combinations can 
+This script contains tests on various Timeseries Tools options using monthly
+data. For now, the tests only test that the various parameter combinations can
 run through `transform_data` without error, and that the data has been transformed
 (not equal to original values), but does not test for exact expected values.
 """

--- a/tests/unit_conversions/test_unit_conversions.py
+++ b/tests/unit_conversions/test_unit_conversions.py
@@ -1,4 +1,4 @@
-""" This script runs tests that unit conversions perform as expected """
+"""This script runs tests that unit conversions perform as expected"""
 
 import pytest
 from climakitae.util.unit_conversions import convert_units


### PR DESCRIPTION
## Summary of changes and related issue

Reformat code to adhere to Black 25.1.0 version used by lint CI workflow.

## Relevant motivation and context

Black stable version changed to 25.1.0. Very minor changes to code formatting (whitespace removal).

## How to test 
[How should reviewers test the changes?] 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
