### PR TITLE
Test for util/generate_gwl_tables.py

### DIFF
--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -215,7 +215,7 @@ def main():
                 wl_ts = scenario[scenario >= degree].index[0]
                 return wl_ts
             else:
-                return np.NaN
+                return np.nan
 
         gwl = smoothed.apply(lambda scenario: get_wl_timestamp(scenario, degree))
         return gwl
@@ -553,9 +553,7 @@ def get_sims_on_aws(df: pd.DataFrame) -> pd.DataFrame:
                 & (df.source_id == model)
             ]
             ensMembers = list(set(df_scenario.member_id))
-            # TODO: This line throws a warning ChainedAssignmentError
-            # Use `df.loc[row_indexer, "col"] = values`
-            sims_on_aws[scenario][model] = ensMembers
+            sims_on_aws.loc[model,scenario] = ensMembers
 
     # cut the table to those GCMs that have a historical + at least one SSP ensemble member
     for i, item in enumerate(sims_on_aws.T.columns):

--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -88,7 +88,7 @@ def main():
         return timeseries
 
     def buildDFtimeSeries_cesm2(
-        variable: str, model: str, ens_mem: str, scenarios: list
+        variable: str, model: str, ens_mem: str, scenarios: list[str]
     ) -> xr.Dataset:
         """
         Builds a global temperature time series by weighting latitudes and averaging longitudes
@@ -396,7 +396,7 @@ def main():
     def get_gwl_table(
         variable: str,
         model: str,
-        scenarios: list,
+        scenarios: list[str],
         start_year: str = "18500101",
         end_year: str = "19000101",
     ) -> tuple:

--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -122,7 +122,7 @@ def main():
         return data_one_model
 
     def build_timeseries(
-        variable: str, model: str, ens_mem: str, scenarios: list
+        variable: str, model: str, ens_mem: str, scenarios: list[str]
     ) -> xr.Dataset:
         """
         Builds an xarray Dataset with a time dimension, containing the concatenated historical
@@ -233,7 +233,7 @@ def main():
         scenarios: list,
         start_year: str = "18500101",
         end_year: str = "19000101",
-    ) -> tuple:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Generates a GWL lookup table for one ensemble member of CESM2.
 
@@ -282,7 +282,7 @@ def main():
         scenarios: list,
         start_year: str = "18500101",
         end_year: str = "19000101",
-    ) -> tuple:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Generates a GWL table for the CESM2 model.
 
@@ -328,10 +328,10 @@ def main():
         variable: str,
         model: str,
         ens_mem: str,
-        scenarios: list,
+        scenarios: list[str],
         start_year: str = "18500101",
         end_year: str = "19000101",
-    ) -> tuple:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Generates a GWL table for a single model and ensemble member.
 
@@ -401,7 +401,7 @@ def main():
         scenarios: list[str],
         start_year: str = "18500101",
         end_year: str = "19000101",
-    ) -> tuple:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Generates a GWL table for a given model and scenarios.
 

--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -58,7 +58,7 @@ def main():
     }
     ens_mem_cesm_rev = dict([(v, k) for k, v in ens_mems_cesm.items()])
 
-    def make_weighted_timeseries(temp):
+    def make_weighted_timeseries(temp: xr.DataArray) -> xr.DataArray:
         """
         Creates a spatially-weighted single-dimension time series of global temperature.
 
@@ -87,7 +87,7 @@ def main():
         timeseries = (temp * weightlat).sum(lat).mean(lon)
         return timeseries
 
-    def buildDFtimeSeries_cesm2(variable, model, ens_mem, scenarios):
+    def buildDFtimeSeries_cesm2(variable: str, model: str, ens_mem: str, scenarios: list) -> xr.Dataset:
         """
         Builds a global temperature time series by weighting latitudes and averaging longitudes
         for the CESM2 model across specified scenarios from 1980 to 2100.
@@ -119,7 +119,7 @@ def main():
             data_one_model[scenario] = timeseries
         return data_one_model
 
-    def build_timeseries(variable, model, ens_mem, scenarios):
+    def build_timeseries(variable: str, model: str, ens_mem: str, scenarios: list) -> xr.Dataset:
         """
         Builds an xarray Dataset with a time dimension, containing the concatenated historical
         and SSP time series for all specified scenarios of a given model and ensemble member.
@@ -187,7 +187,7 @@ def main():
                         )  # .to_pandas())
         return data_one_model
 
-    def get_gwl(smoothed, degree):
+    def get_gwl(smoothed: pd.DataFrame, degree: float) -> pd.DataFrame:
         """
         Computes the timestamp when a given GWL is first reached.
         Takes a smoothed time series of global mean temperature of different scenarios for a model
