### PR TITLE
Time-optimization changes to CAVA data function

### DIFF
--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -427,6 +427,7 @@ def get_ks_stat(bms, distr="gev", multiple_points=True):
         bms,
         input_core_dims=[["time"]],
         exclude_dims=set(("time",)),
+        vectorize=True,
         output_core_dims=[[], []],
     )
 
@@ -679,6 +680,7 @@ def _get_return_variable(
         bms,
         input_core_dims=[["time"]],
         exclude_dims=set(("time",)),
+        vectorize=True,
         output_core_dims=[[], [], []],
     )
 

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -675,8 +675,7 @@ def _get_return_variable(
             conf_int_upper_bound=conf_int_upper_bound,
             block_size=block_size,
         )
-
-        return return_variable, conf_int_lower_limit, conf_int_upper_limit
+        return np.array([return_variable]), np.array([conf_int_lower_limit]), np.array([conf_int_upper_limit])
 
     return_variable, conf_int_lower_limit, conf_int_upper_limit = xr.apply_ufunc(
         _return_variable,

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -678,7 +678,11 @@ def _get_return_variable(
             conf_int_upper_bound=conf_int_upper_bound,
             block_size=block_size,
         )
-        return np.array([return_variable]), np.array([conf_int_lower_limit]), np.array([conf_int_upper_limit])
+        return (
+            np.array([return_variable]),
+            np.array([conf_int_lower_limit]),
+            np.array([conf_int_upper_limit]),
+        )
 
     return_variable, conf_int_lower_limit, conf_int_upper_limit = xr.apply_ufunc(
         _return_variable,

--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -629,6 +629,9 @@ def _get_return_variable(
     -------
     xarray.Dataset
     """
+    # If there is only one X input, then make it a list, so that this function can properly behave on a LIST of X values for 1-in-X calculations
+    if not isinstance(arg_value, np.ndarray):
+        arg_value = np.array([arg_value])
 
     data_variables = ["return_value", "return_period", "return_prob"]
     if data_variable not in data_variables:
@@ -683,17 +686,15 @@ def _get_return_variable(
         input_core_dims=[["time"]],
         exclude_dims=set(("time",)),
         vectorize=True,
-        output_core_dims=[["arg_value"], ["arg_value"], ["arg_value"]],
+        output_core_dims=[["one_in_x"], ["one_in_x"], ["one_in_x"]],
     )
-
     return_variable = return_variable.rename(data_variable)
     new_ds = return_variable.to_dataset()
     new_ds = new_ds.assign_coords(
-        arg_value=arg_value
+        one_in_x=arg_value
     )  # Writing multiple 1-in-X params as different coords of `arg_value` dimension
     new_ds["conf_int_lower_limit"] = conf_int_lower_limit
     new_ds["conf_int_upper_limit"] = conf_int_upper_limit
-
     if multiple_points:
         new_ds = new_ds.unstack("allpoints")
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -831,7 +831,7 @@ def cava_data(
                 for pt_idx in range(len(metric_data)):
                     _export_no_e(
                         metric_data[pt_idx],
-                        filename=f"{clean_params['calc_name']}_{str(round(metric_data[pt_idx].lat.item(), 3)).replace('.', '')}N_{round(str(metric_data[pt_idx].lon.item(), 3)).replace('.', '')}W",
+                        filename=f"{clean_params['calc_name']}_{str(round(metric_data[pt_idx].lat.item(), 3)).replace('.', '')}N_{str(round(metric_data[pt_idx].lon.item(), 3)).replace('.', '')}W",
                         format=file_format,
                     )  # Will need to include naming convention for calculated file too.
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -225,8 +225,10 @@ def _metric_agg(
                 sample_size=len(ams),
             )
 
-            # Change `arg_value` dimension coordinates to `1-in-X` parameter
-            calc_val.assign_coords(arg_value=one_in_x)
+            # Change `arg_value` dimension coordinates to `1-in-X` parameter and rename to `one_in_x`
+            calc_val = calc_val.assign_coords(arg_value=one_in_x).rename(
+                {"arg_value": "one_in_x"}
+            )
 
         elif percentile or percentile == 0:
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -186,7 +186,7 @@ def _metric_agg(
                     duration=duration,
                     groupby=groupby,
                     check_ess=False,
-                ).squeeze()  # `get_return_value` is expecting a 1-D array
+                ).squeeze()
 
                 # Calculating 1-in-X return value
                 return_values = get_return_value(
@@ -198,35 +198,24 @@ def _metric_agg(
                 return_vals.append(return_values)
 
                 # Determining goodness-of-fit for the given distribution
-                d_statistic, p_value = [
-                    float(v)
-                    for v in get_ks_stat(
-                        ams, distr=distr, multiple_points=False
-                    ).data_vars.values()
-                ]
-                p_vals.append(p_value)
-
-                # Printing out p-values
-                p_val_print = (
-                    format(p_value, ".3e") if p_value < 0.05 else round(p_value, 4)
-                )
-                to_print = f"The simulation {sim} fitted with a {distr} distribution has a p-value of {p_val_print}.\n"
-
-                if p_value < 0.05:
-                    to_print += " Since the p-value is <0.05, the selected distribution does not fit the data well and therefore is not a good fit (see guidance)."
-                print(to_print)
+                d_statistics, p_values = get_ks_stat(
+                    ams, distr=distr, multiple_points=False
+                ).data_vars.values()
+                p_vals.append(p_values)
 
             # Creating output 1-in-X object with p-values
-            calc_val = xr.concat(return_vals, dim="simulation")
-            calc_val = calc_val.assign_coords(p_values=("simulation", p_vals))
+            ret_vals = xr.concat(return_vals, dim="simulation")
+            p_vals = xr.concat(p_vals, dim="simulation")
+
+            # Removing any potential `None` attributes in the 1 in X or p-value DataArrays (i.e. from duration=None)
+            ret_vals.attrs = {k: v for k, v in ret_vals.attrs.items() if v is not None}
+            p_vals.attrs = {k: v for k, v in p_vals.attrs.items() if v is not None}
+
+            calc_val = xr.Dataset({"return_value": ret_vals, "p_values": p_vals})
 
             # Changing attributes for thresholds DataArray because of export issue later on
-            if groupby:
-                old_group = calc_val.attrs["groupby"]
-                calc_val.attrs["groupby"] = f"{old_group[0]} {old_group[1]}"
-            elif duration:
-                old_duration = calc_val.attrs["duration"]
-                calc_val.attrs["duration"] = f"{old_duration[0]} {old_duration[1]}"
+            num, size = event_duration
+            calc_val.attrs["groupby"] = f"{num} {size}"
 
             # Add distribution to attributes
             calc_val = calc_val.assign_attrs(
@@ -248,7 +237,9 @@ def _metric_agg(
                 .rename({"quantile": "percentile"})
             )
 
-        calc_val.name = name_of_calc
+        if isinstance(calc_val, xr.DataArray):
+            calc_val.name = name_of_calc
+
         return calc_val
 
     # If the data passed in is warming level data, then a dummy timestamp must be added to act as the current WL 'time' dimension

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -595,96 +595,69 @@ def cava_data(
     ValueError
         If input coordinates lack 'lat' and 'lon' columns or if 'lat'/'lon' columns are not of type float64 or int64.
     """
-    # with param.exceptions_summarized():
-    params = CavaParams(**locals())
-    clean_params = params.get_names()
+    with param.exceptions_summarized():
+        params = CavaParams(**locals())
+        clean_params = params.get_names()
 
-    # Convert string input to list
-    # ssp_data input requires a list even if the user is just inputting a single value
-    # i.e. ssp_data = "SSP 3-7.0" is NOT valid; needs to be ssp_data = ["SSP 3-7.0]
-    # Here, we catch that error for the user and just convert the string to a list :D
-    if type(ssp_data) == str:
-        ssp_data = [ssp_data]
+        # Convert string input to list
+        # ssp_data input requires a list even if the user is just inputting a single value
+        # i.e. ssp_data = "SSP 3-7.0" is NOT valid; needs to be ssp_data = ["SSP 3-7.0]
+        # Here, we catch that error for the user and just convert the string to a list :D
+        if type(ssp_data) == str:
+            ssp_data = [ssp_data]
 
-    months_map = {
-        "winter": [12, 1, 2],
-        "summer": [6, 7, 8],
-        "all": list(np.arange(1, 13)),
-    }
+        months_map = {
+            "winter": [12, 1, 2],
+            "summer": [6, 7, 8],
+            "all": list(np.arange(1, 13)),
+        }
 
-    locations = input_locations[["lat", "lon"]].values
+        locations = input_locations[["lat", "lon"]].values
 
-    print(f"Calculating {clean_params['var_name']}")
+        print(f"Calculating {clean_params['var_name']}")
 
-    print(f"--- Selecting Data Points --- \n")
+        print(f"--- Selecting Data Points --- \n")
 
-    selections = DataParameters()
-    selections.approach = approach
-    selections.data_type = "Gridded"
-    selections.downscaling_method = downscaling_method
-    selections.timescale = "hourly" if downscaling_method == "Dynamical" else "daily"
-    selections.variable_type = clean_params["variable_type"]
-    selections.variable = clean_params["variable"]
-    selections.resolution = "3 km"
-    selections.units = units
-
-    # Setting WL vs time-based attributes
-    if approach == "Warming Level":
-        selections.warming_level = [float(warming_level)]
-        selections.warming_level_months = months_map[season]
-        selections.scenario_ssp = ["n/a"]
-        selections.scenario_historical = ["n/a"]
-
-    else:
-        selections.scenario_ssp = (
-            clean_params["ssp_selected"]
-            if historical_data != "Historical Reconstruction"
-            else []
+        selections = DataParameters()
+        selections.approach = approach
+        selections.data_type = "Gridded"
+        selections.downscaling_method = downscaling_method
+        selections.timescale = (
+            "hourly" if downscaling_method == "Dynamical" else "daily"
         )
-        selections.scenario_historical = [historical_data]
-        selections.time_slice = (time_start_year, time_end_year)
+        selections.variable_type = clean_params["variable_type"]
+        selections.variable = clean_params["variable"]
+        selections.resolution = "3 km"
+        selections.units = units
 
-    if batch_mode and downscaling_method == "Statistical":
-        print(
-            "Batch mode for Statistical data in Warming Level approach is not optimized for multiple locations (in development). Resetting `batch_mode` to False. This may take some time because each location is retrieved and returned separately.\n"
-        )
-        batch_mode = False
+        # Setting WL vs time-based attributes
+        if approach == "Warming Level":
+            selections.warming_level = [float(warming_level)]
+            selections.warming_level_months = months_map[season]
+            selections.scenario_ssp = ["n/a"]
+            selections.scenario_historical = ["n/a"]
 
-    if batch_mode:
-        separate_files = False
-        data_pts = batch_select(approach, selections, locations)
-
-        data = _filter_ba_models(
-            data_pts, downscaling_method, wrf_bias_adjust, historical_data
-        )
-
-        if approach == "Warming Level" and warming_level == 0.8:
-            # Filter out inappropriate models for historical GWL baseline
-            data = _filter_hist_gwl_models(
-                data, downscaling_method, approach, warming_level
+        else:
+            selections.scenario_ssp = (
+                clean_params["ssp_selected"]
+                if historical_data != "Historical Reconstruction"
+                else []
             )
+            selections.scenario_historical = [historical_data]
+            selections.time_slice = (time_start_year, time_end_year)
 
-    else:
-        data_pts = []
-        for idx, loc in input_locations.iterrows():
+        if batch_mode and downscaling_method == "Statistical":
+            print(
+                "Batch mode for Statistical data in Warming Level approach is not optimized for multiple locations (in development). Resetting `batch_mode` to False. This may take some time because each location is retrieved and returned separately.\n"
+            )
+            batch_mode = False
 
-            lat, lon = float(loc["lat"]), float(loc["lon"])
-            print(f"Selecting data for {lat, lon}")
-
-            selections.latitude = (lat - 0.02, lat + 0.02)
-            selections.longitude = (lon - 0.02, lon + 0.02)
-            data = selections.retrieve()
-
-            if approach == "Time":
-                # Remove leap days, if applicable
-                data = data.sel(
-                    time=~((data.time.dt.month == 2) & (data.time.dt.day == 29))
-                )
-
-            data = get_closest_gridcell(data, lat, lon, print_coords=False)
+        if batch_mode:
+            separate_files = False
+            data_pts = batch_select(approach, selections, locations)
 
             data = _filter_ba_models(
-                data, downscaling_method, wrf_bias_adjust, historical_data
+                data_pts, downscaling_method, wrf_bias_adjust, historical_data
             )
 
             if approach == "Warming Level" and warming_level == 0.8:
@@ -692,57 +665,107 @@ def cava_data(
                 data = _filter_hist_gwl_models(
                     data, downscaling_method, approach, warming_level
                 )
-            data_pts.append(data)
 
-    if historical_data == "Historical Reconstruction":
-        data = data.squeeze(dim="scenario")
+        else:
+            data_pts = []
+            for idx, loc in input_locations.iterrows():
 
-    # Determining how to concatenate or load data, if necessary, depending on `approach` and `separate_files` parameters.
-    print("\n--- Loading Data into Memory ---\n")
+                lat, lon = float(loc["lat"]), float(loc["lon"])
+                print(f"Selecting data for {lat, lon}")
 
-    if separate_files:
-        loaded_data = []
-        for point in data_pts:
-            print(f"Point ({point.lat.compute().item()}, {point.lon.compute().item()})")
-            data = load(point, progress_bar=True)
-            loaded_data.append(data)
+                selections.latitude = (lat - 0.02, lat + 0.02)
+                selections.longitude = (lon - 0.02, lon + 0.02)
+                data = selections.retrieve()
 
-    else:
-        data_pts = xr.concat(data_pts, dim="simulation").chunk(chunks="auto")
-        loaded_data = load(data_pts, progress_bar=True)
+                if approach == "Time":
+                    # Remove leap days, if applicable
+                    data = data.sel(
+                        time=~((data.time.dt.month == 2) & (data.time.dt.day == 29))
+                    )
 
-    # Export raw data if desired
-    if export_method == "raw" or export_method == "both":
+                data = get_closest_gridcell(data, lat, lon, print_coords=False)
 
-        print("\n--- Exporting Raw Data ---")
+                data = _filter_ba_models(
+                    data, downscaling_method, wrf_bias_adjust, historical_data
+                )
 
-        if downscaling_method == "Statistical":
-            print(
-                "\nExporting Statistical data in most granular time availability (daily)\n"
-            )
+                if approach == "Warming Level" and warming_level == 0.8:
+                    # Filter out inappropriate models for historical GWL baseline
+                    data = _filter_hist_gwl_models(
+                        data, downscaling_method, approach, warming_level
+                    )
+                data_pts.append(data)
+
+        if historical_data == "Historical Reconstruction":
+            data = data.squeeze(dim="scenario")
+
+        # Determining how to concatenate or load data, if necessary, depending on `approach` and `separate_files` parameters.
+        print("\n--- Loading Data into Memory ---\n")
 
         if separate_files:
-            for pt_idx in range(len(loaded_data)):
-                _export_no_e(
-                    loaded_data[pt_idx],
-                    filename=clean_params["raw_name"],
-                    format=file_format,
+            loaded_data = []
+            for point in data_pts:
+                print(
+                    f"Point ({point.lat.compute().item()}, {point.lon.compute().item()})"
                 )
+                data = load(point, progress_bar=True)
+                loaded_data.append(data)
+
         else:
-            _export_no_e(loaded_data, filename="combined_raw_data", format=file_format)
+            data_pts = xr.concat(data_pts, dim="simulation").chunk(chunks="auto")
+            loaded_data = load(data_pts, progress_bar=True)
 
-        if export_method == "raw":
-            return loaded_data
+        # Export raw data if desired
+        if export_method == "raw" or export_method == "both":
 
-    print("\n--- Calculating Metrics ---")
-    print("Calculating...\n")  # , end="", flush=True)
+            print("\n--- Exporting Raw Data ---")
 
-    if separate_files:
-        metric_data = []
-        # Calculate and export into separate files
-        for point in loaded_data:
-            calc_val = _metric_agg(
-                point,
+            if downscaling_method == "Statistical":
+                print(
+                    "\nExporting Statistical data in most granular time availability (daily)\n"
+                )
+
+            if separate_files:
+                for pt_idx in range(len(loaded_data)):
+                    _export_no_e(
+                        loaded_data[pt_idx],
+                        filename=clean_params["raw_name"],
+                        format=file_format,
+                    )
+            else:
+                _export_no_e(
+                    loaded_data, filename="combined_raw_data", format=file_format
+                )
+
+            if export_method == "raw":
+                return loaded_data
+
+        print("\n--- Calculating Metrics ---")
+        print("Calculating...\n")  # , end="", flush=True)
+
+        if separate_files:
+            metric_data = []
+            # Calculate and export into separate files
+            for point in loaded_data:
+                calc_val = _metric_agg(
+                    point,
+                    variable,
+                    months_map[season],
+                    approach,
+                    metric_calc,
+                    clean_params["var_name"],
+                    heat_idx_threshold,
+                    percentile,
+                    one_in_x,
+                    event_duration,
+                    distr,
+                )
+                metric_data.append(calc_val)
+
+        # Export a combined file of all metrics
+        else:
+            metric_data = _metric_agg(
+                loaded_data,
                 variable,
                 months_map[season],
                 approach,
@@ -754,76 +777,59 @@ def cava_data(
                 event_duration,
                 distr,
             )
-            metric_data.append(calc_val)
 
-    # Export a combined file of all metrics
-    else:
-        metric_data = _metric_agg(
-            loaded_data,
-            variable,
-            months_map[season],
-            approach,
-            metric_calc,
-            clean_params["var_name"],
-            heat_idx_threshold,
-            percentile,
-            one_in_x,
-            event_duration,
-            distr,
-        )
+        print("\nComplete!")
 
-    print("\nComplete!")
+        # Export the data
+        print("\n--- Exporting Metric Data ---")
 
-    # Export the data
-    print("\n--- Exporting Metric Data ---")
+        if export_method == "calculate" or export_method == "both":
 
-    if export_method == "calculate" or export_method == "both":
+            if separate_files:
+                for pt_idx in range(len(metric_data)):
+                    _export_no_e(
+                        metric_data[pt_idx],
+                        filename=f"{clean_params['calc_name']}_{str(metric_data[pt_idx].lat.item()).replace('.', '')}N_{str(metric_data[pt_idx].lon.item()).replace('.', '')}W",
+                        format=file_format,
+                    )  # Will need to include naming convention for calculated file too.
 
-        if separate_files:
-            for pt_idx in range(len(metric_data)):
-                _export_no_e(
-                    metric_data[pt_idx],
-                    filename=f"{clean_params['calc_name']}_{str(metric_data[pt_idx].lat.item()).replace('.', '')}N_{str(metric_data[pt_idx].lon.item()).replace('.', '')}W",
-                    format=file_format,
-                )  # Will need to include naming convention for calculated file too.
+            else:
+                _export_no_e(metric_data, filename="metric_data", format=file_format)
 
-        else:
-            _export_no_e(metric_data, filename="metric_data", format=file_format)
+            # Returning values to user
+            if len(metric_data) == 1:
+                metric_data = metric_data[0]
+            if len(loaded_data) == 1:
+                loaded_data = loaded_data[0]
 
-        # Returning values to user
-        if len(metric_data) == 1:
-            metric_data = metric_data[0]
-        if len(loaded_data) == 1:
-            loaded_data = loaded_data[0]
+            if export_method == "calculate":
+                return {"calc_data": metric_data}
+            elif export_method == "both":
+                return {"calc_data": metric_data, "raw_data": loaded_data}
 
-        if export_method == "calculate":
+        elif export_method == "None":  # Specific for table generation
+            print("Data export selection set to 'None'; no data is exported!")
             return {"calc_data": metric_data}
-        elif export_method == "both":
-            return {"calc_data": metric_data, "raw_data": loaded_data}
-
-    elif export_method == "None":  # Specific for table generation
-        print("Data export selection set to 'None'; no data is exported!")
-        return {"calc_data": metric_data}
 
 
-# def _get_sce_3km_latlon():
-# """Get all 3 km lat/lon coordinates for SCE service territory"""
-# # Retrieve SCE territory data
-# selections = DataParameters()
-# selections.downscaling_method = "Dynamical"
-# selections.timescale = "monthly"
-# selections.time_slice = (2010, 2011)
-# selections.resolution = "3 km"
-# selections.area_subset = "CA Electric Load Serving Entities (IOU & POU)"
-# selections.cached_area = ["Southern California Edison"]
-# ds = selections.retrieve()
+def _get_sce_3km_latlon():
+    """Get all 3 km lat/lon coordinates for SCE service territory"""
+    # Retrieve SCE territory data
+    selections = DataParameters()
+    selections.downscaling_method = "Dynamical"
+    selections.timescale = "monthly"
+    selections.time_slice = (2010, 2011)
+    selections.resolution = "3 km"
+    selections.area_subset = "CA Electric Load Serving Entities (IOU & POU)"
+    selections.cached_area = ["Southern California Edison"]
+    ds = selections.retrieve()
 
-# # Find only values within the boxed area that are within the service territory
-# single_slice = ds.isel(time=0).isel(simulation=0).squeeze().compute()
+    # Find only values within the boxed area that are within the service territory
+    single_slice = ds.isel(time=0).isel(simulation=0).squeeze().compute()
 
-# single_dim = single_slice.stack(spatial=["y", "x"])
-# non_null = single_dim[~single_dim.isnull()]
+    single_dim = single_slice.stack(spatial=["y", "x"])
+    non_null = single_dim[~single_dim.isnull()]
 
-# df = pd.DataFrame({"lat": non_null.lat.values, "lon": non_null.lon.values})
+    df = pd.DataFrame({"lat": non_null.lat.values, "lon": non_null.lon.values})
 
-# return df
+    return df

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -150,8 +150,9 @@ def _metric_agg(
             one_in_x is not None
         ):  # This is done since `one_in_x` param could hold multiple X values
 
+            x_vals = [f"1-in-{x}" for x in one_in_x]
             print(
-                f"Goodness of fit for 1-in-{one_in_x}, {'-'.join(map(str, event_duration))} {variable} events: "
+                f"Goodness of fit for {", ".join(x_vals)}, {'-'.join(map(str, event_duration))} {variable} events: "
             )
 
             # Get 1-in-x event values
@@ -343,6 +344,12 @@ class CavaParams(param.Parameterized):
     def validate_params(self):
         errors = []
 
+        # Change `one_in_x` type before param validation and arg generation
+        if not isinstance(self.one_in_x, (list)):
+            self.one_in_x = np.array([self.one_in_x])
+        elif isinstance(self.one_in_x, list):
+            self.one_in_x = np.array(self.one_in_x)
+
         # Check if input_locations is a DataFrame with lat/lon columns
         if isinstance(self.input_locations, pd.DataFrame):
             if (
@@ -494,17 +501,26 @@ class CavaParams(param.Parameterized):
             calc_name = f"heat_index_thresh{self.heat_idx_threshold}_{approach_str}"
 
         elif self.one_in_x is not None:
-            var_name = f"1-in-{self.one_in_x} year, {'-'.join(map(str, self.event_duration))} {self.metric_calc.capitalize()} {variable} for {self.season} seasons {approach_var_name}"
+
+            x_names = [
+                f"1-in-{x} year, {'-'.join(map(str, self.event_duration))} {self.metric_calc.capitalize()} {variable} for {self.season} seasons {approach_var_name}"
+                for x in self.one_in_x
+            ]
+            var_name = " and ".join(x_names)
 
             # Making names for raw and calculated data
+            x_vals_str = "-".join(map(str, self.one_in_x))
+
             dur_len, dur_type = self.event_duration
             shortname_event = f"{dur_len}_{dur_type if dur_type == 'day' else 'hr'}"
             if variable == "Precipitation (total)":
-                raw_name = f"one_in_{self.one_in_x}_precipitation_raw_data"
-                calc_name = f"one_in_{self.one_in_x}_{shortname_event}_precipitation_{approach_str}"
+                raw_name = f"one_in_{x_vals_str}_precipitation_raw_data"
+                calc_name = f"one_in_{x_vals_str}_{shortname_event}_precipitation_{approach_str}"
             elif variable == "Air Temperature at 2m" or "Maximum air temperature at 2m":
-                raw_name = f"one_in_{self.one_in_x}_temperature_raw_data"
-                calc_name = f"one_in_{self.one_in_x}_{shortname_event}_temperature_{approach_str}"
+                raw_name = f"one_in_{x_vals_str}_temperature_raw_data"
+                calc_name = (
+                    f"one_in_{x_vals_str}_{shortname_event}_temperature_{approach_str}"
+                )
 
         return {
             "ssp_selected": self.ssp_data,
@@ -605,8 +621,14 @@ def cava_data(
         # ssp_data input requires a list even if the user is just inputting a single value
         # i.e. ssp_data = "SSP 3-7.0" is NOT valid; needs to be ssp_data = ["SSP 3-7.0]
         # Here, we catch that error for the user and just convert the string to a list :D
-        if type(ssp_data) == str:
+        if isinstance(ssp_data, str):
             ssp_data = [ssp_data]
+
+        # Convert `one_in_x` param to a np.ndarray object instead of a list, if it is currently a list
+        if not isinstance(one_in_x, (list)):
+            one_in_x = np.array([one_in_x])
+        elif isinstance(one_in_x, list):
+            one_in_x = np.array(one_in_x)
 
         months_map = {
             "winter": [12, 1, 2],
@@ -731,7 +753,7 @@ def cava_data(
                 for pt_idx in range(len(loaded_data)):
                     _export_no_e(
                         loaded_data[pt_idx],
-                        filename=clean_params["raw_name"],
+                        filename=f"{clean_params['raw_name']}_{str(metric_data[pt_idx].lat.item()).replace('.', '')}N_{str(metric_data[pt_idx].lon.item()).replace('.', '')}W",
                         format=file_format,
                     )
             else:

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -771,7 +771,7 @@ def cava_data(
                 for pt_idx in range(len(loaded_data)):
                     _export_no_e(
                         loaded_data[pt_idx],
-                        filename=f"{clean_params['raw_name']}_{str(loaded_data[pt_idx].lat.item()).replace('.', '')}N_{str(loaded_data[pt_idx].lon.item()).replace('.', '')}W",
+                        filename=f"{clean_params['raw_name']}_{str(round(loaded_data[pt_idx].lat.item(), 3)).replace('.', '')}N_{str(round(loaded_data[pt_idx].lon.item(), 3)).replace('.', '')}W",
                         format=file_format,
                     )
             else:
@@ -831,7 +831,7 @@ def cava_data(
                 for pt_idx in range(len(metric_data)):
                     _export_no_e(
                         metric_data[pt_idx],
-                        filename=f"{clean_params['calc_name']}_{str(metric_data[pt_idx].lat.item()).replace('.', '')}N_{str(metric_data[pt_idx].lon.item()).replace('.', '')}W",
+                        filename=f"{clean_params['calc_name']}_{str(round(metric_data[pt_idx].lat.item(), 3)).replace('.', '')}N_{round(str(metric_data[pt_idx].lon.item(), 3)).replace('.', '')}W",
                         format=file_format,
                     )  # Will need to include naming convention for calculated file too.
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -407,9 +407,6 @@ class CavaParams(param.Parameterized):
                 and not any(x is None for x in self.one_in_x)
             )
         ):
-            import pdb
-
-            pdb.set_trace()
             errors.append(
                 "Only one of heat_idx_threshold, one_in_x, and percentile can be non-None."
             )
@@ -420,9 +417,6 @@ class CavaParams(param.Parameterized):
             and self.percentile is None
             and all(x is None for x in self.one_in_x)
         ):
-            import pdb
-
-            pdb.set_trace()
             errors.append(
                 "`heat_idx_threshold`, `percentile`, and `one_in_x` cannot all be None."
             )

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -146,8 +146,8 @@ def _metric_agg(
                 .mean(dim="time")
             )  # This line counts the average number of high heat days per year over this time interval
 
-        elif (
-            one_in_x is not None
+        elif not any(
+            x is None for x in one_in_x
         ):  # This is done since `one_in_x` param could hold multiple X values
 
             x_vals = [f"1-in-{x}" for x in one_in_x]
@@ -398,9 +398,18 @@ class CavaParams(param.Parameterized):
         # Validating that only one of heat_idx_threshold, percentile, or one_in_x is passed
         if (
             (self.heat_idx_threshold is not None and self.percentile is not None)
-            or (self.heat_idx_threshold is not None and self.one_in_x is not None)
-            or (self.percentile is not None and self.one_in_x is not None)
+            or (
+                self.heat_idx_threshold is not None
+                and not any(x is None for x in self.one_in_x)
+            )
+            or (
+                self.percentile is not None
+                and not any(x is None for x in self.one_in_x)
+            )
         ):
+            import pdb
+
+            pdb.set_trace()
             errors.append(
                 "Only one of heat_idx_threshold, one_in_x, and percentile can be non-None."
             )
@@ -409,8 +418,11 @@ class CavaParams(param.Parameterized):
         if (
             self.heat_idx_threshold is None
             and self.percentile is None
-            and self.one_in_x is None
+            and all(x is None for x in self.one_in_x)
         ):
+            import pdb
+
+            pdb.set_trace()
             errors.append(
                 "`heat_idx_threshold`, `percentile`, and `one_in_x` cannot all be None."
             )
@@ -500,7 +512,7 @@ class CavaParams(param.Parameterized):
             raw_name = "heat_index_raw_data"
             calc_name = f"heat_index_thresh{self.heat_idx_threshold}_{approach_str}"
 
-        elif self.one_in_x is not None:
+        elif not any(x is None for x in self.one_in_x):
 
             x_names = [
                 f"1-in-{x} year, {'-'.join(map(str, self.event_duration))} {self.metric_calc.capitalize()} {variable} for {self.season} seasons {approach_var_name}"
@@ -753,7 +765,7 @@ def cava_data(
                 for pt_idx in range(len(loaded_data)):
                     _export_no_e(
                         loaded_data[pt_idx],
-                        filename=f"{clean_params['raw_name']}_{str(metric_data[pt_idx].lat.item()).replace('.', '')}N_{str(metric_data[pt_idx].lon.item()).replace('.', '')}W",
+                        filename=f"{clean_params['raw_name']}_{str(loaded_data[pt_idx].lat.item()).replace('.', '')}N_{str(loaded_data[pt_idx].lon.item()).replace('.', '')}W",
                         format=file_format,
                     )
             else:

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -225,10 +225,10 @@ def _metric_agg(
                 sample_size=len(ams),
             )
 
-            # Change `arg_value` dimension coordinates to `1-in-X` parameter and rename to `one_in_x`
-            calc_val = calc_val.assign_coords(arg_value=one_in_x).rename(
-                {"arg_value": "one_in_x"}
-            )
+            # # Change `arg_value` dimension coordinates to `1-in-X` parameter and rename to `one_in_x`
+            # calc_val = calc_val.assign_coords(arg_value=one_in_x).rename(
+            #     {"arg_value": "one_in_x"}
+            # )
 
         elif percentile or percentile == 0:
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -201,10 +201,22 @@ def _metric_agg(
                 return_vals.append(return_values)
 
                 # Determining goodness-of-fit for the given distribution
-                d_statistics, p_values = get_ks_stat(
+                d_statistics, p_value = get_ks_stat(
                     ams, distr=distr, multiple_points=False
                 ).data_vars.values()
-                p_vals.append(p_values)
+                p_vals.append(p_value)
+
+                # Printing out p-values
+                p_val_print = (
+                    format(p_value.item(), ".3e")
+                    if p_value.item() < 0.05
+                    else round(p_value.item(), 4)
+                )
+                to_print = f"The simulation {sim} fitted with a {distr} distribution has a p-value of {p_val_print}.\n"
+
+                if p_value.item() < 0.05:
+                    to_print += " Since the p-value is <0.05, the selected distribution does not fit the data well and therefore is not a good fit (see guidance)."
+                print(to_print)
 
             # Creating output 1-in-X object with p-values
             ret_vals = xr.concat(return_vals, dim="simulation")

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -631,7 +631,7 @@ def cava_data(
             ssp_data = [ssp_data]
 
         # Convert `one_in_x` param to a np.ndarray object instead of a list, if it is currently a list
-        if not isinstance(one_in_x, (list)):
+        if not isinstance(one_in_x, (list, np.ndarray)):
             one_in_x = np.array([one_in_x])
         elif isinstance(one_in_x, list):
             one_in_x = np.array(one_in_x)

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -146,7 +146,9 @@ def _metric_agg(
                 .mean(dim="time")
             )  # This line counts the average number of high heat days per year over this time interval
 
-        elif one_in_x:  # Calculate 1-in-X events
+        elif (
+            one_in_x is not None
+        ):  # This is done since `one_in_x` param could hold multiple X values
 
             print(
                 f"Goodness of fit for 1-in-{one_in_x}, {'-'.join(map(str, event_duration))} {variable} events: "
@@ -223,6 +225,9 @@ def _metric_agg(
                 sample_size=len(ams),
             )
 
+            # Change `arg_value` dimension coordinates to `1-in-X` parameter
+            calc_val.assign_coords(arg_value=one_in_x)
+
         elif percentile or percentile == 0:
 
             calc_val = (
@@ -270,7 +275,6 @@ class CavaParams(param.Parameterized):
         objects=["Air Temperature at 2m", "Precipitation (total)", "NOAA Heat Index"],
         doc="Variable to analyze",
     )
-
     metric_calc = param.ObjectSelector(
         default="max",
         objects=["min", "max", "mean", "median"],
@@ -282,7 +286,9 @@ class CavaParams(param.Parameterized):
     heat_idx_threshold = param.Number(
         default=None, allow_None=True, doc="Threshold for heat index"
     )
-    one_in_x = param.Integer(default=None, allow_None=True, doc="1-in-x year event")
+    one_in_x = param.Parameter(
+        default=None, allow_None=True, doc="1-in-x year event(s) — number or list"
+    )
     season = param.ObjectSelector(
         default="all", objects=["summer", "winter", "all"], doc="Season to analyze"
     )
@@ -589,70 +595,96 @@ def cava_data(
     ValueError
         If input coordinates lack 'lat' and 'lon' columns or if 'lat'/'lon' columns are not of type float64 or int64.
     """
+    # with param.exceptions_summarized():
+    params = CavaParams(**locals())
+    clean_params = params.get_names()
 
-    with param.exceptions_summarized():
-        params = CavaParams(**locals())
-        clean_params = params.get_names()
+    # Convert string input to list
+    # ssp_data input requires a list even if the user is just inputting a single value
+    # i.e. ssp_data = "SSP 3-7.0" is NOT valid; needs to be ssp_data = ["SSP 3-7.0]
+    # Here, we catch that error for the user and just convert the string to a list :D
+    if type(ssp_data) == str:
+        ssp_data = [ssp_data]
 
-        # Convert string input to list
-        # ssp_data input requires a list even if the user is just inputting a single value
-        # i.e. ssp_data = "SSP 3-7.0" is NOT valid; needs to be ssp_data = ["SSP 3-7.0]
-        # Here, we catch that error for the user and just convert the string to a list :D
-        if type(ssp_data) == str:
-            ssp_data = [ssp_data]
+    months_map = {
+        "winter": [12, 1, 2],
+        "summer": [6, 7, 8],
+        "all": list(np.arange(1, 13)),
+    }
 
-        months_map = {
-            "winter": [12, 1, 2],
-            "summer": [6, 7, 8],
-            "all": list(np.arange(1, 13)),
-        }
+    locations = input_locations[["lat", "lon"]].values
 
-        locations = input_locations[["lat", "lon"]].values
+    print(f"Calculating {clean_params['var_name']}")
 
-        print(f"Calculating {clean_params['var_name']}")
+    print(f"--- Selecting Data Points --- \n")
 
-        print(f"--- Selecting Data Points --- \n")
+    selections = DataParameters()
+    selections.approach = approach
+    selections.data_type = "Gridded"
+    selections.downscaling_method = downscaling_method
+    selections.timescale = "hourly" if downscaling_method == "Dynamical" else "daily"
+    selections.variable_type = clean_params["variable_type"]
+    selections.variable = clean_params["variable"]
+    selections.resolution = "3 km"
+    selections.units = units
 
-        selections = DataParameters()
-        selections.approach = approach
-        selections.data_type = "Gridded"
-        selections.downscaling_method = downscaling_method
-        selections.timescale = (
-            "hourly" if downscaling_method == "Dynamical" else "daily"
+    # Setting WL vs time-based attributes
+    if approach == "Warming Level":
+        selections.warming_level = [float(warming_level)]
+        selections.warming_level_months = months_map[season]
+        selections.scenario_ssp = ["n/a"]
+        selections.scenario_historical = ["n/a"]
+
+    else:
+        selections.scenario_ssp = (
+            clean_params["ssp_selected"]
+            if historical_data != "Historical Reconstruction"
+            else []
         )
-        selections.variable_type = clean_params["variable_type"]
-        selections.variable = clean_params["variable"]
-        selections.resolution = "3 km"
-        selections.units = units
+        selections.scenario_historical = [historical_data]
+        selections.time_slice = (time_start_year, time_end_year)
 
-        # Setting WL vs time-based attributes
-        if approach == "Warming Level":
-            selections.warming_level = [float(warming_level)]
-            selections.warming_level_months = months_map[season]
-            selections.scenario_ssp = ["n/a"]
-            selections.scenario_historical = ["n/a"]
+    if batch_mode and downscaling_method == "Statistical":
+        print(
+            "Batch mode for Statistical data in Warming Level approach is not optimized for multiple locations (in development). Resetting `batch_mode` to False. This may take some time because each location is retrieved and returned separately.\n"
+        )
+        batch_mode = False
 
-        else:
-            selections.scenario_ssp = (
-                clean_params["ssp_selected"]
-                if historical_data != "Historical Reconstruction"
-                else []
+    if batch_mode:
+        separate_files = False
+        data_pts = batch_select(approach, selections, locations)
+
+        data = _filter_ba_models(
+            data_pts, downscaling_method, wrf_bias_adjust, historical_data
+        )
+
+        if approach == "Warming Level" and warming_level == 0.8:
+            # Filter out inappropriate models for historical GWL baseline
+            data = _filter_hist_gwl_models(
+                data, downscaling_method, approach, warming_level
             )
-            selections.scenario_historical = [historical_data]
-            selections.time_slice = (time_start_year, time_end_year)
 
-        if batch_mode and downscaling_method == "Statistical":
-            print(
-                "Batch mode for Statistical data in Warming Level approach is not optimized for multiple locations (in development). Resetting `batch_mode` to False. This may take some time because each location is retrieved and returned separately.\n"
-            )
-            batch_mode = False
+    else:
+        data_pts = []
+        for idx, loc in input_locations.iterrows():
 
-        if batch_mode:
-            separate_files = False
-            data_pts = batch_select(approach, selections, locations)
+            lat, lon = float(loc["lat"]), float(loc["lon"])
+            print(f"Selecting data for {lat, lon}")
+
+            selections.latitude = (lat - 0.02, lat + 0.02)
+            selections.longitude = (lon - 0.02, lon + 0.02)
+            data = selections.retrieve()
+
+            if approach == "Time":
+                # Remove leap days, if applicable
+                data = data.sel(
+                    time=~((data.time.dt.month == 2) & (data.time.dt.day == 29))
+                )
+
+            data = get_closest_gridcell(data, lat, lon, print_coords=False)
 
             data = _filter_ba_models(
-                data_pts, downscaling_method, wrf_bias_adjust, historical_data
+                data, downscaling_method, wrf_bias_adjust, historical_data
             )
 
             if approach == "Warming Level" and warming_level == 0.8:
@@ -660,107 +692,57 @@ def cava_data(
                 data = _filter_hist_gwl_models(
                     data, downscaling_method, approach, warming_level
                 )
+            data_pts.append(data)
 
-        else:
-            data_pts = []
-            for idx, loc in input_locations.iterrows():
+    if historical_data == "Historical Reconstruction":
+        data = data.squeeze(dim="scenario")
 
-                lat, lon = float(loc["lat"]), float(loc["lon"])
-                print(f"Selecting data for {lat, lon}")
+    # Determining how to concatenate or load data, if necessary, depending on `approach` and `separate_files` parameters.
+    print("\n--- Loading Data into Memory ---\n")
 
-                selections.latitude = (lat - 0.02, lat + 0.02)
-                selections.longitude = (lon - 0.02, lon + 0.02)
-                data = selections.retrieve()
+    if separate_files:
+        loaded_data = []
+        for point in data_pts:
+            print(f"Point ({point.lat.compute().item()}, {point.lon.compute().item()})")
+            data = load(point, progress_bar=True)
+            loaded_data.append(data)
 
-                if approach == "Time":
-                    # Remove leap days, if applicable
-                    data = data.sel(
-                        time=~((data.time.dt.month == 2) & (data.time.dt.day == 29))
-                    )
+    else:
+        data_pts = xr.concat(data_pts, dim="simulation").chunk(chunks="auto")
+        loaded_data = load(data_pts, progress_bar=True)
 
-                data = get_closest_gridcell(data, lat, lon, print_coords=False)
+    # Export raw data if desired
+    if export_method == "raw" or export_method == "both":
 
-                data = _filter_ba_models(
-                    data, downscaling_method, wrf_bias_adjust, historical_data
-                )
+        print("\n--- Exporting Raw Data ---")
 
-                if approach == "Warming Level" and warming_level == 0.8:
-                    # Filter out inappropriate models for historical GWL baseline
-                    data = _filter_hist_gwl_models(
-                        data, downscaling_method, approach, warming_level
-                    )
-                data_pts.append(data)
-
-        if historical_data == "Historical Reconstruction":
-            data = data.squeeze(dim="scenario")
-
-        # Determining how to concatenate or load data, if necessary, depending on `approach` and `separate_files` parameters.
-        print("\n--- Loading Data into Memory ---\n")
+        if downscaling_method == "Statistical":
+            print(
+                "\nExporting Statistical data in most granular time availability (daily)\n"
+            )
 
         if separate_files:
-            loaded_data = []
-            for point in data_pts:
-                print(
-                    f"Point ({point.lat.compute().item()}, {point.lon.compute().item()})"
-                )
-                data = load(point, progress_bar=True)
-                loaded_data.append(data)
-
-        else:
-            data_pts = xr.concat(data_pts, dim="simulation").chunk(chunks="auto")
-            loaded_data = load(data_pts, progress_bar=True)
-
-        # Export raw data if desired
-        if export_method == "raw" or export_method == "both":
-
-            print("\n--- Exporting Raw Data ---")
-
-            if downscaling_method == "Statistical":
-                print(
-                    "\nExporting Statistical data in most granular time availability (daily)\n"
-                )
-
-            if separate_files:
-                for pt_idx in range(len(loaded_data)):
-                    _export_no_e(
-                        loaded_data[pt_idx],
-                        filename=clean_params["raw_name"],
-                        format=file_format,
-                    )
-            else:
+            for pt_idx in range(len(loaded_data)):
                 _export_no_e(
-                    loaded_data, filename="combined_raw_data", format=file_format
+                    loaded_data[pt_idx],
+                    filename=clean_params["raw_name"],
+                    format=file_format,
                 )
-
-            if export_method == "raw":
-                return loaded_data
-
-        print("\n--- Calculating Metrics ---")
-        print("Calculating...\n")  # , end="", flush=True)
-
-        if separate_files:
-            metric_data = []
-            # Calculate and export into separate files
-            for point in loaded_data:
-                calc_val = _metric_agg(
-                    point,
-                    variable,
-                    months_map[season],
-                    approach,
-                    metric_calc,
-                    clean_params["var_name"],
-                    heat_idx_threshold,
-                    percentile,
-                    one_in_x,
-                    event_duration,
-                    distr,
-                )
-                metric_data.append(calc_val)
-
-        # Export a combined file of all metrics
         else:
-            metric_data = _metric_agg(
-                loaded_data,
+            _export_no_e(loaded_data, filename="combined_raw_data", format=file_format)
+
+        if export_method == "raw":
+            return loaded_data
+
+    print("\n--- Calculating Metrics ---")
+    print("Calculating...\n")  # , end="", flush=True)
+
+    if separate_files:
+        metric_data = []
+        # Calculate and export into separate files
+        for point in loaded_data:
+            calc_val = _metric_agg(
+                point,
                 variable,
                 months_map[season],
                 approach,
@@ -772,59 +754,76 @@ def cava_data(
                 event_duration,
                 distr,
             )
+            metric_data.append(calc_val)
 
-        print("\nComplete!")
+    # Export a combined file of all metrics
+    else:
+        metric_data = _metric_agg(
+            loaded_data,
+            variable,
+            months_map[season],
+            approach,
+            metric_calc,
+            clean_params["var_name"],
+            heat_idx_threshold,
+            percentile,
+            one_in_x,
+            event_duration,
+            distr,
+        )
 
-        # Export the data
-        print("\n--- Exporting Metric Data ---")
+    print("\nComplete!")
 
-        if export_method == "calculate" or export_method == "both":
+    # Export the data
+    print("\n--- Exporting Metric Data ---")
 
-            if separate_files:
-                for pt_idx in range(len(metric_data)):
-                    _export_no_e(
-                        metric_data[pt_idx],
-                        filename=f"{clean_params['calc_name']}_{str(metric_data[pt_idx].lat.item()).replace('.', '')}N_{str(metric_data[pt_idx].lon.item()).replace('.', '')}W",
-                        format=file_format,
-                    )  # Will need to include naming convention for calculated file too.
+    if export_method == "calculate" or export_method == "both":
 
-            else:
-                _export_no_e(metric_data, filename="metric_data", format=file_format)
+        if separate_files:
+            for pt_idx in range(len(metric_data)):
+                _export_no_e(
+                    metric_data[pt_idx],
+                    filename=f"{clean_params['calc_name']}_{str(metric_data[pt_idx].lat.item()).replace('.', '')}N_{str(metric_data[pt_idx].lon.item()).replace('.', '')}W",
+                    format=file_format,
+                )  # Will need to include naming convention for calculated file too.
 
-            # Returning values to user
-            if len(metric_data) == 1:
-                metric_data = metric_data[0]
-            if len(loaded_data) == 1:
-                loaded_data = loaded_data[0]
+        else:
+            _export_no_e(metric_data, filename="metric_data", format=file_format)
 
-            if export_method == "calculate":
-                return {"calc_data": metric_data}
-            elif export_method == "both":
-                return {"calc_data": metric_data, "raw_data": loaded_data}
+        # Returning values to user
+        if len(metric_data) == 1:
+            metric_data = metric_data[0]
+        if len(loaded_data) == 1:
+            loaded_data = loaded_data[0]
 
-        elif export_method == "None":  # Specific for table generation
-            print("Data export selection set to 'None'; no data is exported!")
+        if export_method == "calculate":
             return {"calc_data": metric_data}
+        elif export_method == "both":
+            return {"calc_data": metric_data, "raw_data": loaded_data}
+
+    elif export_method == "None":  # Specific for table generation
+        print("Data export selection set to 'None'; no data is exported!")
+        return {"calc_data": metric_data}
 
 
-def _get_sce_3km_latlon():
-    """Get all 3 km lat/lon coordinates for SCE service territory"""
-    # Retrieve SCE territory data
-    selections = DataParameters()
-    selections.downscaling_method = "Dynamical"
-    selections.timescale = "monthly"
-    selections.time_slice = (2010, 2011)
-    selections.resolution = "3 km"
-    selections.area_subset = "CA Electric Load Serving Entities (IOU & POU)"
-    selections.cached_area = ["Southern California Edison"]
-    ds = selections.retrieve()
+# def _get_sce_3km_latlon():
+# """Get all 3 km lat/lon coordinates for SCE service territory"""
+# # Retrieve SCE territory data
+# selections = DataParameters()
+# selections.downscaling_method = "Dynamical"
+# selections.timescale = "monthly"
+# selections.time_slice = (2010, 2011)
+# selections.resolution = "3 km"
+# selections.area_subset = "CA Electric Load Serving Entities (IOU & POU)"
+# selections.cached_area = ["Southern California Edison"]
+# ds = selections.retrieve()
 
-    # Find only values within the boxed area that are within the service territory
-    single_slice = ds.isel(time=0).isel(simulation=0).squeeze().compute()
+# # Find only values within the boxed area that are within the service territory
+# single_slice = ds.isel(time=0).isel(simulation=0).squeeze().compute()
 
-    single_dim = single_slice.stack(spatial=["y", "x"])
-    non_null = single_dim[~single_dim.isnull()]
+# single_dim = single_slice.stack(spatial=["y", "x"])
+# non_null = single_dim[~single_dim.isnull()]
 
-    df = pd.DataFrame({"lat": non_null.lat.values, "lon": non_null.lon.values})
+# df = pd.DataFrame({"lat": non_null.lat.values, "lon": non_null.lon.values})
 
-    return df
+# return df

--- a/climakitae/tools/batch.py
+++ b/climakitae/tools/batch.py
@@ -20,17 +20,6 @@ def batch_select(approach, selections, points, load_data=False, progress_bar=Tru
     -------
     cells_of_interest: xr.DataArray of the gridcells that the points lie within, aggregated together into one DataArray. It can or cannot be loaded into memory, depending on `load_data`.
     """
-
-    def _retrieve_pts(data, points):
-        """Retrieving all individual points within the entire domain of data pulled."""
-        data_pts = []
-        for point in points:
-            lat, lon = point
-            closest_cell = get_closest_gridcells(data, lat, lon, print_coords=False)
-            stacked_data = stack_sims_across_locs(closest_cell)
-            data_pts.append(closest_cell)
-        return data_pts
-
     print(f"Batch retrieving all {len(points)} points passed in...\n")
 
     # Add selections attributes to cover the entire domain since we don't know exactly where the selected points lie.
@@ -44,7 +33,7 @@ def batch_select(approach, selections, points, load_data=False, progress_bar=Tru
         data = data.sel(time=~((data.time.dt.month == 2) & (data.time.dt.day == 29)))
 
     # Find the closest gridcells for each of the passed in points and concatenate them on a new 'points' dimension to go from 2D grid to 1D series of points
-    da_points = get_closest_gridcells(data, points[:, 0], points[:, 1])
+    cells_of_interest = get_closest_gridcells(data, points[:, 0], points[:, 1])
 
     # Load in the cells of interest into memory, if desired.
     if load_data:

--- a/climakitae/tools/batch.py
+++ b/climakitae/tools/batch.py
@@ -1,4 +1,4 @@
-from climakitae.util.utils import get_closest_gridcell, stack_sims_across_locs
+from climakitae.util.utils import get_closest_gridcells, stack_sims_across_locs
 from climakitae.core.data_load import load
 import xarray as xr
 
@@ -26,7 +26,7 @@ def batch_select(approach, selections, points, load_data=False, progress_bar=Tru
         data_pts = []
         for point in points:
             lat, lon = point
-            closest_cell = get_closest_gridcell(data, lat, lon, print_coords=False)
+            closest_cell = get_closest_gridcells(data, lat, lon, print_coords=False)
             stacked_data = stack_sims_across_locs(closest_cell)
             data_pts.append(closest_cell)
         return data_pts
@@ -43,10 +43,8 @@ def batch_select(approach, selections, points, load_data=False, progress_bar=Tru
         # Remove leap days, if applicable
         data = data.sel(time=~((data.time.dt.month == 2) & (data.time.dt.day == 29)))
 
-    data_pts = _retrieve_pts(data, points)
-
-    # Combine data points into a single xr.Dataset
-    cells_of_interest = xr.concat(data_pts, dim="simulation").chunk(chunks="auto")
+    # Find the closest gridcells for each of the passed in points and concatenate them on a new 'points' dimension to go from 2D grid to 1D series of points
+    da_points = get_closest_gridcells(data, points[:, 0], points[:, 1])
 
     # Load in the cells of interest into memory, if desired.
     if load_data:

--- a/tests/vulnerability/test_vulnerability.py
+++ b/tests/vulnerability/test_vulnerability.py
@@ -245,7 +245,6 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
     ), "The expected output dimension of `metric_agg` 1-in-X has `simulation`."
 
 
-
 ### Listing out different parameters to test `cava_data` on
 inputs = [
     ## WRF Time

--- a/tests/vulnerability/test_vulnerability.py
+++ b/tests/vulnerability/test_vulnerability.py
@@ -121,7 +121,6 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
         type(calc_val) == xr.core.dataarray.DataArray
     ), "The output type of `metric_agg` should be an xarray DataArray."
 
-    print(calc_val)
     assert calc_val.shape == (
         1,  # scenario
         num_sims,  # simulation
@@ -197,17 +196,23 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
     )
 
     assert (
-        type(calc_val) == xr.core.dataarray.DataArray
-    ), "The output type of `metric_agg` should be an xarray DataArray."
-    assert calc_val.shape == (
+        type(calc_val) == xr.core.dataarray.Dataset
+    ), "The output type of `metric_agg` should be an xarray Dataset."
+    assert calc_val['return_value'].shape == (
         num_sims,
-    ), "This is not an expected output shape of `metric_agg`."
+        1
+    ), "This is not an expected output shape of the `return_value` data variable for `calc_val`."
+    assert calc_val['p_values'].shape == (
+        num_sims,
+    ), "This is not an expected output shape of the `p_values` data variable for `calc_val`."
     assert (
         "simulation" in calc_val.dims
     ), "The expected output dimension of `metric_agg` 1-in-X has `simulation`."
-    assert (
-        calc_val.name == new_name
-    ), "New name of DataArray should be carried on from argument."
+    
+    ### This last assertion does not apply to a returned xr.Dataset
+    # assert (
+    #     calc_val.name == new_name
+    # ), "New name of DataArray should be carried on from argument."
 
 
 ### Listing out different parameters to test `cava_data` on
@@ -302,7 +307,7 @@ inputs = [
         False,
         "test_dataarray_time_2030_2035_wrf_3km_hourly_heat_index",
     ),
-    #     ### Historical Reconstruction, no batch
+    # ### Historical Reconstruction, no batch
     # (
     #     "Air Temperature at 2m",
     #     "Dynamical",
@@ -317,7 +322,7 @@ inputs = [
     #     False,
     #     "test_dataarray_time_2010_2015_histrecon_wrf_3km_hourly_temp_single_cell",
     # ),
-    #     ## Historical Reconstruction, batch
+    ## Historical Reconstruction, batch
     (
         "Air Temperature at 2m",
         "Dynamical",
@@ -474,8 +479,8 @@ def test_cava_data_params(
                 if approach == "Time":
                     if historical_data == "Historical Reconstruction":
                         assert raw_res.shape == (
-                            batch,
                             (end_year - start_year + 1) * days_by_season[season] * 24,
+                            batch,
                         )  # Finding the total number of hours after filtering for specific seasons
                     elif wrf_bias_adjust == True:
                         num_sims = 5 * batch
@@ -552,7 +557,11 @@ def test_cava_data_params(
                     assert np.all(
                         np.isclose(calc_res.lon, [-119.06061, -119.02176], atol=0.1)
                     )
-                    assert np.isclose(calc_res.x, -4089113.66, atol=5000)
+                    assert np.all(
+                        np.isclose(
+                            calc_res.x, [-4089113.66186097, -4089113.66186097], atol=5000
+                        )
+                    )
                     assert np.all(
                         np.isclose(
                             calc_res.y, [1015911.73069854, 1009911.73069854], atol=5000

--- a/tests/vulnerability/test_vulnerability.py
+++ b/tests/vulnerability/test_vulnerability.py
@@ -112,7 +112,7 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
         new_name,
         91,
         None,
-        None,
+        np.array([None]),
         (1, "day"),
         "gev",
     )
@@ -150,7 +150,7 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
         new_name,
         None,
         95,
-        None,
+        np.array([None]),
         (1, "day"),
         "gev",
     )
@@ -190,7 +190,7 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
         new_name,
         None,
         None,
-        10,
+        np.array([10]),
         (1, "day"),
         "gev",
     )
@@ -213,6 +213,37 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
     # assert (
     #     calc_val.name == new_name
     # ), "New name of DataArray should be carried on from argument."
+
+    # One-in-X test for multiple 1-in-X values
+    one_in_x_vals = np.array([10, 100])
+    calc_val = _metric_agg(
+        ds,
+        "Air Temperature at 2m",
+        np.arange(1, 13),
+        "time",
+        "max",
+        new_name,
+        None,
+        None,
+        one_in_x_vals,
+        (1, "day"),
+        "gev",
+    )
+
+    assert (
+        type(calc_val) == xr.core.dataarray.Dataset
+    ), "The output type of `metric_agg` should be an xarray Dataset."
+    assert calc_val["return_value"].shape == (
+        num_sims,
+        len(one_in_x_vals),
+    ), "This is not an expected output shape of the `return_value` data variable for `calc_val`."
+    assert calc_val["p_values"].shape == (
+        num_sims,
+    ), "This is not an expected output shape of the `p_values` data variable for `calc_val`."
+    assert (
+        "simulation" in calc_val.dims
+    ), "The expected output dimension of `metric_agg` 1-in-X has `simulation`."
+
 
 
 ### Listing out different parameters to test `cava_data` on

--- a/tests/vulnerability/test_vulnerability.py
+++ b/tests/vulnerability/test_vulnerability.py
@@ -198,17 +198,17 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
     assert (
         type(calc_val) == xr.core.dataarray.Dataset
     ), "The output type of `metric_agg` should be an xarray Dataset."
-    assert calc_val['return_value'].shape == (
+    assert calc_val["return_value"].shape == (
         num_sims,
-        1
+        1,
     ), "This is not an expected output shape of the `return_value` data variable for `calc_val`."
-    assert calc_val['p_values'].shape == (
+    assert calc_val["p_values"].shape == (
         num_sims,
     ), "This is not an expected output shape of the `p_values` data variable for `calc_val`."
     assert (
         "simulation" in calc_val.dims
     ), "The expected output dimension of `metric_agg` 1-in-X has `simulation`."
-    
+
     ### This last assertion does not apply to a returned xr.Dataset
     # assert (
     #     calc_val.name == new_name
@@ -559,7 +559,9 @@ def test_cava_data_params(
                     )
                     assert np.all(
                         np.isclose(
-                            calc_res.x, [-4089113.66186097, -4089113.66186097], atol=5000
+                            calc_res.x,
+                            [-4089113.66186097, -4089113.66186097],
+                            atol=5000,
                         )
                     )
                     assert np.all(


### PR DESCRIPTION
## Summary of changes and related issue
This PR focuses on the 1-in-X calculation for the CAVA data function. It addresses SCE's concerns with a time bottleneck by parallelizing the compute of 1-in-X calculations across all points at the same time, and also allows for multiple X parameters to be passed into the 1-in-X parameter.

## Relevant motivation and context
This reduces the overall runtime of the 1-in-X calculation from N points X M simulations X P 1-in-X values to now just M simulations run time. The next PR for time optimization will focus on reducing the M simulations runtime to just 1 simulation run time.

## How to test 
Run `vulnerability_assessment.ipynb` with multiple X's in `one_in_x` param, like

`one_in_x=np.array([20, 100])`

and check that the multiple X calculations are working properly, and that the `one_in_x` distributions are not being fit on the points one by one when `batch_mode=True`.

Use the latest notebook in https://github.com/cal-adapt/cae-notebooks/pull/150

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
