### PR TITLE
Add unit tests for explore/timeseries coverage

### DIFF
--- a/climakitae/explore/timeseries.py
+++ b/climakitae/explore/timeseries.py
@@ -18,7 +18,7 @@ class TimeSeriesParameters(param.Parameterized):
         [("hours", "h"), ("days", "D"), ("months", "MS"), ("years", "YS-SEP")]
     )
 
-    def __init__(self, dataset, **params):
+    def __init__(self, dataset: xr.Dataset, **params: param.Parameterized):
         super().__init__(**params)
         self.data = dataset
 
@@ -62,7 +62,7 @@ class TimeSeriesParameters(param.Parameterized):
         if self.remove_seasonal_cycle:
             self.anomaly = True
 
-    def transform_data(self):
+    def transform_data(self) -> xr.DataArray:
         """
         Returns a dataset that has been transformed in the ways that the params
         indicate, ready to plot in the preview window ("view" method of this
@@ -75,7 +75,7 @@ class TimeSeriesParameters(param.Parameterized):
         else:
             to_plot = self.data
 
-        def _get_anom(y):
+        def _get_anom(y: xr.Dataset) -> xr.DataArray:
             """
             Returns the difference with respect to the average across a historical range.
             """
@@ -93,7 +93,7 @@ class TimeSeriesParameters(param.Parameterized):
             else:
                 return y - y.sel(time=slice(*self.reference_range)).mean("time")
 
-        def _running_mean(y):
+        def _running_mean(y: xr.Dataset) -> xr.DataArray:
             # If timescale is monthly, need to weight the rolling average by the number of days in each month
             if y.attrs["frequency"] == "1month":
                 # Access the number of days in each month corresponding to each element of y
@@ -128,7 +128,7 @@ class TimeSeriesParameters(param.Parameterized):
             else:
                 to_plot = _running_mean(to_plot)
 
-        def _extremes_da(y):
+        def _extremes_da(y: xr.Dataset) -> xr.DataArray:
             plot_multiple = xr.Dataset()
             if "Max" in self.extremes:
                 plot_multiple["max"] = to_plot.resample(
@@ -153,8 +153,10 @@ class TimeSeriesParameters(param.Parameterized):
             return to_plot
 
 
-def _update_attrs(data_to_output, attrs_to_add):
-    """
+def _update_attrs(
+    data_to_output: xr.DataArray, attrs_to_add: dict[str, str]
+) -> xr.DataArray:
+    """]
     This function updates the attributes of the DataArray being output
     so that it contains new attributes that describe the transforms
     that were performed in the timeseries toolkit.
@@ -198,7 +200,7 @@ class TimeSeries:
     2) to save the transform represented by the current state of that preview into a new variable (output_current).
     """
 
-    def __init__(self, data):
+    def __init__(self, data: xr.DataArray):
         if (
             type(data) != xr.core.dataarray.DataArray
         ):  # Data is NOT in the form of xr.DataArray
@@ -226,7 +228,7 @@ class TimeSeries:
 
         self.choices = TimeSeriesParameters(data)
 
-    def output_current(self):
+    def output_current(self) -> xr.DataArray:
         """Output the current attributes of the class to a DataArray object.
         Allows the data to be easily accessed by the user after modifying the attributes directly in the explore panel, for example.
 

--- a/climakitae/explore/timeseries.py
+++ b/climakitae/explore/timeseries.py
@@ -303,6 +303,6 @@ class TimeSeries:
 
         """
         to_output = self.choices.transform_data()
-        attrs_to_add = dict(self.choices.get_param_values())
+        attrs_to_add = dict(self.choices.param.values())
         to_output = _update_attrs(to_output, attrs_to_add)
         return to_output

--- a/climakitae/explore/timeseries.py
+++ b/climakitae/explore/timeseries.py
@@ -100,7 +100,7 @@ class TimeSeriesParameters(param.Parameterized):
             self.anomaly = True
 
     def transform_data(self) -> xr.DataArray:
-        """
+        """Transform timeseries based on parameters.
         Returns a dataset that has been transformed in the ways that the params
         indicate, ready to plot in the preview window ("view" method of this
         class), or be saved out.
@@ -198,7 +198,7 @@ class TimeSeriesParameters(param.Parameterized):
 def _update_attrs(
     data_to_output: xr.DataArray, attrs_to_add: dict[str, str]
 ) -> xr.DataArray:
-    """
+    """Update DataArray attributes.
     This function updates the attributes of the DataArray being output
     so that it contains new attributes that describe the transforms
     that were performed in the timeseries toolkit.
@@ -261,7 +261,7 @@ class TimeSeries:
     Attributes
     ----------
     choices: TimeSeriesParameters
