### PR TITLE
Test Coverage for `util.dev_logging`

### DIFF
--- a/climakitae/util/dev_logging.py
+++ b/climakitae/util/dev_logging.py
@@ -128,4 +128,3 @@ def _disable_lib_logging(module: types.ModuleType):
             original_func = res.__wrapped__
             setattr(module, name, original_func)
             delattr(res, "_is_logged")
-    return

--- a/climakitae/util/dev_logging.py
+++ b/climakitae/util/dev_logging.py
@@ -25,7 +25,6 @@ Some limitations of this logger include:
 
 """
 
-import importlib
 import time
 import types
 
@@ -74,7 +73,7 @@ def _log(func: types.FunctionType) -> types.FunctionType:
     return _wrapper
 
 
-def _enable_lib_logging(obj: types.ModuleType):
+def enable_lib_logging(obj: types.ModuleType):
     """
     Adds the `log` wrapper to all functions and sub-classes within the given module or class.
 
@@ -108,12 +107,12 @@ def _enable_lib_logging(obj: types.ModuleType):
                     and res.__module__[:10] == "climakitae"
                 ):
                     # Recursively add logging wrapper to any classes within the passed in module/class.
-                    _enable_lib_logging(res)
+                    enable_lib_logging(res)
     else:
         print("Error: Current object is not a module object.")
 
 
-def _disable_lib_logging(module: types.ModuleType):
+def disable_lib_logging(module: types.ModuleType):
     """
     Removes the `log` wrapper to all functions within the given module.
 

--- a/climakitae/util/dev_logging.py
+++ b/climakitae/util/dev_logging.py
@@ -49,7 +49,7 @@ def _log(func: types.FunctionType) -> types.FunctionType:
         The wrapped function with logging capabilities.
     """
 
-    def _wrapper(*args, **kwargs):
+    def _wrapper(*args, **kwargs) -> types.FunctionType:
         """
         Wraps timer and print statement around functions if `lib_log_enabled` is True,
         otherwise return the function's result.
@@ -62,7 +62,7 @@ def _log(func: types.FunctionType) -> types.FunctionType:
         indentation_level -= 1
         end_time = time.time()
         print(
-            "    " * indentation_level
+            "\t" * indentation_level
             + f"Execution time for {func.__name__}: {end_time - start_time:.4g}"
         )
         return results

--- a/climakitae/util/dev_logging.py
+++ b/climakitae/util/dev_logging.py
@@ -25,22 +25,36 @@ Some limitations of this logger include:
 
 """
 
+import importlib
 import time
 import types
-import importlib
 
 # Controls the amount of indentation for library logging
 indentation_level = 0
 
 
-def _log(func):
+def _log(func: types.FunctionType) -> types.FunctionType:
     """
-    Wraps around existing functions, adding print statements upon execution and the amount of time it takes for execution. Allows function's call-stack to be viewed for all sub-functions that also have this wrapper.
+    Wraps around existing functions, adding print statements upon execution and the
+    amount of time it takes for execution. Allows function's call-stack to be viewed
+    for all sub-functions that also have this wrapper.
+
+    Parameters
+    ----------
+    func: types.FunctionType
+        The function to be wrapped.
+
+    Returns
+    -------
+    function
+        The wrapped function with logging capabilities.
     """
 
     def _wrapper(*args, **kwargs):
-        """Wraps timer and print statement around functions if `lib_log_enabled` is True, otherwise
-        just return the function's result."""
+        """
+        Wraps timer and print statement around functions if `lib_log_enabled` is True,
+        otherwise return the function's result.
+        """
         global indentation_level
         start_time = time.time()
         print("    " * indentation_level + f"Executing function: {func.__name__}")
@@ -54,11 +68,15 @@ def _log(func):
         )
         return results
 
+    # Set the wrapper's attributes to maintain the original function's metadata
+    _wrapper.__wrapped__ = func
+    _wrapper._is_logged = True
     return _wrapper
 
 
-def _enable_lib_logging(obj):
-    """Adds the `log` wrapper to all functions and sub-classes within the given module or class.
+def _enable_lib_logging(obj: types.ModuleType):
+    """
+    Adds the `log` wrapper to all functions and sub-classes within the given module or class.
 
     Parameters
     ----------
@@ -70,9 +88,8 @@ def _enable_lib_logging(obj):
             res = getattr(obj, name)
 
             # Initial logic to prevent loggers from double wrapping functions