@@ -221,8 +221,8 @@ def main():
         return gwl
 
     def get_table_one_cesm2(
-        variable, model, ens_mem, scenarios, start_year="18500101", end_year="19000101"
-    ):
+        variable: str, model: str, ens_mem: str, scenarios: list, start_year: str = "18500101", end_year: str = "19000101"
+    ) -> tuple:
         """
         Generates a GWL lookup table for one ensemble member of CESM2.
 
@@ -266,8 +266,8 @@ def main():
         return gwlevels, final_model
 
     def get_table_cesm2(
-        variable, model, scenarios, start_year="18500101", end_year="19000101"
-    ):
+        variable: str, model: str, scenarios: list, start_year: str = "18500101", end_year: str = "19000101"
+    ) -> tuple:
         """
         Generates a GWL table for the CESM2 model.
 
@@ -310,8 +310,8 @@ def main():
         )
 
     def get_gwl_table_one(
-        variable, model, ens_mem, scenarios, start_year="18500101", end_year="19000101"
-    ):
+        variable: str, model: str, ens_mem: str, scenarios: list, start_year: str = "18500101", end_year: str = "19000101"
+    ) -> tuple:
         """
         Generates a GWL table for a single model and ensemble member.
 
@@ -376,8 +376,8 @@ def main():
         return gwlevels, final_model
 
     def get_gwl_table(
-        variable, model, scenarios, start_year="18500101", end_year="19000101"
-    ):
+        variable: str, model: str, scenarios: list, start_year: str = "18500101", end_year: str = "19000101"
+    ) -> tuple:
         """
         Generates a GWL table for a given model and scenarios.
 
@@ -553,6 +553,8 @@ def get_sims_on_aws(df: pd.DataFrame) -> pd.DataFrame:
                 & (df.source_id == model)
             ]
             ensMembers = list(set(df_scenario.member_id))
+            # TODO: This line throws a warning ChainedAssignmentError
+            # Use `df.loc[row_indexer, "col"] = values`
             sims_on_aws[scenario][model] = ensMembers
 
     # cut the table to those GCMs that have a historical + at least one SSP ensemble member

--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -230,7 +230,7 @@ def main():
         variable: str,
         model: str,
         ens_mem: str,
-        scenarios: list,
+        scenarios: list[str],
         start_year: str = "18500101",
         end_year: str = "19000101",
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
@@ -279,7 +279,7 @@ def main():
     def get_table_cesm2(
         variable: str,
         model: str,
-        scenarios: list,
+        scenarios: list[str],
         start_year: str = "18500101",
         end_year: str = "19000101",
     ) -> tuple[pd.DataFrame, pd.DataFrame]:

--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -511,7 +511,7 @@ def main():
         )
 
 
-def get_sims_on_aws(df):
+def get_sims_on_aws(df: pd.DataFrame) -> pd.DataFrame:
     """
     Generates a pandas DataFrame listing all relevant CMIP6 simulations available on AWS.
 

--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -87,7 +87,9 @@ def main():
         timeseries = (temp * weightlat).sum(lat).mean(lon)
         return timeseries
 
-    def buildDFtimeSeries_cesm2(variable: str, model: str, ens_mem: str, scenarios: list) -> xr.Dataset:
+    def buildDFtimeSeries_cesm2(
+        variable: str, model: str, ens_mem: str, scenarios: list
+    ) -> xr.Dataset:
         """
         Builds a global temperature time series by weighting latitudes and averaging longitudes
         for the CESM2 model across specified scenarios from 1980 to 2100.
@@ -119,7 +121,9 @@ def main():
             data_one_model[scenario] = timeseries
         return data_one_model
 
-    def build_timeseries(variable: str, model: str, ens_mem: str, scenarios: list) -> xr.Dataset:
+    def build_timeseries(
+        variable: str, model: str, ens_mem: str, scenarios: list
+    ) -> xr.Dataset:
         """
         Builds an xarray Dataset with a time dimension, containing the concatenated historical
         and SSP time series for all specified scenarios of a given model and ensemble member.
@@ -221,7 +225,12 @@ def main():
         return gwl
 
     def get_table_one_cesm2(
-        variable: str, model: str, ens_mem: str, scenarios: list, start_year: str = "18500101", end_year: str = "19000101"
+        variable: str,
+        model: str,
+        ens_mem: str,
+        scenarios: list,
+        start_year: str = "18500101",
+        end_year: str = "19000101",
     ) -> tuple:
         """
         Generates a GWL lookup table for one ensemble member of CESM2.