-        Object containing time series data and analysis parameters.
+        Param object containing time series data and analysis parameters.
 
     """
 

--- a/tests/timeseriestools/test_timeseriestools_daily.py
+++ b/tests/timeseriestools/test_timeseriestools_daily.py
@@ -1,3 +1,10 @@
+"""
+This script contains tests on various Timeseries Tools options using daily
+data. For now, the tests only test that the various parameter combinations can
+run through `transform_data` without error, and that the data has been transformed
+(not equal to original values), but does not test for exact expected values.
+"""
+
 import datetime as dt
 import os
 

--- a/tests/timeseriestools/test_timeseriestools_daily.py
+++ b/tests/timeseriestools/test_timeseriestools_daily.py
@@ -1,8 +1,10 @@
-import pytest
-import os
 import datetime as dt
+import os
+
 import numpy as np
+import pytest
 import xarray as xr
+
 import climakitae.explore.timeseries as tst
 
 # -------- Read in the test dataset and return a TimeSeriesParams object -------

--- a/tests/timeseriestools/test_timeseriestools_daily.py
+++ b/tests/timeseriestools/test_timeseriestools_daily.py
@@ -47,7 +47,7 @@ def test_daily_smoothing(test_TSP: tst.TimeSeriesParameters):
 # ------------- Test anomaly and smoothing together ----------------------------
 
 
-def test_daily_anomaly_and_smoothing(test_TSP):
+def test_daily_anomaly_and_smoothing(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.smoothing = "Running Mean"
     test_TSP.num_timesteps = 3

--- a/tests/timeseriestools/test_timeseriestools_daily.py
+++ b/tests/timeseriestools/test_timeseriestools_daily.py
@@ -18,6 +18,7 @@ def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
     test_data = (
         test_data.sel({"simulation": "cesm2"}).resample(time="1D").interpolate("linear")
     )
+    test_data.attrs["frequency"] = "daily"
 
     # Compute area average
     weights = np.cos(np.deg2rad(test_data.lat))
@@ -52,70 +53,6 @@ def test_daily_anomaly_and_smoothing(test_TSP):
     test_TSP.num_timesteps = 3
     test_TSP.anomaly = True
     test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
-
-
-# ------------- Test seasonal cycle removal w/ and w/o smoothing ---------------
-
-
-def test_seasonal(test_TSP):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.remove_seasonal_cycle = True
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
-
-
-def test_seasonal_and_smoothing(test_TSP):
-    # Specify Params options
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.anomaly = False
-    test_TSP.remove_seasonal_cycle = True
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
-
-
-# ------------- Test extremes options ------------------------------------------
-
-
-def test_extremes_smoothing(test_TSP):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.extremes = ["Min"]
-    test_TSP.resample_window = 2
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
-
-
-def test_extremes_min(test_TSP):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.extremes = ["Min"]
-    test_TSP.resample_window = 2
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
-
-
-def test_extremes_percentile(test_TSP):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.extremes = ["Percentile"]
-    test_TSP.resample_window = 2
-    test_TSP.percentile = 0.95
 
     # Transform data and test
     result = test_TSP.transform_data()

--- a/tests/timeseriestools/test_timeseriestools_daily.py
+++ b/tests/timeseriestools/test_timeseriestools_daily.py
@@ -42,27 +42,27 @@ def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
     return ts.choices  # return the underlying TimeSeriesParams object for testing
 
 
-def test_daily_smoothing(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.anomaly = False
+class TestTimeseriesDaily:
 
-    # Transform data and test
-    result = test_TSP.transform_data()  # transform_data calls _running_mean()
-    assert (result == test_TSP.data).sum().values.item() == 0
+    def test_daily_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.smoothing = "Running Mean"
+        test_TSP.num_timesteps = 3
+        test_TSP.anomaly = False
 
+        # Transform data and test
+        result = test_TSP.transform_data()  # transform_data calls _running_mean()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
-# ------------- Test anomaly and smoothing together ----------------------------
+    # ------------- Test anomaly and smoothing together ----------------------------
 
+    def test_daily_anomaly_and_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.smoothing = "Running Mean"
+        test_TSP.num_timesteps = 3
+        test_TSP.anomaly = True
+        test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
 
-def test_daily_anomaly_and_smoothing(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.anomaly = True
-    test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0

--- a/tests/timeseriestools/test_timeseriestools_daily.py
+++ b/tests/timeseriestools/test_timeseriestools_daily.py
@@ -1,0 +1,122 @@
+import pytest
+import os
+import datetime as dt
+import numpy as np
+import xarray as xr
+import climakitae.explore.timeseries as tst
+
+# -------- Read in the test dataset and return a TimeSeriesParams object -------
+
+
+@pytest.fixture
+def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
+    # This data is generated in "create_timeseries_test_data.py"
+    test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
+    test_filepath = os.path.join(rootdir, test_filename)
+    test_data = xr.open_dataset(test_filepath).T2
+    # Resample to daily frequency for single simulation
+    test_data = (
+        test_data.sel({"simulation": "cesm2"}).resample(time="1D").interpolate("linear")
+    )
+
+    # Compute area average
+    weights = np.cos(np.deg2rad(test_data.lat))
+    test_data = test_data.weighted(weights).mean("x").mean("y")
+
+    # Adding in some daily variability
+    rng = np.random.default_rng()
+    n = rng.uniform(-5, 5, (len(test_data.time),))
+    test_data = test_data + n
+
+    ts = tst.TimeSeries(test_data)  # make Timeseries object
+    return ts.choices  # return the underlying TimeSeriesParams object for testing
+
+
+def test_daily_smoothing(test_TSP: tst.TimeSeriesParameters):
+    # Specify Params options
+    test_TSP.smoothing = "Running Mean"
+    test_TSP.num_timesteps = 3
+    test_TSP.anomaly = False
+
+    # Transform data and test
+    result = test_TSP.transform_data()  # transform_data calls _running_mean()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
+# ------------- Test anomaly and smoothing together ----------------------------
+
+
+def test_daily_anomaly_and_smoothing(test_TSP):
+    # Specify Params options
+    test_TSP.smoothing = "Running Mean"
+    test_TSP.num_timesteps = 3
+    test_TSP.anomaly = True
+    test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
+# ------------- Test seasonal cycle removal w/ and w/o smoothing ---------------
+
+
+def test_seasonal(test_TSP):
+    # Specify Params options
+    test_TSP.anomaly = False
+    test_TSP.remove_seasonal_cycle = True
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
+def test_seasonal_and_smoothing(test_TSP):
+    # Specify Params options
+    test_TSP.smoothing = "Running Mean"
+    test_TSP.num_timesteps = 3
+    test_TSP.anomaly = False
+    test_TSP.remove_seasonal_cycle = True
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
+# ------------- Test extremes options ------------------------------------------
+
+
+def test_extremes_smoothing(test_TSP):
+    # Specify Params options
+    test_TSP.anomaly = False
+    test_TSP.smoothing = "Running Mean"
+    test_TSP.num_timesteps = 3
+    test_TSP.extremes = ["Min"]
+    test_TSP.resample_window = 2
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
+def test_extremes_min(test_TSP):
+    # Specify Params options
+    test_TSP.anomaly = False
+    test_TSP.extremes = ["Min"]
+    test_TSP.resample_window = 2
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
+def test_extremes_percentile(test_TSP):
+    # Specify Params options
+    test_TSP.anomaly = False
+    test_TSP.extremes = ["Percentile"]
+    test_TSP.resample_window = 2
+    test_TSP.percentile = 0.95
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0

--- a/tests/timeseriestools/test_timeseriestools_daily.py
+++ b/tests/timeseriestools/test_timeseriestools_daily.py
@@ -14,11 +14,10 @@ import xarray as xr
 
 import climakitae.explore.timeseries as tst
 
-# -------- Read in the test dataset and return a TimeSeriesParams object -------
-
 
 @pytest.fixture
 def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
+    """Read in the test dataset and return a TimeSeriesParams object."""
     # This data is generated in "create_timeseries_test_data.py"
     test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
     test_filepath = os.path.join(rootdir, test_filename)
@@ -45,6 +44,7 @@ def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
 class TestTimeseriesDaily:
 
     def test_daily_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        """Test running mean smoothing with daily data."""
         # Specify Params options
         test_TSP.smoothing = "Running Mean"
         test_TSP.num_timesteps = 3
@@ -54,9 +54,8 @@ class TestTimeseriesDaily:
         result = test_TSP.transform_data()  # transform_data calls _running_mean()
         assert (result == test_TSP.data).sum().values.item() == 0
 
-    # ------------- Test anomaly and smoothing together ----------------------------
-
     def test_daily_anomaly_and_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        """Test anomaly and smoothing together."""
         # Specify Params options
         test_TSP.smoothing = "Running Mean"
         test_TSP.num_timesteps = 3

--- a/tests/timeseriestools/test_timeseriestools_hourly.py
+++ b/tests/timeseriestools/test_timeseriestools_hourly.py
@@ -1,7 +1,9 @@
-import pytest
 import os
+
 import numpy as np
+import pytest
 import xarray as xr
+
 import climakitae.explore.timeseries as tst
 
 # -------- Read in the test dataset and return a TimeSeriesParams object -------

--- a/tests/timeseriestools/test_timeseriestools_hourly.py
+++ b/tests/timeseriestools/test_timeseriestools_hourly.py
@@ -1,0 +1,46 @@
+import pytest
+import os
+import datetime as dt
+import numpy as np
+import xarray as xr
+import climakitae.explore.timeseries as tst
+
+# -------- Read in the test dataset and return a TimeSeriesParams object -------
+
+
+@pytest.fixture
+def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
+    # This data is generated in "create_timeseries_test_data.py"
+    test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
+    test_filepath = os.path.join(rootdir, test_filename)
+    test_data = xr.open_dataset(test_filepath).T2
+    # Resample to hourly frequency for single simulation
+    test_data = (
+        test_data.sel({"simulation": "cesm2"})
+        .sel(time=slice("2014-01-01", "2014-01-31"))
+        .resample(time="1H")
+        .interpolate("linear")
+    )
+    test_data.attrs["frequency"] = "hourly"
+
+    # Compute area average
+    weights = np.cos(np.deg2rad(test_data.lat))
+    test_data = test_data.weighted(weights).mean("x").mean("y")
+
+    # Adding in some hourly variability
+    rng = np.random.default_rng()
+    n = rng.uniform(-0.5, 0.5, (len(test_data.time),))
+    test_data = test_data + n
+
+    ts = tst.TimeSeries(test_data)  # make Timeseries object
+    return ts.choices  # return the underlying TimeSeriesParams object for testing
+
+
+def test_hourly_seasonal(test_TSP):
+    # Specify Params options
+    test_TSP.anomaly = False
+    test_TSP.remove_seasonal_cycle = True
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0

--- a/tests/timeseriestools/test_timeseriestools_hourly.py
+++ b/tests/timeseriestools/test_timeseriestools_hourly.py
@@ -44,11 +44,13 @@ def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
     return ts.choices  # return the underlying TimeSeriesParams object for testing
 
 
-def test_hourly_seasonal(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.remove_seasonal_cycle = True
+class TestTimeseriesHourly:
 
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+    def test_hourly_seasonal(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.anomaly = False
+        test_TSP.remove_seasonal_cycle = True
+
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0

--- a/tests/timeseriestools/test_timeseriestools_hourly.py
+++ b/tests/timeseriestools/test_timeseriestools_hourly.py
@@ -13,11 +13,10 @@ import xarray as xr
 
 import climakitae.explore.timeseries as tst
 
-# -------- Read in the test dataset and return a TimeSeriesParams object -------
-
 
 @pytest.fixture
 def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
+    """Read in the test dataset and return a TimeSeriesParams object."""
     # This data is generated in "create_timeseries_test_data.py"
     test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
     test_filepath = os.path.join(rootdir, test_filename)
@@ -47,8 +46,8 @@ def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
 class TestTimeseriesHourly:
 
     def test_hourly_seasonal(self, test_TSP: tst.TimeSeriesParameters):
+        """Testing a basic transformation with hourly data."""
         # Specify Params options
-        test_TSP.anomaly = False
         test_TSP.remove_seasonal_cycle = True
 
         # Transform data and test

--- a/tests/timeseriestools/test_timeseriestools_hourly.py
+++ b/tests/timeseriestools/test_timeseriestools_hourly.py
@@ -1,3 +1,10 @@
+"""
+This script contains tests on various Timeseries Tools options using hourly
+data. For now, the tests only test that the various parameter combinations can
+run through `transform_data` without error, and that the data has been transformed
+(not equal to original values), but does not test for exact expected values.
+"""
+
 import os
 
 import numpy as np

--- a/tests/timeseriestools/test_timeseriestools_hourly.py
+++ b/tests/timeseriestools/test_timeseriestools_hourly.py
@@ -36,7 +36,7 @@ def test_TSP(rootdir: str) -> tst.TimeSeriesParameters:
     return ts.choices  # return the underlying TimeSeriesParams object for testing
 
 
-def test_hourly_seasonal(test_TSP):
+def test_hourly_seasonal(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.anomaly = False
     test_TSP.remove_seasonal_cycle = True

--- a/tests/timeseriestools/test_timeseriestools_hourly.py
+++ b/tests/timeseriestools/test_timeseriestools_hourly.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import datetime as dt
 import numpy as np
 import xarray as xr
 import climakitae.explore.timeseries as tst

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -193,6 +193,7 @@ class TestTimeseriesMonthlyErrors:
         with pytest.raises(ValueError):
             ts = tst.TimeSeries(test_data)
 
+
 class TestTimeseriesObject:
 
     def test_output_current(self, rootdir: str):
@@ -206,7 +207,15 @@ class TestTimeseriesObject:
 
         ts = tst.TimeSeries(test_data)  # make Timeseries object
         current = ts.output_current()
-        
+
         assert isinstance(current, xr.core.dataarray.DataArray)
-        for item in ["anomaly","extremes","reference_range","remove_seasonal_cycle","resample_period","resample_window","smoothing"]:
+        for item in [
+            "anomaly",
+            "extremes",
+            "reference_range",
+            "remove_seasonal_cycle",
+            "resample_period",
+            "resample_window",
+            "smoothing",
+        ]:
             assert "timeseries: " + item in current.attrs

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -82,7 +82,9 @@ def test_monthly_anomaly_and_smoothing(test_TSP: tst.TimeSeriesParameters):
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
-def test_monthly_anomaly_and_smoothing_separate_seasons(test_TSP: tst.TimeSeriesParameters):
+def test_monthly_anomaly_and_smoothing_separate_seasons(
+    test_TSP: tst.TimeSeriesParameters,
+):
     # Specify Params options
     test_TSP.smoothing = "Running Mean"
     test_TSP.num_timesteps = 3

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -131,3 +131,25 @@ def test_extremes_percentile(test_TSP):
     # Transform data and test
     result = test_TSP.transform_data()
     assert (result == test_TSP.data).sum().values.item() == 0
+
+
+# ------------- Test errors ------------------------------------------
+
+
+def test_timeseries_lat_error(rootdir):
+    # Provide lat/lon data to TimeSeries to raise error
+    test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
+    test_filepath = os.path.join(rootdir, test_filename)
+    test_data = xr.open_dataset(test_filepath).T2
+
+    with pytest.raises(ValueError):
+        ts = tst.TimeSeries(test_data)  # make Timeseries object
+
+
+def test_timeseries_scenario_error(test_TSP):
+    # Removing 'Historical' from scenario list in data to raise error
+    test_data = test_TSP.data
+    test_data["scenario"] = np.array(["SSP 2-4.5"], dtype="<U44")
+
+    with pytest.raises(ValueError):
+        ts = tst.TimeSeries(test_data)

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -164,7 +164,7 @@ class TestTimeseriesMonthlyTransform:
 # ------------- Test errors ------------------------------------------
 
 
-class TestTimeseriesErrors:
+class TestTimeseriesMonthlyErrors:
 
     def test_timeseries_no_data_array(
         self,

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -15,9 +15,9 @@ import xarray as xr
 import climakitae.explore.timeseries as tst
 
 
-# -------- Read in the test dataset and return a TimeSeriesParams object -------
 @pytest.fixture
 def test_TSP(rootdir) -> tst.TimeSeriesParameters:
+    """Read in the test dataset and return a TimeSeriesParams object."""
     # This data is generated in "create_timeseries_test_data.py"
     test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
     test_filepath = os.path.join(rootdir, test_filename)
@@ -33,9 +33,8 @@ def test_TSP(rootdir) -> tst.TimeSeriesParameters:
 
 class TestTimeseriesMonthlyTransform:
 
-    # ------------- Test monthly running mean ----------------------------------
-
     def test_monthly_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        """Test monthly running mean."""
         # Specify Params options
         test_TSP.smoothing = "Running Mean"
         test_TSP.num_timesteps = 3
@@ -45,9 +44,8 @@ class TestTimeseriesMonthlyTransform:
         result = test_TSP.transform_data()  # transform_data calls _running_mean()
         assert (result == test_TSP.data).sum().values.item() == 0
 
-    # ------------- Test monthly weighted anomaly ----------------------------------
-
     def test_monthly_anomaly(self, test_TSP: tst.TimeSeriesParameters):
+        """Test monthly weighted anomaly."""
         # Specify Params options
         test_TSP.anomaly = True
         test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
@@ -57,6 +55,7 @@ class TestTimeseriesMonthlyTransform:
         assert (result == test_TSP.data).sum().values.item() == 0
 
     def test_monthly_anomaly_separate_seasons(self, test_TSP: tst.TimeSeriesParameters):
+        """Test monthly weighted anomaly with separate seasons option."""
         # Specify Params options
         test_TSP.anomaly = True
         test_TSP.separate_seasons = True
@@ -66,9 +65,8 @@ class TestTimeseriesMonthlyTransform:
         result = test_TSP.transform_data()
         assert (result == test_TSP.data).sum().values.item() == 0
 
-    # ------------- Test anomaly and smoothing together ----------------------------
-
     def test_monthly_anomaly_and_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        """Test anomaly and smoothing together."""
         # Specify Params options
         test_TSP.smoothing = "Running Mean"
         test_TSP.num_timesteps = 3
@@ -83,6 +81,7 @@ class TestTimeseriesMonthlyTransform:
         self,
         test_TSP: tst.TimeSeriesParameters,
     ):
+        """Test anomaly, smoothing, and separate seasons options together."""
         # Specify Params options
         test_TSP.smoothing = "Running Mean"
         test_TSP.num_timesteps = 3
@@ -94,9 +93,8 @@ class TestTimeseriesMonthlyTransform:
         result = test_TSP.transform_data()
         assert (result == test_TSP.data).sum().values.item() == 0
 
-    # ------------- Test seasonal cycle removal w/ and w/o smoothing ---------------
-
     def test_seasonal(self, test_TSP: tst.TimeSeriesParameters):
+        """Test seasonal cycle removal without smoothing."""
         # Specify Params options
         test_TSP.anomaly = False
         test_TSP.remove_seasonal_cycle = True
@@ -106,6 +104,7 @@ class TestTimeseriesMonthlyTransform:
         assert (result == test_TSP.data).sum().values.item() == 0
 
     def test_seasonal_and_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        """Test seasonal cycle removal with smoothing."""
         # Specify Params options
         test_TSP.smoothing = "Running Mean"
         test_TSP.num_timesteps = 3
@@ -116,9 +115,8 @@ class TestTimeseriesMonthlyTransform:
         result = test_TSP.transform_data()
         assert (result == test_TSP.data).sum().values.item() == 0
 
-    # ------------- Test extremes options ------------------------------------------
-
     def test_extremes_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        """Test extremes min with smoothing."""
         # Specify Params options
         test_TSP.anomaly = False
         test_TSP.smoothing = "Running Mean"
@@ -131,6 +129,7 @@ class TestTimeseriesMonthlyTransform:
         assert (result == test_TSP.data).sum().values.item() == 0
 
     def test_extremes_min(self, test_TSP: tst.TimeSeriesParameters):
+        """Test extremes min without smoothing."""
         # Specify Params options
         test_TSP.anomaly = False
         test_TSP.extremes = ["Min"]
@@ -141,6 +140,7 @@ class TestTimeseriesMonthlyTransform:
         assert (result == test_TSP.data).sum().values.item() == 0
 
     def test_extremes_max(self, test_TSP: tst.TimeSeriesParameters):
+        """Test extremes max without smoothing."""
         # Specify Params options
         test_TSP.extremes = ["Max"]
         test_TSP.resample_window = 2
@@ -150,6 +150,7 @@ class TestTimeseriesMonthlyTransform:
         assert (result == test_TSP.data).sum().values.item() == 0
 
     def test_extremes_percentile(self, test_TSP: tst.TimeSeriesParameters):
+        """Test extremes percentile without smoothing."""
         # Specify Params options
         test_TSP.anomaly = False
         test_TSP.extremes = ["Percentile"]
@@ -161,20 +162,17 @@ class TestTimeseriesMonthlyTransform:
         assert (result == test_TSP.data).sum().values.item() == 0
 
 
-# ------------- Test errors ------------------------------------------
-
-
 class TestTimeseriesMonthlyErrors:
 
     def test_timeseries_no_data_array(
         self,
     ):
-        # Provide empty dataset (not data array) to raise error
+        """Provide empty dataset (not data array) to raise error."""
         with pytest.raises(ValueError):
             ts = tst.TimeSeries(xr.Dataset())
 
     def test_timeseries_lat_error(self, rootdir: str):
-        # Provide lat/lon data to TimeSeries to raise error
+        """Provide lat/lon data to TimeSeries to raise error."""
         # Also changing the scenario to test multiple error case
         test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
         test_filepath = os.path.join(rootdir, test_filename)
@@ -185,7 +183,7 @@ class TestTimeseriesMonthlyErrors:
             ts = tst.TimeSeries(test_data)
 
     def test_timeseries_scenario_error(self, test_TSP: tst.TimeSeriesParameters):
-        # Removing 'Historical' from scenario list in data to raise error
+        """Remove 'Historical' text from scenario list in data to raise error."""
         test_data = test_TSP.data
         test_data["scenario"] = np.array(["SSP 2-4.5"], dtype="<U44")
 

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -5,11 +5,13 @@ run through `transform_data` without error, and that the data has been transform
 (not equal to original values), but does not test for exact expected values.
 """
 