-            if "__name__" in dir(res):
-                if res.__name__ == "wrapper":
-                    continue
+            if hasattr(res, "_is_logged"):
+                continue
 
             # Do not add loggers to any built-in functions
             if not name.startswith("__") and not name.endswith("__"):
@@ -96,11 +113,19 @@ def _enable_lib_logging(obj):
         print("Error: Current object is not a module object.")
 
 
-def _disable_lib_logging(module):
+def _disable_lib_logging(module: types.ModuleType):
     """
     Removes the `log` wrapper to all functions within the given module.
+
+    Parameters
+    ----------
+    module: types.ModuleType (module)
+        The module to remove the logger from.
     """
-    # Currently, in order to remove the logger from all decorated functions, you will need to reload the module.
-    # I have tried to reference a `__wrapped__` attribute on wrapped functions, but they don't seem to exist.
-    importlib.reload(module)
+    for name in dir(module):
+        res = getattr(module, name)
+        if hasattr(res, "_is_logged"):
+            original_func = res.__wrapped__
+            setattr(module, name, original_func)
+            delattr(res, "_is_logged")
     return

--- a/tests/util/test_dev_logging.py
+++ b/tests/util/test_dev_logging.py
@@ -67,7 +67,7 @@ class TestEnableLibLogging:
     def test_recursive_class_logging(self, mock_module_with_class: types.ModuleType):
         """Test that _enable_lib_logging recursively adds logging to class methods."""
         # Enable logging on the module
-        dev_logging._enable_lib_logging(mock_module_with_class)
+        dev_logging.enable_lib_logging(mock_module_with_class)
 
         # Check if the standalone function was wrapped
         assert hasattr(mock_module_with_class.standalone_function, "_is_logged")
@@ -84,7 +84,7 @@ class TestEnableLibLogging:
             assert result == "class method result"
 
     def test_enable_lib_logging(self, mock_module: types.ModuleType):
-        dev_logging._enable_lib_logging(mock_module)
+        dev_logging.enable_lib_logging(mock_module)
         assert hasattr(mock_module.mock_function, "_is_logged")
 
         with patch("builtins.print") as mock_print:
@@ -93,18 +93,18 @@ class TestEnableLibLogging:
 
     def test_enable_lib_logging_non_module(self):
         with patch("builtins.print") as mock_print:
-            dev_logging._enable_lib_logging("not_a_module")
+            dev_logging.enable_lib_logging("not_a_module")
             mock_print.assert_called_with(
                 "Error: Current object is not a module object."
             )
 
     def test_already_wrapped(self, mock_module: types.ModuleType):
         # Enable logging once
-        dev_logging._enable_lib_logging(mock_module)
+        dev_logging.enable_lib_logging(mock_module)
         original_function = mock_module.mock_function
 
         # Enable logging again - should not wrap again
-        dev_logging._enable_lib_logging(mock_module)
+        dev_logging.enable_lib_logging(mock_module)
         assert mock_module.mock_function == original_function
 
 
@@ -128,10 +128,10 @@ class TestDisableLibLogging:
 
     def test_disable_lib_logging(self, mock_module: types.ModuleType):
         # First, enable logging
-        dev_logging._enable_lib_logging(mock_module)
+        dev_logging.enable_lib_logging(mock_module)
         assert hasattr(mock_module.mock_function, "_is_logged")
 
         # Then, disable logging
-        dev_logging._disable_lib_logging(mock_module)
+        dev_logging.disable_lib_logging(mock_module)
         assert not hasattr(mock_module.mock_function, "_is_logged")
         assert mock_module.mock_function() == "original"

