### PR TITLE
Revert add_dummy_time_to_wl code to previous method

### DIFF
--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -264,7 +264,7 @@ def _metric_agg(
 
     # If the data passed in is warming level data, then a dummy timestamp must be added to act as the current WL 'time' dimension
     if approach == "Warming Level":
-        da = add_dummy_time_to_wl(da, time_delta=True)
+        da = add_dummy_time_to_wl(da)
 
     metric_data = _apply_metric(da)
     return metric_data

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -264,7 +264,7 @@ def _metric_agg(
 
     # If the data passed in is warming level data, then a dummy timestamp must be added to act as the current WL 'time' dimension
     if approach == "Warming Level":
-        da = add_dummy_time_to_wl(da)
+        da = add_dummy_time_to_wl(da, time_delta=True)
 
     metric_data = _apply_metric(da)
     return metric_data

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -892,7 +892,6 @@ def add_dummy_time_to_wl(wl_da):
         time_freq_name = wl_time_dim.split("_")[0]
         name_to_freq = {"hours": "h", "days": "D", "months": "ME"}
 
-
     # Creating dummy timestamps
     timestamps = pd.date_range(
         "2000-01-01",

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -883,17 +883,15 @@ def add_dummy_time_to_wl(wl_da):
             "DataArray does not contain necessary warming level information."
         )
 
-    # Finding time frequency
-    if wl_time_dim == "time_delta":
-        time_freq_name = wl_da.frequency
-    else:
-        time_freq_name = wl_time_dim.split("_")[0]
-
+    # Finding time frequency and
     # Creating map from frequency name to freq var needed for pandas date range
     if wl_time_dim == "time_delta":
+        time_freq_name = wl_da.frequency
         name_to_freq = {"hourly": "h", "daily": "D", "monthly": "ME"}
     else:
-        name_to_freq = {"hours": "H", "days": "D", "months": "ME"}
+        time_freq_name = wl_time_dim.split("_")[0]
+        name_to_freq = {"hours": "h", "days": "D", "months": "ME"}
+
 
     # Creating dummy timestamps
     timestamps = pd.date_range(

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -870,19 +870,19 @@ def add_dummy_time_to_wl(wl_da, time_delta=False):
     """
     # Adjusting the time index into dummy time-series for counting
     # Finding time-based dimension
-    if (time_delta):
+    if time_delta:
         wl_time_dim = "time_delta"
     else:
         wl_time_dim = [dim for dim in wl_da.dims if "from_center" in dim][0]
 
     # Finding time frequency
-    if (time_delta):
+    if time_delta:
         time_freq_name = wl_da.frequency
     else:
         time_freq_name = wl_time_dim.split("_")[0]
 
     # Creating map from frequency name to freq var needed for pandas date range
-    if (time_delta):
+    if time_delta:
         name_to_freq = {"hourly": "h", "daily": "D", "monthly": "ME"}
     else:
         name_to_freq = {"hours": "H", "days": "D", "months": "ME"}

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -870,13 +870,16 @@ def add_dummy_time_to_wl(wl_da):
     """
     # Adjusting the time index into dummy time-series for counting
     # Finding time-based dimension
+    wl_time_dim = ""
+
     for dim in wl_da.dims:
         if dim == "time_delta":
             wl_time_dim = "time_delta"
         elif "from_center" in dim:
             wl_time_dim = dim
-        else:
-            raise ValueError("DataArray does not contain necessary warming level information.")
+
+    if wl_time_dim == "":
+        raise ValueError("DataArray does not contain necessary warming level information.")
 
     # Finding time frequency
     if wl_time_dim == "time_delta":

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -868,21 +868,26 @@ def add_dummy_time_to_wl(wl_da):
     - It supports creating dummy time series with frequencies of hours, days, or months, based on the prefix of the dimension name.
     - The dummy time series starts from "2000-01-01".
     """
+    # Adjusting the time index into dummy time-series for counting
+    # Finding time-based dimension
+    wl_time_dim = [dim for dim in wl_da.dims if "from_center" in dim][0]
+
+    # Finding time frequency ("hours", "days", "months")
+    time_freq_name = wl_time_dim.split("_")[0]
+
     # Creating map from frequency name to freq var needed for pandas date range
-    name_to_freq = {"hourly": "h", "daily": "D", "monthly": "ME"}
+    name_to_freq = {"hours": "H", "days": "D", "months": "ME"}
 
     # Creating dummy timestamps
     timestamps = pd.date_range(
         "2000-01-01",
-        periods=len(wl_da["time_delta"]),
-        freq=name_to_freq[wl_da.frequency],
+        periods=len(wl_da[wl_time_dim]),
+        freq=name_to_freq[time_freq_name],
     )
 
     # Replacing WL timestamps with dummy timestamps so that calculations from tools like `thresholds_tools`
     # can be computed on a DataArray with a time dimension
-    wl_da = wl_da.assign_coords({"time_delta": timestamps}).rename(
-        {"time_delta": "time"}
-    )
+    wl_da = wl_da.assign_coords({wl_time_dim: timestamps}).rename({wl_time_dim: "time"})
     return wl_da
 
 

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -879,7 +879,9 @@ def add_dummy_time_to_wl(wl_da):
             wl_time_dim = dim
 
     if wl_time_dim == "":
-        raise ValueError("DataArray does not contain necessary warming level information.")
+        raise ValueError(
+            "DataArray does not contain necessary warming level information."
+        )
 
     # Finding time frequency
     if wl_time_dim == "time_delta":


### PR DESCRIPTION
## Summary of changes and related issue

Revert `add_dummy_time_to_wl` function to original design. Function was changed to look for `time_delta` instead of `{time_freq}_from_center`.  `WarmingLevels` `sliced_data` DataArray uses this later time dimension.

## Relevant motivation and context

Fixes broken `warming_level_approach` notebook.

## How to test 

Run the `warming_level_approach` notebook with this branch loaded for `climakitae`. Plus load the `fix_wl_plot2` branch for `climakitaegui` to fix the visualization plots.

## Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ x ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ x ] Any notebooks known to utilize the affected functions are still working
- [ x ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