-import pytest
-import os
 import datetime as dt
+import os
+
 import numpy as np
+import pytest
 import xarray as xr
+
 import climakitae.explore.timeseries as tst
 
 # -------- Read in the test dataset and return a TimeSeriesParams object -------

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -14,9 +14,8 @@ import xarray as xr
 
 import climakitae.explore.timeseries as tst
 
+
 # -------- Read in the test dataset and return a TimeSeriesParams object -------
-
-
 @pytest.fixture
 def test_TSP(rootdir) -> tst.TimeSeriesParameters:
     # This data is generated in "create_timeseries_test_data.py"
@@ -32,170 +31,163 @@ def test_TSP(rootdir) -> tst.TimeSeriesParameters:
     return ts.choices  # return the underlying TimeSeriesParams object for testing
 
 
-def test_monthly_smoothing(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.anomaly = False
+class TestTimeseriesMonthlyTransform:
 
-    # Transform data and test
-    result = test_TSP.transform_data()  # transform_data calls _running_mean()
-    assert (result == test_TSP.data).sum().values.item() == 0
+    # ------------- Test monthly running mean ----------------------------------
 
+    def test_monthly_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.smoothing = "Running Mean"
+        test_TSP.num_timesteps = 3
+        test_TSP.anomaly = False
 
-# ------------- Test monthly weighted anomaly ----------------------------------
+        # Transform data and test
+        result = test_TSP.transform_data()  # transform_data calls _running_mean()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
+    # ------------- Test monthly weighted anomaly ----------------------------------
 
-def test_monthly_anomaly(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.anomaly = True
-    test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
+    def test_monthly_anomaly(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.anomaly = True
+        test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
 
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
+    def test_monthly_anomaly_separate_seasons(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.anomaly = True
+        test_TSP.separate_seasons = True
+        test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
 
-def test_monthly_anomaly_separate_seasons(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.anomaly = True
-    test_TSP.separate_seasons = True
-    test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+    # ------------- Test anomaly and smoothing together ----------------------------
 
+    def test_monthly_anomaly_and_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.smoothing = "Running Mean"
+        test_TSP.num_timesteps = 3
+        test_TSP.anomaly = True
+        test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
 
-# ------------- Test anomaly and smoothing together ----------------------------
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
+    def test_monthly_anomaly_and_smoothing_separate_seasons(
+        self,
+        test_TSP: tst.TimeSeriesParameters,
+    ):
+        # Specify Params options
+        test_TSP.smoothing = "Running Mean"
+        test_TSP.num_timesteps = 3
+        test_TSP.anomaly = True
+        test_TSP.separate_seasons = True
+        test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
 
-def test_monthly_anomaly_and_smoothing(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.anomaly = True
-    test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+    # ------------- Test seasonal cycle removal w/ and w/o smoothing ---------------
 
+    def test_seasonal(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.anomaly = False
+        test_TSP.remove_seasonal_cycle = True
 
-def test_monthly_anomaly_and_smoothing_separate_seasons(
-    test_TSP: tst.TimeSeriesParameters,
-):
-    # Specify Params options
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.anomaly = True
-    test_TSP.separate_seasons = True
-    test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+    def test_seasonal_and_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.smoothing = "Running Mean"
+        test_TSP.num_timesteps = 3
+        test_TSP.anomaly = False
+        test_TSP.remove_seasonal_cycle = True
 
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
-# ------------- Test seasonal cycle removal w/ and w/o smoothing ---------------
+    # ------------- Test extremes options ------------------------------------------
 
+    def test_extremes_smoothing(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.anomaly = False
+        test_TSP.smoothing = "Running Mean"
+        test_TSP.num_timesteps = 3
+        test_TSP.extremes = ["Min"]
+        test_TSP.resample_window = 2
 
-def test_seasonal(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.remove_seasonal_cycle = True
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+    def test_extremes_min(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.anomaly = False
+        test_TSP.extremes = ["Min"]
+        test_TSP.resample_window = 2
 
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
-def test_seasonal_and_smoothing(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.anomaly = False
-    test_TSP.remove_seasonal_cycle = True
+    def test_extremes_max(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.extremes = ["Max"]
+        test_TSP.resample_window = 2
 
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
+    def test_extremes_percentile(self, test_TSP: tst.TimeSeriesParameters):
+        # Specify Params options
+        test_TSP.anomaly = False
+        test_TSP.extremes = ["Percentile"]
+        test_TSP.resample_window = 2
+        test_TSP.percentile = 0.95
 
-# ------------- Test extremes options ------------------------------------------
-
-
-def test_extremes_smoothing(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.smoothing = "Running Mean"
-    test_TSP.num_timesteps = 3
-    test_TSP.extremes = ["Min"]
-    test_TSP.resample_window = 2
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
-
-
-def test_extremes_min(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.extremes = ["Min"]
-    test_TSP.resample_window = 2
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
-
-
-def test_extremes_max(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.extremes = ["Max"]
-    test_TSP.resample_window = 2
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
-
-
-def test_extremes_percentile(test_TSP: tst.TimeSeriesParameters):
-    # Specify Params options
-    test_TSP.anomaly = False
-    test_TSP.extremes = ["Percentile"]
-    test_TSP.resample_window = 2
-    test_TSP.percentile = 0.95
-
-    # Transform data and test
-    result = test_TSP.transform_data()
-    assert (result == test_TSP.data).sum().values.item() == 0
+        # Transform data and test
+        result = test_TSP.transform_data()
+        assert (result == test_TSP.data).sum().values.item() == 0
 
 
 # ------------- Test errors ------------------------------------------
 
 
-def test_timeseries_no_data_array():
-    # Provide empty dataset (not data array) to raise error
-    with pytest.raises(ValueError):
-        ts = tst.TimeSeries(xr.Dataset())
+class TestTimeseriesErrors:
 
+    def test_timeseries_no_data_array(
+        self,
+    ):
+        # Provide empty dataset (not data array) to raise error
+        with pytest.raises(ValueError):
+            ts = tst.TimeSeries(xr.Dataset())
 
-def test_timeseries_lat_error(rootdir: str):
-    # Provide lat/lon data to TimeSeries to raise error
-    # Also changing the scenario to test multiple error case
-    test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
-    test_filepath = os.path.join(rootdir, test_filename)
-    test_data = xr.open_dataset(test_filepath).T2
-    test_data["scenario"] = np.array(["SSP 2-4.5"], dtype="<U44")
+    def test_timeseries_lat_error(self, rootdir: str):
+        # Provide lat/lon data to TimeSeries to raise error
+        # Also changing the scenario to test multiple error case
+        test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
+        test_filepath = os.path.join(rootdir, test_filename)
+        test_data = xr.open_dataset(test_filepath).T2
+        test_data["scenario"] = np.array(["SSP 2-4.5"], dtype="<U44")
 
-    with pytest.raises(ValueError):
-        ts = tst.TimeSeries(test_data)
+        with pytest.raises(ValueError):
+            ts = tst.TimeSeries(test_data)
 
+    def test_timeseries_scenario_error(self, test_TSP: tst.TimeSeriesParameters):
+        # Removing 'Historical' from scenario list in data to raise error
+        test_data = test_TSP.data
+        test_data["scenario"] = np.array(["SSP 2-4.5"], dtype="<U44")
 
-def test_timeseries_scenario_error(test_TSP: tst.TimeSeriesParameters):
-    # Removing 'Historical' from scenario list in data to raise error
-    test_data = test_TSP.data
-    test_data["scenario"] = np.array(["SSP 2-4.5"], dtype="<U44")
-
-    with pytest.raises(ValueError):
-        ts = tst.TimeSeries(test_data)
+        with pytest.raises(ValueError):
+            ts = tst.TimeSeries(test_data)

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -115,6 +115,9 @@ class TestTimeseriesMonthlyTransform:
         result = test_TSP.transform_data()
         assert (result == test_TSP.data).sum().values.item() == 0
 
+
+class TestTimeseriesMonthlyExtremes:
+
     def test_extremes_smoothing(self, test_TSP: tst.TimeSeriesParameters):
         """Test extremes min with smoothing."""
         # Specify Params options

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -192,3 +192,21 @@ class TestTimeseriesMonthlyErrors:
 
         with pytest.raises(ValueError):
             ts = tst.TimeSeries(test_data)
+
+class TestTimeseriesObject:
+
+    def test_output_current(self, rootdir: str):
+        test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
+        test_filepath = os.path.join(rootdir, test_filename)
+        test_data = xr.open_dataset(test_filepath).T2
+
+        # Compute area average
+        weights = np.cos(np.deg2rad(test_data.lat))
+        test_data = test_data.weighted(weights).mean("x").mean("y")
+
+        ts = tst.TimeSeries(test_data)  # make Timeseries object
+        current = ts.output_current()
+        
+        assert isinstance(current, xr.core.dataarray.DataArray)
+        for item in ["anomaly","extremes","reference_range","remove_seasonal_cycle","resample_period","resample_window","smoothing"]:
+            assert "timeseries: " + item in current.attrs

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -16,7 +16,7 @@ import climakitae.explore.timeseries as tst
 
 
 @pytest.fixture
-def test_TSP(rootdir):
+def test_TSP(rootdir) -> tst.TimeSeriesParameters:
     # This data is generated in "create_timeseries_test_data.py"
     test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
     test_filepath = os.path.join(rootdir, test_filename)
@@ -30,7 +30,7 @@ def test_TSP(rootdir):
     return ts.choices  # return the underlying TimeSeriesParams object for testing
 
 
-def test_monthly_smoothing(test_TSP):
+def test_monthly_smoothing(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.smoothing = "Running Mean"
     test_TSP.num_timesteps = 3
@@ -44,7 +44,7 @@ def test_monthly_smoothing(test_TSP):
 # ------------- Test monthly weighted anomaly ----------------------------------
 
 
-def test_monthly_anomaly(test_TSP):
+def test_monthly_anomaly(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.anomaly = True
     test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
@@ -54,7 +54,7 @@ def test_monthly_anomaly(test_TSP):
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
-def test_monthly_anomaly_separate_seasons(test_TSP):
+def test_monthly_anomaly_separate_seasons(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.anomaly = True
     test_TSP.separate_seasons = True
@@ -68,7 +68,7 @@ def test_monthly_anomaly_separate_seasons(test_TSP):
 # ------------- Test anomaly and smoothing together ----------------------------
 
 
-def test_monthly_anomaly_and_smoothing(test_TSP):
+def test_monthly_anomaly_and_smoothing(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.smoothing = "Running Mean"
     test_TSP.num_timesteps = 3
@@ -80,7 +80,7 @@ def test_monthly_anomaly_and_smoothing(test_TSP):
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
-def test_monthly_anomaly_and_smoothing_separate_seasons(test_TSP):
+def test_monthly_anomaly_and_smoothing_separate_seasons(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.smoothing = "Running Mean"
     test_TSP.num_timesteps = 3
@@ -96,7 +96,7 @@ def test_monthly_anomaly_and_smoothing_separate_seasons(test_TSP):
 # ------------- Test seasonal cycle removal w/ and w/o smoothing ---------------
 
 
-def test_seasonal(test_TSP):
+def test_seasonal(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.anomaly = False
     test_TSP.remove_seasonal_cycle = True
@@ -106,7 +106,7 @@ def test_seasonal(test_TSP):
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
-def test_seasonal_and_smoothing(test_TSP):
+def test_seasonal_and_smoothing(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.smoothing = "Running Mean"
     test_TSP.num_timesteps = 3
@@ -121,7 +121,7 @@ def test_seasonal_and_smoothing(test_TSP):
 # ------------- Test extremes options ------------------------------------------
 
 
-def test_extremes_smoothing(test_TSP):
+def test_extremes_smoothing(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.anomaly = False
     test_TSP.smoothing = "Running Mean"
@@ -134,7 +134,7 @@ def test_extremes_smoothing(test_TSP):
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
-def test_extremes_min(test_TSP):
+def test_extremes_min(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.anomaly = False
     test_TSP.extremes = ["Min"]
@@ -145,17 +145,17 @@ def test_extremes_min(test_TSP):
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
-def test_extremes_max(test_TSP):
+def test_extremes_max(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.extremes = ["Max"]
-    test_TSP.resample_window = 3
+    test_TSP.resample_window = 2
 
     # Transform data and test
     result = test_TSP.transform_data()
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
-def test_extremes_percentile(test_TSP):
+def test_extremes_percentile(test_TSP: tst.TimeSeriesParameters):
     # Specify Params options
     test_TSP.anomaly = False
     test_TSP.extremes = ["Percentile"]
@@ -176,7 +176,7 @@ def test_timeseries_no_data_array():
         ts = tst.TimeSeries(xr.Dataset())
 
 
-def test_timeseries_lat_error(rootdir):
+def test_timeseries_lat_error(rootdir: str):
     # Provide lat/lon data to TimeSeries to raise error
     # Also changing the scenario to test multiple error case
     test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
@@ -188,7 +188,7 @@ def test_timeseries_lat_error(rootdir):
         ts = tst.TimeSeries(test_data)
 
 
-def test_timeseries_scenario_error(test_TSP):
+def test_timeseries_scenario_error(test_TSP: tst.TimeSeriesParameters):
     # Removing 'Historical' from scenario list in data to raise error
     test_data = test_TSP.data
     test_data["scenario"] = np.array(["SSP 2-4.5"], dtype="<U44")

--- a/tests/timeseriestools/test_timeseriestools_monthly.py
+++ b/tests/timeseriestools/test_timeseriestools_monthly.py
@@ -54,6 +54,17 @@ def test_monthly_anomaly(test_TSP):
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
+def test_monthly_anomaly_separate_seasons(test_TSP):
+    # Specify Params options
+    test_TSP.anomaly = True
+    test_TSP.separate_seasons = True
+    test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
 # ------------- Test anomaly and smoothing together ----------------------------
 
 
@@ -62,6 +73,19 @@ def test_monthly_anomaly_and_smoothing(test_TSP):
     test_TSP.smoothing = "Running Mean"
     test_TSP.num_timesteps = 3
     test_TSP.anomaly = True
+    test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
+def test_monthly_anomaly_and_smoothing_separate_seasons(test_TSP):
+    # Specify Params options
+    test_TSP.smoothing = "Running Mean"
+    test_TSP.num_timesteps = 3
+    test_TSP.anomaly = True
+    test_TSP.separate_seasons = True
     test_TSP.reference_range = (dt.datetime(2014, 1, 1), dt.datetime(2014, 12, 31))
 
     # Transform data and test
@@ -121,6 +145,16 @@ def test_extremes_min(test_TSP):
     assert (result == test_TSP.data).sum().values.item() == 0
 
 
+def test_extremes_max(test_TSP):
+    # Specify Params options
+    test_TSP.extremes = ["Max"]
+    test_TSP.resample_window = 3
+
+    # Transform data and test
+    result = test_TSP.transform_data()
+    assert (result == test_TSP.data).sum().values.item() == 0
+
+
 def test_extremes_percentile(test_TSP):
     # Specify Params options
     test_TSP.anomaly = False
@@ -136,14 +170,22 @@ def test_extremes_percentile(test_TSP):
 # ------------- Test errors ------------------------------------------
 
 
+def test_timeseries_no_data_array():
+    # Provide empty dataset (not data array) to raise error
+    with pytest.raises(ValueError):
+        ts = tst.TimeSeries(xr.Dataset())
+
+
 def test_timeseries_lat_error(rootdir):
     # Provide lat/lon data to TimeSeries to raise error
+    # Also changing the scenario to test multiple error case
     test_filename = "test_data/timeseries_data_T2_2014_2016_monthly_45km.nc"
     test_filepath = os.path.join(rootdir, test_filename)
     test_data = xr.open_dataset(test_filepath).T2
+    test_data["scenario"] = np.array(["SSP 2-4.5"], dtype="<U44")
 
     with pytest.raises(ValueError):
-        ts = tst.TimeSeries(test_data)  # make Timeseries object
+        ts = tst.TimeSeries(test_data)
 
 
 def test_timeseries_scenario_error(test_TSP):


### PR DESCRIPTION
## Summary of changes and related issue
Tests are added to increase the test coverage of explore/timeseries.py. I updated a deprecated call to the Param() class in Timeseries.output_current(). Types hints are added and docstrings are extended.

## Relevant motivation and context
These changes increase test coverage to 97% (124 statements, 4 missing).

The tests are reorganized into classes for readability and consistency. Type hints are added for readability.

The timeseries_transformations notebook cannot be completely run in its current state because output_current() uses a deprecated method. This change allows the notebook to run in entirety.

## How to test 
```
pip install pytest-cov
pytest tests/timeseriestools --cov=climakitae.explore.timeseries --cov-report term-missing
```

If you run timeseries_transformations.ipynb, make sure to select "yes" for area averaging in the parameter gui. You may experience the notebook crashing otherwise (I opened an issue https://github.com/cal-adapt/cae-notebooks/issues/159).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
