### PR TITLE
fixed area mean

### DIFF
--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -49,7 +49,7 @@ def area_average(dset):
     weights = np.cos(np.deg2rad(dset.lat))
     if set(["x", "y"]).issubset(set(dset.dims)):
         # WRF data has x,y
-        dset = dset.weighted(weights).mean(["x","y"])
+        dset = dset.weighted(weights).mean(["x", "y"])
     elif set(["lat", "lon"]).issubset(set(dset.dims)):
         # LOCA data has lat, lon
         dset = dset.weighted(weights).mean(["lat", "lon"])

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -52,7 +52,7 @@ def area_average(dset):
         dset = dset.weighted(weights).mean("x").mean("y")
     elif set(["lat", "lon"]).issubset(set(dset.dims)):
         # LOCA data has lat, lon
-        dset = dset.weighted(weights).mean(["lat","lon"])
+        dset = dset.weighted(weights).mean(["lat", "lon"])
     return dset
 
 

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -49,7 +49,7 @@ def area_average(dset):
     weights = np.cos(np.deg2rad(dset.lat))
     if set(["x", "y"]).issubset(set(dset.dims)):
         # WRF data has x,y
-        dset = dset.weighted(weights).mean("x").mean("y")
+        dset = dset.weighted(weights).mean(["x","y"])
     elif set(["lat", "lon"]).issubset(set(dset.dims)):
         # LOCA data has lat, lon
         dset = dset.weighted(weights).mean(["lat", "lon"])

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -52,7 +52,7 @@ def area_average(dset):
         dset = dset.weighted(weights).mean("x").mean("y")
     elif set(["lat", "lon"]).issubset(set(dset.dims)):
         # LOCA data has lat, lon
-        dset = dset.weighted(weights).mean("lat").mean("lon")
+        dset = dset.weighted(weights).mean(["lat","lon"])
     return dset
 
 

--- a/tests/create_test_dataset.py
+++ b/tests/create_test_dataset.py
@@ -154,7 +154,7 @@ print("COMPLETE.")
 
 # Area average?
 if area_average == "Yes":
-    test_dataset = test_dataset.mean("x").mean("y")
+    test_dataset = test_dataset.mean(["x", "y"])
 
 # Load lazy dask data
 print("Loading data...", end="")

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -24,7 +24,7 @@ def test_TSP(rootdir):
 
     # Compute area average
     weights = np.cos(np.deg2rad(test_data.lat))
-    test_data = test_data.weighted(weights).mean("x").mean("y")
+    test_data = test_data.weighted(weights).mean(["x", "y"])
 
     ts = tst.TimeSeries(test_data)  # make Timeseries object
     return ts.choices  # return the underlying TimeSeriesParams object for testing


### PR DESCRIPTION
## Summary of changes and related issue
Fixed area weighted average function, and two other places in tests that area mean was taken incorrectly

## Relevant motivation and context
Function for taking area weighted mean took lat and lon means consecutively rather than simultaneously, which can produce incorrect results.


## How to test 
Try taking a mean with the function

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [X] Black formatting has been utilized
- [X] Tagged/notified 2 reviewers for this PR