--- a/tests/util/test_dev_logging.py
+++ b/tests/util/test_dev_logging.py
@@ -1,0 +1,137 @@
+import types
+from unittest.mock import patch
+
+import pytest
+
+from climakitae.util import dev_logging
+
+
+class TestLogDecorator:
+    def test_log_decorator(self):
+        @dev_logging._log
+        def test_function() -> str:
+            return "test"
+
+        with patch("builtins.print") as mock_print:
+            result = test_function()
+            assert result == "test"
+            assert mock_print.called
+
+
+class TestEnableLibLogging:
+    @pytest.fixture
+    def mock_module(self) -> types.ModuleType:
+        # Create a mock module for testing
+        mock_module = types.ModuleType("mock_module")
+        mock_module.__name__ = "mock_module"
+        mock_module.__module__ = "climakitae"
+        mock_module.__package__ = "climakitae"
+
+        def mock_function() -> str:
+            return "original"
+
+        # Set the __module__ attribute of the function properly
+        mock_function.__module__ = "climakitae.mock_module"
+
+        mock_module.mock_function = mock_function
+        return mock_module
+
+    @pytest.fixture
+    def mock_module_with_class(self, mock_module: types.ModuleType) -> types.ModuleType:
+        """Create a mock module with a class that has a method."""
+
+        class TestClass:
+            # Add a regular function at class level that will be detected during module inspection
+            def __init__(self):
+                pass
+
+            # Keep the staticmethod for consistency with existing tests
+            @staticmethod
+            def class_method() -> str:
+                return "class method result"
+
+        # Make a separate function that belongs to the class's module
+        def standalone_function() -> str:
+            return "standalone function result"
+
+        # Set proper module attributes
+        TestClass.__module__ = "climakitae.mock_module"
+        standalone_function.__module__ = "climakitae.mock_module"
+
+        # Add both to the module
+        mock_module.TestClass = TestClass
+        mock_module.standalone_function = standalone_function
+
+        return mock_module
+
+    def test_recursive_class_logging(self, mock_module_with_class: types.ModuleType):
+        """Test that _enable_lib_logging recursively adds logging to class methods."""
+        # Enable logging on the module
+        dev_logging._enable_lib_logging(mock_module_with_class)
+
+        # Check if the standalone function was wrapped
+        assert hasattr(mock_module_with_class.standalone_function, "_is_logged")
+
+        # Test that the function works and is logged
+        with patch("builtins.print") as mock_print:
+            result = mock_module_with_class.standalone_function()
+            assert result == "standalone function result"
+            assert mock_print.called
+            mock_print.reset_mock()
+
+            # We can still test the static method works, even if not directly wrapped
+            result = mock_module_with_class.TestClass.class_method()
+            assert result == "class method result"
+
+    def test_enable_lib_logging(self, mock_module: types.ModuleType):
+        dev_logging._enable_lib_logging(mock_module)
+        assert hasattr(mock_module.mock_function, "_is_logged")
+
+        with patch("builtins.print") as mock_print:
+            mock_module.mock_function()
+            assert mock_print.called
+
+    def test_enable_lib_logging_non_module(self):
+        with patch("builtins.print") as mock_print:
+            dev_logging._enable_lib_logging("not_a_module")
+            mock_print.assert_called_with(
+                "Error: Current object is not a module object."
+            )
+
+    def test_already_wrapped(self, mock_module: types.ModuleType):
+        # Enable logging once
+        dev_logging._enable_lib_logging(mock_module)
+        original_function = mock_module.mock_function
+
+        # Enable logging again - should not wrap again
+        dev_logging._enable_lib_logging(mock_module)
+        assert mock_module.mock_function == original_function
+
+
+class TestDisableLibLogging:
+    @pytest.fixture
+    def mock_module(self) -> types.ModuleType:
+        # Create a mock module for testing
+        mock_module = types.ModuleType("mock_module")
+        mock_module.__name__ = "mock_module"
+        mock_module.__module__ = "climakitae"
+        mock_module.__package__ = "climakitae"
+
+        def mock_function():
+            return "original"
+
+        # Set the __module__ attribute of the function properly
+        mock_function.__module__ = "climakitae.mock_module"
+
+        mock_module.mock_function = mock_function
+        return mock_module
+
+    def test_disable_lib_logging(self, mock_module: types.ModuleType):
+        # First, enable logging
+        dev_logging._enable_lib_logging(mock_module)
+        assert hasattr(mock_module.mock_function, "_is_logged")
+
+        # Then, disable logging
+        dev_logging._disable_lib_logging(mock_module)
+        assert not hasattr(mock_module.mock_function, "_is_logged")
+        assert mock_module.mock_function() == "original"


### PR DESCRIPTION
## Summary of changes and related issue
Added test coverage for `climakitae.util.dev_logging`
Also changed the structure of the `_log` function to add `__wrapped__` and `_is_logged` parameters to be able to catch wrapped functions and remove the wrapper later without having to reload the module.

## Relevant motivation and context
Test coverage is important. 
The other changes are motivated by code hygiene and philosophy. You shouldn't have to reload your module to remove the wrapped function.

## How to test 
```bash
pip install pytest-cov
pytest tests/util/test_dev_logging.py --cov=climakitae.util.dev_logging --cov-report term-missing
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name: NOTE removed functions from hidden state since they're supposed to be called by a user (even if that user is a dev).
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
