### PR TITLE
Bug fix to `warming.py`

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -241,7 +241,7 @@ def get_sliced_data(y, level, years, months=np.arange(1, 13), window=15, anom="N
         if len(sliced["time"]) < expected_counts[sliced.frequency]:
             try:
                 print(
-                    f"\nWarming Level data for {sliced.simulation[0]} is not completely available, since the warming level slice's center year is towards the end of the century. All other valid data is returned.\n"
+                    f"\nWarming Level data for {sliced.simulation[0].item()} is not completely available, since the warming level slice's center year is towards the end of the century. All other valid data is returned.\n"
                 )
             except:
                 print(


### PR DESCRIPTION
## Summary of changes and related issue
Noticed this in reviewing Eric's latest PR. Simulation is completely printed instead of just the name. Fixing this in this PR.

## Relevant motivation and context
Make print statement correct

## How to test 
Run `warming_levels.ipynb` with this PR and confirm that the output for warming level data not being completely available looks like the following instead of printing an entire DataArray object:

![image](https://github.com/user-attachments/assets/c03c210e-a607-4d6b-a428-06b93f32f6b3)


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