@@ -266,7 +275,11 @@ def main():
         return gwlevels, final_model
 
     def get_table_cesm2(
-        variable: str, model: str, scenarios: list, start_year: str = "18500101", end_year: str = "19000101"
+        variable: str,
+        model: str,
+        scenarios: list,
+        start_year: str = "18500101",
+        end_year: str = "19000101",
     ) -> tuple:
         """
         Generates a GWL table for the CESM2 model.
@@ -310,7 +323,12 @@ def main():
         )
 
     def get_gwl_table_one(
-        variable: str, model: str, ens_mem: str, scenarios: list, start_year: str = "18500101", end_year: str = "19000101"
+        variable: str,
+        model: str,
+        ens_mem: str,
+        scenarios: list,
+        start_year: str = "18500101",
+        end_year: str = "19000101",
     ) -> tuple:
         """
         Generates a GWL table for a single model and ensemble member.
@@ -376,7 +394,11 @@ def main():
         return gwlevels, final_model
 
     def get_gwl_table(
-        variable: str, model: str, scenarios: list, start_year: str = "18500101", end_year: str = "19000101"
+        variable: str,
+        model: str,
+        scenarios: list,
+        start_year: str = "18500101",
+        end_year: str = "19000101",
     ) -> tuple:
         """
         Generates a GWL table for a given model and scenarios.
@@ -553,7 +575,7 @@ def get_sims_on_aws(df: pd.DataFrame) -> pd.DataFrame:
                 & (df.source_id == model)
             ]
             ensMembers = list(set(df_scenario.member_id))
-            sims_on_aws.loc[model,scenario] = ensMembers
+            sims_on_aws.loc[model, scenario] = ensMembers
 
     # cut the table to those GCMs that have a historical + at least one SSP ensemble member
     for i, item in enumerate(sims_on_aws.T.columns):
@@ -571,7 +593,7 @@ def get_sims_on_aws(df: pd.DataFrame) -> pd.DataFrame:
             for ssp in ["ssp585", "ssp370", "ssp245", "ssp126"]:
                 if str(variant) in sims_on_aws.loc[item][ssp]:
                     variants_to_keep.append(variant)
-        sims_on_aws.loc[item]["historical"] = list(set(variants_to_keep))
+        sims_on_aws.loc[item, "historical"] = list(set(variants_to_keep))
 
     return sims_on_aws
 

--- a/climakitae/util/generate_gwl_tables.py
+++ b/climakitae/util/generate_gwl_tables.py
@@ -210,7 +210,9 @@ def main():
             A table containing timestamps for when each scenario first crosses the specified warming level.
         """
 
-        def get_wl_timestamp(scenario, degree):
+        def get_wl_timestamp(
+            scenario: pd.Series, degree: float
+        ) -> cftime.DatetimeNoLeap | float:
             """
             Given a scenario of wl's and timestamps, find the timestamp that first crosses the degree passed in.
             Return np.NaN if none of the timestamps pass this degree level.

--- a/tests/util/test_generate_gwl_tables.py
+++ b/tests/util/test_generate_gwl_tables.py
@@ -9,16 +9,14 @@ from climakitae.util.generate_gwl_tables import get_sims_on_aws
 def test_get_sims_on_aws():
     """Check that expected scenarios and models are returned."""
     df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
-    df_subset = df[
-        (df.table_id == "Amon")
-        & (df.variable_id == "tas")
-        & (df.experiment_id == "historical")
-    ]
     sims_on_aws = get_sims_on_aws(df)
-    rows = sims_on_aws.index.tolist()
     cols = sims_on_aws.columns.tolist()
 
     for scenario in ["historical", "ssp585", "ssp370", "ssp245", "ssp126"]:
         assert scenario in cols
 
     assert sims_on_aws["historical"]["TaiESM1"] == ["r1i1p1f1"]
+    assert sims_on_aws["ssp585"]["MPI-ESM1-2-HR"] == ["r1i1p1f1", "r2i1p1f1"]
+    assert sims_on_aws["ssp370"]["GFDL-CM4"] == []
+    assert len(sims_on_aws["ssp245"]["ACCESS-ESM1-5"]) == 10
+    assert sims_on_aws["ssp126"]["CESM2"] == ["r11i1p1f1", "r4i1p1f1", "r10i1p1f1"]

--- a/tests/util/test_generate_gwl_tables.py
+++ b/tests/util/test_generate_gwl_tables.py
@@ -24,4 +24,4 @@ def test_get_sims_on_aws():
     assert len(sims_on_aws["ssp245"]["ACCESS-ESM1-5"]) == 10
     test_data = sims_on_aws["ssp126"]["CESM2"]
     test_data.sort()
-    assert  test_data == ["r10i1p1f1", "r11i1p1f1", "r4i1p1f1"]
+    assert test_data == ["r10i1p1f1", "r11i1p1f1", "r4i1p1f1"]

--- a/tests/util/test_generate_gwl_tables.py
+++ b/tests/util/test_generate_gwl_tables.py
@@ -1,0 +1,22 @@
+"""Tests capability to read CMIP6 simulation information from aws"""
+
+import pytest
+import pandas as pd
+from climakitae.util.generate_gwl_tables import get_sims_on_aws
+
+def test_get_sims_on_aws():
+    """Check that all expected scenarios and models are returned."""
+    df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
+    df_subset = df[
+        (df.table_id == "Amon")
+        & (df.variable_id == "tas")
+        & (df.experiment_id == "historical")
+    ]
+    sims_on_aws = get_sims_on_aws(df)
+    rows = sims_on_aws.index.tolist()
+    cols = sims_on_aws.columns.tolist()
+
+    for scenario in ["historical", "ssp585", "ssp370", "ssp245", "ssp126"]:
+        assert scenario in cols
+
+    assert sims_on_aws["historical"]["TaiESM1"] == ["r1i1p1f1"]

--- a/tests/util/test_generate_gwl_tables.py
+++ b/tests/util/test_generate_gwl_tables.py
@@ -15,6 +15,7 @@ def test_get_sims_on_aws():
     for scenario in ["historical", "ssp585", "ssp370", "ssp245", "ssp126"]:
         assert scenario in cols
 
+    # Spot checking each scenario
     assert sims_on_aws["historical"]["TaiESM1"] == ["r1i1p1f1"]
     assert sims_on_aws["ssp585"]["MPI-ESM1-2-HR"] == ["r1i1p1f1", "r2i1p1f1"]
     assert sims_on_aws["ssp370"]["GFDL-CM4"] == []

--- a/tests/util/test_generate_gwl_tables.py
+++ b/tests/util/test_generate_gwl_tables.py
@@ -1,8 +1,10 @@
 """Tests capability to read CMIP6 simulation information from aws"""
 
-import pytest
 import pandas as pd
+import pytest
+
 from climakitae.util.generate_gwl_tables import get_sims_on_aws
+
 
 def test_get_sims_on_aws():
     """Check that all expected scenarios and models are returned."""

--- a/tests/util/test_generate_gwl_tables.py
+++ b/tests/util/test_generate_gwl_tables.py
@@ -17,7 +17,11 @@ def test_get_sims_on_aws():
 
     # Spot checking each scenario
     assert sims_on_aws["historical"]["TaiESM1"] == ["r1i1p1f1"]
-    assert sims_on_aws["ssp585"]["MPI-ESM1-2-HR"] == ["r1i1p1f1", "r2i1p1f1"]
+    test_data = sims_on_aws["ssp585"]["MPI-ESM1-2-HR"]
+    test_data.sort()
+    assert test_data == ["r1i1p1f1", "r2i1p1f1"]
     assert sims_on_aws["ssp370"]["GFDL-CM4"] == []
     assert len(sims_on_aws["ssp245"]["ACCESS-ESM1-5"]) == 10
-    assert sims_on_aws["ssp126"]["CESM2"] == ["r11i1p1f1", "r4i1p1f1", "r10i1p1f1"]
+    test_data = sims_on_aws["ssp126"]["CESM2"]
+    test_data.sort()
+    assert  test_data == ["r10i1p1f1", "r11i1p1f1", "r4i1p1f1"]

--- a/tests/util/test_generate_gwl_tables.py
+++ b/tests/util/test_generate_gwl_tables.py
@@ -7,7 +7,7 @@ from climakitae.util.generate_gwl_tables import get_sims_on_aws
 
 
 def test_get_sims_on_aws():
-    """Check that all expected scenarios and models are returned."""
+    """Check that expected scenarios and models are returned."""
     df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
     df_subset = df[
         (df.table_id == "Amon")


### PR DESCRIPTION
## Summary of changes and related issue
I added a test for the function get_sims_on_aws() in generate_gwl_tables.py. This only gets coverage to 19% (184 statements, 149 missing). The main() function does not look straightforward to test in its current form, but could possibly be refactored for better testing.
I also have added type hints and fixes for a pandas ChainedAssignment warning and numpy np.NaN warning.

## Relevant motivation and context
This work improves the test coverage of generate_gwl_tables.py.

## How to test 
```
pip install pytest-cov
pytest tests/util/ --cov=climakitae.util.generate_gwl_tables --cov-report term-missing  # VSCode terminal
pytest tests/util/ --cov=util.generate_gwl_tables --cov-report term-missing              # Jupyter Hub
```
I don't see any notebooks that use this particular script.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
