### PR TITLE
Test Coverage for `util.generate_gwl_tables_unc.py`

### DIFF
--- a/climakitae/util/generate_gwl_tables_unc.py
+++ b/climakitae/util/generate_gwl_tables_unc.py
@@ -10,112 +10,219 @@ To run, type: <<python generate_gwl_tables_unc.py>> in the command line and wait
 for printed model outputs showing progress.
 """
 
-import s3fs
-import intake
-import pandas as pd
-import xarray as xr
 import numpy as np
+import pandas as pd
+import s3fs
+import xarray as xr
+
 from climakitae.util.utils import write_csv_file
 
 
-def main():
+def make_weighted_timeseries(temp: xr.DataArray) -> xr.DataArray:
     """
-    Generates global warming level (GWL) reference file for CMIP6 GCM EC-Earth3.
+    Creates a spatially-weighted single-dimension time series of global temperature.
 
-    This includes:
-    - Connecting to AWS S3 storage to access EC-Earth3 data.
-    - Filtering and processing data to create global temperature time series.
-    - Generating and saving warming level table in CSV format for 1981-2010 reference period.
+    The function weights the latitude grids by size and averages across all longitudes,
+    resulting in a single time series object.
+
+    Parameters:
+    ----------
+    temp : xarray.DataArray
+        An xarray DataArray of global temperature with latitude and longitude coordinates.
+
+    Returns:
+    -------
+    xarray.DataArray
+        A time series of global temperature that is spatially weighted across latitudes and averaged
+        across all longitudes.
     """
-    # Connect to AWS S3 storage
-    fs = s3fs.S3FileSystem(anon=True)
+    # Find variable names for latitude and longitude to make code more readable
+    lat, lon = "lat", "lon"
+    if "lat" not in temp.coords and "lon" not in temp.coords:
+        lat, lon = "latitude", "longitude"
 
-    df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
-    df_subset = df[
-        (df.table_id == "Amon")
-        & (df.variable_id == "tas")
-        & (df.experiment_id == "historical")
-    ]
-    sims_on_aws = get_sims_on_aws(df)
-    models = ["EC-Earth3"]
+    # Weight latitude grids by size, then average across all longitudes to create single time-series object
+    weightlat = np.sqrt(np.cos(np.deg2rad(temp[lat])))
+    weightlat = weightlat / np.sum(weightlat)
+    timeseries = (temp * weightlat).sum(lat).mean(lon)
+    return timeseries
 
-    def make_weighted_timeseries(temp):
+
+class GWLGenerator:
+    """
+    Class for generating Global Warming Level (GWL) reference data.
+    Encapsulates the parameters and methods needed for GWL calculations.
+
+    Attributes
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing metadata for CMIP6 simulations
+    sims_on_aws : pandas.DataFrame
+        DataFrame listing available simulations on AWS
+    fs : s3fs.S3FileSystem
+        S3 file system object for accessing AWS data
+
+    Methods
+    -------
+    get_sims_on_aws() -> pandas.DataFrame
+        Generates a DataFrame listing all relevant CMIP6 simulations available on AWS.
+    build_timeseries(model_config: dict) -> xarray.Dataset
+        Builds an xarray Dataset with a time dimension, containing the concatenated historical
+        and SSP time series for all specified scenarios of a given model and ensemble member.
+    get_gwl(smoothed: pandas.DataFrame, degree: float) -> pandas.DataFrame
+        Computes the timestamp when a given GWL is first reached.
+    get_gwl_table_one(model_config: dict, reference_period: dict) -> tuple[pandas.DataFrame, pandas.DataFrame]
+        Generates a GWL table for a single model and ensemble member.
+    get_gwl_table(model_config: dict, reference_period: dict) -> tuple[pandas.DataFrame, pandas.DataFrame]
+        Generates GWL tables for a model across all its ensemble members.
+    generate_gwl_file(models: list[str], scenarios: list[str], reference_periods: list[dict])
+        Generates global warming level (GWL) reference files for specified models.
+
+    Examples
+    --------
+    >>> df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
+    >>> gwl_generator = GWLGenerator(df)
+    >>> models = ["EC-Earth3"]
+    >>> scenarios = ["ssp370"]
+    >>> reference_periods = [{"start_year": "19810101", "end_year": "20101231"}]
+    >>> gwl_generator.generate_gwl_file(models, scenarios, reference_periods)
+    """
+
+    def __init__(self, df, sims_on_aws=None):
         """
-        Creates a spatially-weighted single-dimension time series of global temperature.
-
-        The function weights the latitude grids by size and averages across all longitudes,
-        resulting in a single time series object.
+        Initialize the GWLGenerator with the CMIP6 data catalog.
 
         Parameters:
         ----------
-        temp : xarray.DataArray
-            An xarray DataArray of global temperature with latitude and longitude coordinates.
+        df : pandas.DataFrame
+            DataFrame containing metadata for CMIP6 simulations
+        sims_on_aws : pandas.DataFrame, optional
+            DataFrame listing available simulations on AWS. If None, it will be generated.
+        """
+        self.df = df
+        self.sims_on_aws = (
+            sims_on_aws if sims_on_aws is not None else self.get_sims_on_aws()
+        )
+        self.fs = s3fs.S3FileSystem(anon=True)
+
+    def get_sims_on_aws(self) -> pd.DataFrame:
+        """
+        Generates a pandas DataFrame listing all relevant CMIP6 simulations available on AWS.
 
         Returns:
         -------
-        xarray.DataArray
-            A time series of global temperature that is spatially weighted across latitudes and averaged
-            across all longitudes.
+        pandas.DataFrame
+            DataFrame indexed by model names with columns for different scenarios.
         """
-        # Find variable names for latitude and longitude to make code more readable
-        lat, lon = "lat", "lon"
-        if "lat" not in temp.coords and "lon" not in temp.coords:
-            lat, lon = "latitude", "longitude"
+        df_subset = self.df[
+            (self.df.table_id == "Amon")
+            & (self.df.variable_id == "tas")
+            & (self.df.experiment_id == "historical")
+        ]
+        models = list(set(df_subset.source_id))
+        models.sort()
 
-        # Weight latitude grids by size, then average across all longitudes to create single time-series object
-        weightlat = np.sqrt(np.cos(np.deg2rad(temp[lat])))
-        weightlat = weightlat / np.sum(weightlat)
-        timeseries = (temp * weightlat).sum(lat).mean(lon)
-        return timeseries
+        # First cut through the catalog
+        scenarios = ["historical", "ssp585", "ssp370", "ssp245", "ssp126"]
+        sims_on_aws = pd.DataFrame(index=models, columns=scenarios)
 
-    def build_timeseries(variable, model, ens_mem, scenarios):
+        # Fix 1: Replace chained assignment with loc indexer
+        for model in models:
+            for scenario in scenarios:
+                df_scenario = self.df[
+                    (self.df.table_id == "Amon")
+                    & (self.df.variable_id == "tas")
+                    & (self.df.experiment_id == scenario)
+                    & (self.df.source_id == model)
+                ]
+                ensMembers = list(set(df_scenario.member_id))
+                # Use .loc instead of chained indexing
+                sims_on_aws.loc[model, scenario] = ensMembers
+
+        # cut the table to those GCMs that have a historical + at least one SSP ensemble member
+        models_to_drop = []
+        for i, item in enumerate(sims_on_aws.T.columns):
+            no_ssp = True
+            for ssp in ["ssp585", "ssp370", "ssp245", "ssp126"]:
+                if len(sims_on_aws.loc[item, ssp]) > 0:
+                    no_ssp = False
+            if (len(sims_on_aws.loc[item, "historical"]) < 1) or (no_ssp):
+                models_to_drop.append(item)
+
+        sims_on_aws = sims_on_aws.drop(index=models_to_drop)
+
+        # Find the historical ensemble members for each model
+        # and remove them from the SSPs
+        for i, item in enumerate(sims_on_aws.T.columns):
+            variants_to_keep = []
+            for variant in sims_on_aws.loc[item, "historical"]:
+                for ssp in ["ssp585", "ssp370", "ssp245", "ssp126"]:
+                    if str(variant) in sims_on_aws.loc[item, ssp]:
+                        variants_to_keep.append(variant)
+            sims_on_aws.loc[item, "historical"] = list(set(variants_to_keep))
+
+        sims_on_aws.index.name = "source_id"
+
+        return sims_on_aws
+
+    def build_timeseries(self, model_config: dict) -> xr.Dataset:
         """
         Builds an xarray Dataset with a time dimension, containing the concatenated historical
         and SSP time series for all specified scenarios of a given model and ensemble member.
-        Works for all of the models(/GCMs) in the list `models`, which appear in the current
-        data catalog of WRF downscaling.
 
         Parameters:
         ----------
-        variable : str
-            The variable to process, e.g., `tas`. `tas` is the only variable used in this file currently.
-        model : str
-            The model name.
-        ens_mem : str
-            The ensemble member ID.
-        scenarios : list
-            A list of scenario names to include, e.g., ['historical', 'ssp585', 'ssp370'].
+        model_config : dict
+            Dictionary containing 'variable', 'model', 'ens_mem', and 'scenarios' keys
 
         Returns:
         -------
         xarray.Dataset
-            A dataset with time as the dimension, containing the appended historical and SSP time series.
+            Dataset with time as the dimension, containing the appended historical and SSP time series.
         """
+        variable = model_config["variable"]
+        model = model_config["model"]
+        ens_mem = model_config["ens_mem"]
+        scenarios = model_config["scenarios"]
+
+        # Get historical data first
         scenario = "historical"
         data_historical = xr.Dataset()
-        df_scenario = df_subset[
-            (df_subset.source_id == model) & (df_subset.member_id == ens_mem)
+        df_scenario = self.df[
+            (self.df.table_id == "Amon")
+            & (self.df.variable_id == variable)
+            & (self.df.experiment_id == scenario)
+            & (self.df.source_id == model)
+            & (self.df.member_id == ens_mem)
         ]
-        with xr.open_zarr(fs.get_mapper(df_scenario.zstore.values[0])) as temp:
+        if not df_scenario.empty:
+            with xr.open_zarr(self.fs.get_mapper(df_scenario.zstore.values[0])) as temp:
+                # Create global weighted time-series of variable
+                data_historical = make_weighted_timeseries(temp[variable])
+                data_historical = data_historical.sortby(
+                    "time"
+                )  # needed for MPI-ESM-2-HR
 
-            # Create global weighted time-series of variable
-            data_historical = make_weighted_timeseries(temp[variable])
-            data_historical = data_historical.sortby("time")  # needed for MPI-ESM-2-HR
-
+        # Now process each scenario
         data_one_model = xr.Dataset()
         for scenario in scenarios:
-            if ens_mem in sims_on_aws.T[model][scenario]:
-                df_scenario = df[
-                    (df.table_id == "Amon")
-                    & (df.variable_id == variable)
-                    & (df.experiment_id == scenario)
-                    & (df.source_id == model)
-                    & (df.member_id == ens_mem)
+            # Check if the ensemble member exists for this scenario
+            if (
+                scenario in self.sims_on_aws.T[model]
+                and ens_mem in self.sims_on_aws.T[model][scenario]
+            ):
+                df_scenario = self.df[
+                    (self.df.table_id == "Amon")
+                    & (self.df.variable_id == variable)
+                    & (self.df.experiment_id == scenario)
+                    & (self.df.source_id == model)
+                    & (self.df.member_id == ens_mem)
                 ]
                 if not df_scenario.empty:
                     with xr.open_zarr(
-                        fs.get_mapper(df_scenario.zstore.values[0]), decode_times=False
-                    ) as temp:  # BUG: Some scenarios not returning a full predictive period of values (i.e. not returning time period of 2015-2100 of data)
+                        self.fs.get_mapper(df_scenario.zstore.values[0]),
+                        decode_times=False,
+                    ) as temp:  # BUG: Some scenarios not returning a full predictive period of values
                         temp = temp.isel(time=slice(0, 1032))
                         temp = xr.decode_cf(temp)
 
@@ -128,72 +235,65 @@ def main():
                         )  # needed for MPI-ESM1-2-LR
                         data_one_model[scenario] = xr.concat(
                             [data_historical, timeseries], dim="time"
-                        )  # .to_pandas())
+                        )
         return data_one_model
 
-    def get_gwl(smoothed, degree):
+    @staticmethod
+    def get_gwl(smoothed: pd.DataFrame, degree: float) -> pd.DataFrame:
         """
         Computes the timestamp when a given GWL is first reached.
-        Takes a smoothed time series of global mean temperature of different scenarios for a model
-        and returns a table indicating the timestamp at which the specified warming level is reached.
 
         Parameters:
         ----------
         smoothed : pandas.DataFrame
-            A DataFrame containing a global mean temperature time series for a model for multiple scenarios.
+            DataFrame containing global mean temperature time series for multiple scenarios
         degree : float
-            The global warming level to detect, e.g., 1.5, 2, etc.
+            The global warming level to detect
 
         Returns:
         -------
         pandas.DataFrame
-            A table containing timestamps for when each scenario first crosses the specified warming level.
+            Table with timestamps for when each scenario first crosses the specified warming level
         """
 
-        def get_wl_timestamp(scenario, degree):
+        def get_wl_timestamp(scenario: str, degree: float) -> pd.Timestamp:
             """
-            Given a scenario of wl's and timestamps, find the timestamp that first crosses the degree passed in.
-            Return np.NaN if none of the timestamps pass this degree level.
+            Find the timestamp that first crosses the given degree.
+            Return np.nan if none of the timestamps pass this degree level.
             """
             if any(scenario >= degree):
                 wl_ts = scenario[scenario >= degree].index[0]
                 return wl_ts
             else:
-                return np.NaN
+                return np.nan
 
         gwl = smoothed.apply(lambda scenario: get_wl_timestamp(scenario, degree))
         return gwl
 
     def get_gwl_table_one(
-        variable, model, ens_mem, scenarios, start_year="18500101", end_year="19000101"
-    ):
+        self, model_config: dict, reference_period: dict
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Generates a GWL table for a single model and ensemble member.
 
-        Loops through various global warming levels (1.5, 2, 2.5, 3, and 4 degrees)
-        for the requested model/variant and scenarios.
-
         Parameters:
         ----------
-        variable : str
-            The variable to process, e.g., 'tas'.
-        model : str
-            The model name.
-        ens_mem : str
-            The ensemble member ID.
-        scenarios : list
-            A list of scenario names to include, e.g., ['historical', 'ssp585', 'ssp370'].
-        start_year : str, optional
-            The start year for the reference period in the format 'YYYYMMDD'.
-        end_year : str, optional
-            The end year for the reference period in the format 'YYYYMMDD'.
+        model_config : dict
+            Dictionary containing 'variable', 'model', 'ens_mem', and 'scenarios' keys
+        reference_period : dict
+            Dictionary containing 'start_year' and 'end_year' keys
 
         Returns:
         -------
         tuple
-            A DataFrame containing warming levels and a DataFrame with global mean temperature time series.
+            DataFrame containing warming levels and DataFrame with global mean temperature time series
         """
-        data_one_model = build_timeseries(variable, model, ens_mem, scenarios)
+        model = model_config["model"]
+        ens_mem = model_config["ens_mem"]
+        start_year = reference_period["start_year"]
+        end_year = reference_period["end_year"]
+
+        data_one_model = self.build_timeseries(model_config)
         try:
             anom = data_one_model - data_one_model.sel(
                 time=slice(start_year, end_year)
@@ -209,7 +309,7 @@ def main():
 
         smoothed = anom.rolling(time=20 * 12, center=True).mean("time")
 
-        ### one_model is a dataframe of times and warming levels by scenario (scenarios as columns) WITHIN a specific model and ensemble member
+        ### one_model is a dataframe of times and warming levels by scenario
         one_model = (
             smoothed.to_array(dim="scenario", name=model)
             .dropna("time", how="all")
@@ -218,178 +318,160 @@ def main():
         gwlevels = pd.DataFrame()
         try:
             for level in [1.5, 2, 2.5, 3, 4]:
-                gwlevels[level] = get_gwl(one_model.T, level)
+                gwlevels[level] = self.get_gwl(one_model.T, level)
         except Exception as e:
             print(
                 model, ens_mem, " problems"
             )  # helps EC-Earth3 not be skipped altogether
             print(e)
 
-        # Modifying and returning one_model to be seen as a WL table to index by timestamp to get average WL across all simulations.one_model.
-        final_model = one_model.T
+        # Modifying and returning one_model to be seen as a WL table
+        final_model = one_model
         final_model.columns = ens_mem + "_" + final_model.columns
         return gwlevels, final_model
 
     def get_gwl_table(
-        variable, model, scenarios, start_year="18500101", end_year="19000101"
-    ):
+        self, model_config: dict, reference_period: dict
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
-        Generates a GWL table for a given model and scenarios.
+        Generates GWL tables for a model across all its ensemble members.
 
         Parameters:
         ----------
-        variable : str
-            The variable to process, e.g., 'tas'.
-        model : str
-            The model name.
-        scenarios : list
-            A list of scenario names to include, e.g., ['ssp585', 'ssp370', 'ssp245'].
-        start_year : str, optional
-            The start year for the reference period in the format 'YYYYMMDD'.
-        end_year : str, optional
-            The end year for the reference period in the format 'YYYYMMDD'.
+        model_config : dict
+            Dictionary containing 'variable', 'model', and 'scenarios' keys
+        reference_period : dict
+            Dictionary containing 'start_year' and 'end_year' keys
 
         Returns:
         -------
         tuple
-            A DataFrame containing warming levels and a DataFrame with global mean temperature time series.
-            To be exported into `gwl_[time period]ref*.csv`.
+            DataFrame containing warming levels and DataFrame with global mean temperature time series
         """
-        ens_mem_list = sims_on_aws.T[model]["ssp370"].copy()
+        model = model_config["model"]
+        scenarios = model_config["scenarios"]
+
+        ens_mem_list = (
+            self.sims_on_aws.T[model]["ssp370"].copy() if "ssp370" in scenarios else []
+        )
         # "historical" gives same list as "ssp370"
         print(f"Number of ensemble members: {len(ens_mem_list)}")
-        try:
-            # Combining all the ensemble members for a given model
-            gwlevels_tbl, wl_data_tbls = [], []
-            for i, ens_mem in enumerate(ens_mem_list):
-                print(f"Getting gwl table for ensemble member {ens_mem}...")
-                gwlevels, wl_data_tbl = get_gwl_table_one(
-                    variable, model, ens_mem, scenarios, start_year, end_year
+
+        # Combining all the ensemble members for a given model
+        gwlevels_tbl, wl_data_tbls = [], []
+        for i, ens_mem in enumerate(ens_mem_list):
+            print(f"Getting gwl table for ensemble member {ens_mem}...")
+            try:
+                member_config = model_config.copy()
+                member_config["ens_mem"] = ens_mem
+
+                gwlevels, wl_data_tbl = self.get_gwl_table_one(
+                    member_config, reference_period
                 )
                 gwlevels_tbl.append(gwlevels)
                 wl_data_tbls.append(wl_data_tbl)
+            except Exception as e:
+                print(f"Cannot get gwl table for {i}th ensemble member {ens_mem}")
+                print(e)
 
+        if gwlevels_tbl and wl_data_tbls:
             # Renaming columns of all ensemble members within model
             wl_data_tbl_sim = pd.concat(wl_data_tbls, axis=1)
             wl_data_tbl_sim.columns = model + "_" + wl_data_tbl_sim.columns
             return pd.concat(gwlevels_tbl, keys=ens_mem_list), wl_data_tbl_sim
+        else:
+            print(f"No valid ensemble members for model {model}")
+            return pd.DataFrame(), pd.DataFrame()
 
-        except:
-            print("Cannot get gwl table")
-            print(f"{i}th ensemble member {ens_mem}")
+    def generate_gwl_file(
+        self, models: list[str], scenarios: list[str], reference_periods: list[dict]
+    ):
+        """
+        Generates global warming level (GWL) reference files for specified models.
 
-    ##### Generating and writing GWL data table EC-Earth3 #####
-
-    ### Generating WL CSV for a reference period overlapping with downscaled data availability:
-    time_periods = [{"start_year": "19810101", "end_year": "20101231"}]
-
-    for period in time_periods:
-
-        # Setting variables
+        Parameters:
+        ----------
+        models : list
+            List of model names to process
+        scenarios : list
+            List of scenario names to include
+        reference_periods : list
+            List of dictionaries with 'start_year' and 'end_year' keys
+        """
         variable = "tas"
-        start_year = period["start_year"]
-        end_year = period["end_year"]
 
-        ## Generating GWL information for rest of models
-        scenarios = ["ssp370"]
-        print("Generate all WL table {}-{}".format(start_year[:4], end_year[:4]))
-        all_wl_data_tbls = pd.DataFrame()
-        all_gw_tbls, all_gw_data_tbls = [], []
+        for period in reference_periods:
+            start_year = period["start_year"]
+            end_year = period["end_year"]
 
-        # Extracts GWL information for each model
-        for i, model in enumerate(models):
-            print(f"\n...Model {i} {model}...\n")
-            gw_tbl, wl_data_tbl_sim = get_gwl_table(
-                variable, model, scenarios, start_year, end_year
-            )
-            all_gw_tbls.append(gw_tbl)
-            all_gw_data_tbls.append(wl_data_tbl_sim)
-            try:
-                all_wl_data_tbls = pd.concat(
-                    [all_wl_data_tbls, wl_data_tbl_sim], axis=1
+            print("Generate all WL table {}-{}".format(start_year[:4], end_year[:4]))
+            all_wl_data_tbls = pd.DataFrame()
+            all_gw_tbls, all_gw_data_tbls = [], []
+
+            # Extracts GWL information for each model
+            for i, model in enumerate(models):
+                print(f"\n...Model {i} {model}...\n")
+
+                model_config = {
+                    "variable": variable,
+                    "model": model,
+                    "scenarios": scenarios,
+                }
+
+                gw_tbl, wl_data_tbl_sim = self.get_gwl_table(model_config, period)
+
+                if not gw_tbl.empty:
+                    all_gw_tbls.append(gw_tbl)
+                    all_gw_data_tbls.append(wl_data_tbl_sim)
+
+                    try:
+                        all_wl_data_tbls = pd.concat(
+                            [all_wl_data_tbls, wl_data_tbl_sim], axis=1
+                        )
+                    except ValueError as e:  # Change Exception to ValueError
+                        print(
+                            f"\n Model {model} is skipped. Its table cannot be concatenated as its datetime indices are different: \n"
+                        )
+                        print(e)
+
+            # Creating WL lookup table if results were found
+            if all_gw_tbls:
+                all_gw_levels = pd.concat(all_gw_tbls, keys=models)
+                all_gw_levels.index = pd.MultiIndex.from_tuples(
+                    all_gw_levels.index, names=["GCM", "run", "scenario"]
                 )
-            except Exception as e:
+                write_csv_file(
+                    all_gw_levels,
+                    "data/gwl_{}-{}ref_EC-Earth3_ssp370.csv".format(
+                        start_year[:4], end_year[:4]
+                    ),
+                )
                 print(
-                    f"\n Model {model} is skipped. Its table cannot be concatenated as its datetime indices are different: \n"
+                    f"Successfully wrote warming level file for {start_year[:4]}-{end_year[:4]}"
                 )
-                print(e)
-
-        # Creating WL lookup table
-        all_gw_levels = pd.concat(all_gw_tbls, keys=models)
-        all_gw_levels.index = pd.MultiIndex.from_tuples(
-            all_gw_levels.index, names=["GCM", "run", "scenario"]
-        )
-        write_csv_file(
-            all_gw_levels,
-            "data/gwl_{}-{}ref_EC-Earth3_ssp370.csv".format(
-                start_year[:4], end_year[:4]
-            ),
-        )
+            else:
+                print(
+                    f"No warming level data was generated for {start_year[:4]}-{end_year[:4]}"
+                )
 
 
-def get_sims_on_aws(df):
+def main():
     """
-    Generates a pandas DataFrame listing all relevant CMIP6 simulations available on AWS.
-
-    This function filters the input DataFrame `df` and identifies and lists CMIP6 model simulations
-    for historical and various SSP (Shared Socioeconomic Pathway) scenarios. It only includes
-    models that have both historical and at least one SSP ensemble member. Additionally, it ensures
-    that only historical ensemble members with variants in at least one SSP are kept.
-
-    Parameters:
-    ----------
-    df : pandas.DataFrame
-        A DataFrame containing metadata for CMIP6 simulations.
-
-    Returns:
-    -------
-    pandas.DataFrame
-        A DataFrame indexed by model names (source_id) and columns corresponding to scenarios
-        ('historical', 'ssp585', 'ssp370', 'ssp245', 'ssp126'). Each cell contains a list of
-        ensemble member IDs available on AWS for that model and scenario.
+    Main function to run the GWL generator for EC-Earth3 model.
     """
-    df_subset = df[
-        (df.table_id == "Amon")
-        & (df.variable_id == "tas")
-        & (df.experiment_id == "historical")
-    ]
-    models = list(set(df_subset.source_id))
-    models.sort()
+    # Load CMIP6 data catalog
+    df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
 
-    # First cut through the catalog
-    scenarios = ["historical", "ssp585", "ssp370", "ssp245", "ssp126"]
-    sims_on_aws = pd.DataFrame(index=models, columns=scenarios)
+    # Initialize the GWL generator
+    gwl_generator = GWLGenerator(df)
 
-    for model in models:
-        for scenario in scenarios:
-            df_scenario = df[
-                (df.table_id == "Amon")
-                & (df.variable_id == "tas")
-                & (df.experiment_id == scenario)
-                & (df.source_id == model)
-            ]
-            ensMembers = list(set(df_scenario.member_id))
-            sims_on_aws[scenario][model] = ensMembers
+    # Configure parameters
+    models = ["EC-Earth3"]
+    scenarios = ["ssp370"]
+    reference_periods = [{"start_year": "19810101", "end_year": "20101231"}]
 
-    # cut the table to those GCMs that have a historical + at least one SSP ensemble member
-    for i, item in enumerate(sims_on_aws.T.columns):
-        no_ssp = True
-        for ssp in ["ssp585", "ssp370", "ssp245", "ssp126"]:
-            if len(sims_on_aws.loc[item][ssp]) > 0:
-                no_ssp = False
-        if (len(sims_on_aws.loc[item]["historical"]) < 1) or (no_ssp):
-            sims_on_aws = sims_on_aws.drop(index=item)
-
-    # next also drop any historical ensemble members that don't have a variant in an SSP
-    for i, item in enumerate(sims_on_aws.T.columns):
-        variants_to_keep = []
-        for variant in sims_on_aws.loc[item]["historical"]:
-            for ssp in ["ssp585", "ssp370", "ssp245", "ssp126"]:
-                if str(variant) in sims_on_aws.loc[item][ssp]:
-                    variants_to_keep.append(variant)
-        sims_on_aws.loc[item]["historical"] = list(set(variants_to_keep))
-
-    return sims_on_aws
+    # Generate GWL files
+    gwl_generator.generate_gwl_file(models, scenarios, reference_periods)
 
 
 if __name__ == "__main__":

--- a/climakitae/util/generate_gwl_tables_unc.py
+++ b/climakitae/util/generate_gwl_tables_unc.py
@@ -1,14 +1,21 @@
 """
-Util for generating warming level reference data file
-"gwl_1981-2010ref_EC-Earth3_ssp370.csv" in ../data
+Utility for generating Global Warming Level (GWL) reference data files.
 
-The CSV file is generated for use in ../explore/uncertainty.py. It contains,
-for each ensemble member of EC-Earth3, the times when five major warming levels
-are reached under SSP3-7.0.
+This script generates CSV files (e.g., "gwl_1981-2010ref_EC-Earth3_ssp370.csv")
+in the ../data directory. These files are intended for use in uncertainty analysis,
+specifically within ../explore/uncertainty.py.
 
-To run, type: <<python generate_gwl_tables_unc.py>> in the command line and wait
-for printed model outputs showing progress.
+Each CSV file contains, for every specified ensemble member of a given GCM (e.g., EC-Earth3),
+the calculated times when five major warming levels (1.5, 2.0, 2.5, 3.0, 4.0 degrees C)
+are projected to be reached under a specific SSP scenario (e.g., SSP3-7.0), relative
+to a defined reference period.
+
+To run this script:
+    python generate_gwl_tables_unc.py
+Monitor the console output for progress updates.
 """
+
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -22,111 +29,116 @@ def make_weighted_timeseries(temp: xr.DataArray) -> xr.DataArray:
     """
     Creates a spatially-weighted single-dimension time series of global temperature.
 
-    The function weights the latitude grids by size and averages across all longitudes,
-    resulting in a single time series object.
+    Weights latitude grids by the square root of the cosine of their latitude
+    (proportional to grid cell area) and averages across all longitudes.
 
-    Parameters:
+    Parameters
     ----------
-    temp : xarray.DataArray
-        An xarray DataArray of global temperature with latitude and longitude coordinates.
+    temp : xr.DataArray
+        Global temperature data with latitude and longitude coordinates.
+        Coordinates can be named 'lat', 'lon' or 'latitude', 'longitude'.
 
-    Returns:
+    Returns
     -------
-    xarray.DataArray
-        A time series of global temperature that is spatially weighted across latitudes and averaged
-        across all longitudes.
+    xr.DataArray
+        Spatially weighted and longitudinally averaged global temperature time series.
     """
-    # Find variable names for latitude and longitude to make code more readable
+    # Determine coordinate names
     lat, lon = "lat", "lon"
-    if "lat" not in temp.coords and "lon" not in temp.coords:
+    if "latitude" in temp.coords and "longitude" in temp.coords:
         lat, lon = "latitude", "longitude"
+    elif "lat" not in temp.coords or "lon" not in temp.coords:
+        raise ValueError(
+            "Input DataArray must have latitude and longitude coordinates."
+        )
 
-    # Weight latitude grids by size, then average across all longitudes to create single time-series object
+    # Weight by latitude and average over longitude
     weightlat = np.sqrt(np.cos(np.deg2rad(temp[lat])))
-    weightlat = weightlat / np.sum(weightlat)
-    timeseries = (temp * weightlat).sum(lat).mean(lon)
+    weightlat = weightlat / weightlat.sum()  # Normalize weights
+    timeseries = (temp * weightlat).sum(dim=lat).mean(dim=lon)
     return timeseries
 
 
 class GWLGenerator:
     """
-    Class for generating Global Warming Level (GWL) reference data.
-    Encapsulates the parameters and methods needed for GWL calculations.
+    Generates Global Warming Level (GWL) reference data tables.
+
+    Orchestrates the process of fetching CMIP6 data, calculating anomalies,
+    smoothing time series, and determining the timing of GWL crossings for
+    various models, scenarios, and ensemble members.
 
     Attributes
     ----------
-    df : pandas.DataFrame
-        DataFrame containing metadata for CMIP6 simulations
-    sims_on_aws : pandas.DataFrame
-        DataFrame listing available simulations on AWS
+    df : pd.DataFrame
+        DataFrame containing metadata for CMIP6 simulations, loaded from the
+        Pangeo CMIP6 catalog.
+    sims_on_aws : pd.DataFrame
+        DataFrame listing available simulations on AWS S3, filtered for 'tas'
+        variable in 'Amon' table, indexed by model ('source_id'), with columns
+        for scenarios ('experiment_id'). Values are lists of available ensemble
+        members ('member_id').
     fs : s3fs.S3FileSystem
-        S3 file system object for accessing AWS data
+        S3 file system object for anonymous access to AWS S3 data.
 
     Methods
     -------
-    get_sims_on_aws() -> pandas.DataFrame
-        Generates a DataFrame listing all relevant CMIP6 simulations available on AWS.
-    build_timeseries(model_config: dict) -> xarray.Dataset
-        Builds an xarray Dataset with a time dimension, containing the concatenated historical
-        and SSP time series for all specified scenarios of a given model and ensemble member.
-    get_gwl(smoothed: pandas.DataFrame, degree: float) -> pandas.DataFrame
-        Computes the timestamp when a given GWL is first reached.
-    get_gwl_table_one(model_config: dict, reference_period: dict) -> tuple[pandas.DataFrame, pandas.DataFrame]
-        Generates a GWL table for a single model and ensemble member.
-    get_gwl_table(model_config: dict, reference_period: dict) -> tuple[pandas.DataFrame, pandas.DataFrame]
-        Generates GWL tables for a model across all its ensemble members.
-    generate_gwl_file(models: list[str], scenarios: list[str], reference_periods: list[dict])
-        Generates global warming level (GWL) reference files for specified models.
-
-    Examples
-    --------
-    >>> df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
-    >>> gwl_generator = GWLGenerator(df)
-    >>> models = ["EC-Earth3"]
-    >>> scenarios = ["ssp370"]
-    >>> reference_periods = [{"start_year": "19810101", "end_year": "20101231"}]
-    >>> gwl_generator.generate_gwl_file(models, scenarios, reference_periods)
+    get_sims_on_aws()
+        Filters the main CMIP6 catalog to find relevant 'tas' simulations.
+    build_timeseries(model_config)
+        Loads and concatenates historical and scenario time series for a model member.
+    get_gwl(smoothed, degree)
+        Finds the first time a smoothed anomaly series crosses a specific GWL.
+    get_gwl_table_for_single_model_and_ensemble(model_config, reference_period)
+        Calculates GWL crossing times for one model ensemble member.
+    get_gwl_table(model_config, reference_period)
+        Aggregates GWL crossing times across all available ensemble members for a model.
+    generate_gwl_file(models, scenarios, reference_periods)
+        Main method to generate and save the GWL reference CSV files.
     """
 
-    def __init__(self, df, sims_on_aws=None):
+    def __init__(self, df: pd.DataFrame, sims_on_aws: pd.DataFrame = None):
         """
-        Initialize the GWLGenerator with the CMIP6 data catalog.
+        Initializes the GWLGenerator.
 
-        Parameters:
+        Parameters
         ----------
-        df : pandas.DataFrame
-            DataFrame containing metadata for CMIP6 simulations
-        sims_on_aws : pandas.DataFrame, optional
-            DataFrame listing available simulations on AWS. If None, it will be generated.
+        df : pd.DataFrame
+            DataFrame containing metadata for CMIP6 simulations.
+        sims_on_aws : pd.DataFrame, optional
+            Pre-computed DataFrame listing available simulations on AWS.
+            If None (default), it will be generated by calling get_sims_on_aws().
         """
-        self.df = df
-        self.sims_on_aws = (
+        self.df: pd.DataFrame = df
+        self.fs: s3fs.S3FileSystem = s3fs.S3FileSystem(anon=True)
+        self.sims_on_aws: pd.DataFrame = (
             sims_on_aws if sims_on_aws is not None else self.get_sims_on_aws()
         )
-        self.fs = s3fs.S3FileSystem(anon=True)
 
     def get_sims_on_aws(self) -> pd.DataFrame:
         """
-        Generates a pandas DataFrame listing all relevant CMIP6 simulations available on AWS.
+        Filters the CMIP6 catalog DataFrame to identify available simulations.
 
-        Returns:
+        Selects simulations for the 'tas' variable from the 'Amon' table,
+        identifies models with both historical and at least one SSP run,
+        and ensures consistency of ensemble members across historical and SSP runs.
+
+        Returns
         -------
-        pandas.DataFrame
-            DataFrame indexed by model names with columns for different scenarios.
+        pd.DataFrame
+            Filtered DataFrame indexed by model ('source_id') with columns for
+            scenarios, containing lists of valid, consistent ensemble members.
         """
         df_subset = self.df[
             (self.df.table_id == "Amon")
             & (self.df.variable_id == "tas")
             & (self.df.experiment_id == "historical")
         ]
-        models = list(set(df_subset.source_id))
-        models.sort()
+        models: List[str] = sorted(list(set(df_subset.source_id)))
 
-        # First cut through the catalog
-        scenarios = ["historical", "ssp585", "ssp370", "ssp245", "ssp126"]
+        scenarios: List[str] = ["historical", "ssp585", "ssp370", "ssp245", "ssp126"]
         sims_on_aws = pd.DataFrame(index=models, columns=scenarios)
 
-        # Fix 1: Replace chained assignment with loc indexer
+        # Populate DataFrame with available ensemble members for each model/scenario
         for model in models:
             for scenario in scenarios:
                 df_scenario = self.df[
@@ -135,81 +147,105 @@ class GWLGenerator:
                     & (self.df.experiment_id == scenario)
                     & (self.df.source_id == model)
                 ]
-                ensMembers = list(set(df_scenario.member_id))
-                # Use .loc instead of chained indexing
+                ensMembers: List[str] = list(set(df_scenario.member_id))
                 sims_on_aws.loc[model, scenario] = ensMembers
 
-        # cut the table to those GCMs that have a historical + at least one SSP ensemble member
-        models_to_drop = []
-        for i, item in enumerate(sims_on_aws.T.columns):
-            no_ssp = True
-            for ssp in ["ssp585", "ssp370", "ssp245", "ssp126"]:
-                if len(sims_on_aws.loc[item, ssp]) > 0:
-                    no_ssp = False
-            if (len(sims_on_aws.loc[item, "historical"]) < 1) or (no_ssp):
-                models_to_drop.append(item)
-
+        # Filter out models lacking historical runs or any SSP runs
+        models_to_drop: List[str] = []
+        for model in sims_on_aws.index:
+            has_historical = len(sims_on_aws.loc[model, "historical"]) > 0
+            has_ssp = any(
+                len(sims_on_aws.loc[model, ssp]) > 0
+                for ssp in scenarios
+                if ssp != "historical"
+            )
+            if not has_historical or not has_ssp:
+                models_to_drop.append(model)
         sims_on_aws = sims_on_aws.drop(index=models_to_drop)
 
-        # Find the historical ensemble members for each model
-        # and remove them from the SSPs
-        for i, item in enumerate(sims_on_aws.T.columns):
-            variants_to_keep = []
-            for variant in sims_on_aws.loc[item, "historical"]:
-                for ssp in ["ssp585", "ssp370", "ssp245", "ssp126"]:
-                    if str(variant) in sims_on_aws.loc[item, ssp]:
-                        variants_to_keep.append(variant)
-            sims_on_aws.loc[item, "historical"] = list(set(variants_to_keep))
+        # Ensure historical ensemble members are also present in at least one SSP scenario
+        for model in sims_on_aws.index:
+            historical_members = sims_on_aws.loc[model, "historical"]
+            ssp_members_sets = [
+                set(sims_on_aws.loc[model, ssp])
+                for ssp in scenarios
+                if ssp != "historical"
+            ]
+            # Find historical members present in the union of all SSP members for this model
+            valid_historical_members = [
+                member
+                for member in historical_members
+                if any(member in ssp_set for ssp_set in ssp_members_sets)
+            ]
+            sims_on_aws.loc[model, "historical"] = list(
+                set(valid_historical_members)
+            )  # Store unique valid members
 
         sims_on_aws.index.name = "source_id"
-
         return sims_on_aws
 
-    def build_timeseries(self, model_config: dict) -> xr.Dataset:
+    def build_timeseries(
+        self, model_config: Dict[str, Union[str, List[str]]]
+    ) -> xr.Dataset:
         """
-        Builds an xarray Dataset with a time dimension, containing the concatenated historical
-        and SSP time series for all specified scenarios of a given model and ensemble member.
+        Builds concatenated historical + scenario time series for a model member.
 
-        Parameters:
+        Loads data from S3 using zarr, applies spatial weighting, and concatenates
+        the historical run with each specified future scenario run.
+
+        Parameters
         ----------
         model_config : dict
-            Dictionary containing 'variable', 'model', 'ens_mem', and 'scenarios' keys
+            Configuration dictionary specifying 'variable', 'model', 'ens_mem',
+            and 'scenarios' (list of SSPs).
 
-        Returns:
+        Returns
         -------
-        xarray.Dataset
-            Dataset with time as the dimension, containing the appended historical and SSP time series.
+        xr.Dataset
+            Dataset containing the concatenated time series for each requested
+            scenario, with time as the dimension. Returns an empty Dataset if
+            data cannot be loaded or processed.
         """
-        variable = model_config["variable"]
-        model = model_config["model"]
-        ens_mem = model_config["ens_mem"]
-        scenarios = model_config["scenarios"]
+        variable: str = model_config["variable"]
+        model: str = model_config["model"]
+        ens_mem: str = model_config["ens_mem"]
+        scenarios: List[str] = model_config["scenarios"]
 
-        # Get historical data first
-        scenario = "historical"
-        data_historical = xr.Dataset()
-        df_scenario = self.df[
+        data_historical: xr.DataArray = None  # Initialize as None
+
+        # Load historical data
+        df_hist = self.df[
             (self.df.table_id == "Amon")
             & (self.df.variable_id == variable)
-            & (self.df.experiment_id == scenario)
+            & (self.df.experiment_id == "historical")
             & (self.df.source_id == model)
             & (self.df.member_id == ens_mem)
         ]
-        if not df_scenario.empty:
-            with xr.open_zarr(self.fs.get_mapper(df_scenario.zstore.values[0])) as temp:
-                # Create global weighted time-series of variable
-                data_historical = make_weighted_timeseries(temp[variable])
-                data_historical = data_historical.sortby(
-                    "time"
-                )  # needed for MPI-ESM-2-HR
+        if not df_hist.empty:
+            try:
+                with xr.open_zarr(
+                    self.fs.get_mapper(df_hist.zstore.values[0])
+                ) as temp_hist:
+                    data_historical = make_weighted_timeseries(temp_hist[variable])
+                    data_historical = data_historical.sortby("time")
+            except Exception as e:
+                print(f"Error loading historical data for {model} {ens_mem}: {e}")
+                return xr.Dataset()  # Return empty if historical fails
 
-        # Now process each scenario
+        if data_historical is None:
+            print(f"No valid historical data found for {model} {ens_mem}. Skipping.")
+            return xr.Dataset()  # Return empty if no historical data
+
+        # Load and concatenate scenario data
         data_one_model = xr.Dataset()
         for scenario in scenarios:
-            # Check if the ensemble member exists for this scenario
             if (
-                scenario in self.sims_on_aws.T[model]
-                and ens_mem in self.sims_on_aws.T[model][scenario]
+                scenario in self.sims_on_aws.columns  # Check if scenario column exists
+                and model in self.sims_on_aws.index  # Check if model row exists
+                and ens_mem
+                in self.sims_on_aws.loc[
+                    model, scenario
+                ]  # Check if member is listed for this model/scenario
             ):
                 df_scenario = self.df[
                     (self.df.table_id == "Amon")
@@ -219,259 +255,418 @@ class GWLGenerator:
                     & (self.df.member_id == ens_mem)
                 ]
                 if not df_scenario.empty:
-                    with xr.open_zarr(
-                        self.fs.get_mapper(df_scenario.zstore.values[0]),
-                        decode_times=False,
-                    ) as temp:  # BUG: Some scenarios not returning a full predictive period of values
-                        temp = temp.isel(time=slice(0, 1032))
-                        temp = xr.decode_cf(temp)
+                    try:
+                        # Use decode_times=False and manual slicing/decoding for robustness
+                        with xr.open_zarr(
+                            self.fs.get_mapper(df_scenario.zstore.values[0]),
+                            decode_times=False,
+                        ) as temp_scenario_raw:
+                            # Limit time steps and decode
+                            temp_scenario = temp_scenario_raw.isel(time=slice(0, 1032))
+                            temp_scenario = xr.decode_cf(temp_scenario)
 
-                        # Create global weighted time-series of variable
-                        timeseries = make_weighted_timeseries(temp[variable])
+                            timeseries_scenario = make_weighted_timeseries(
+                                temp_scenario[variable]
+                            )
+                            timeseries_scenario = timeseries_scenario.sortby("time")
 
-                        # Clean data and append to `data_one_model`
-                        timeseries = timeseries.sortby(
-                            "time"
-                        )  # needed for MPI-ESM1-2-LR
-                        data_one_model[scenario] = xr.concat(
-                            [data_historical, timeseries], dim="time"
+                            # Concatenate historical and scenario data
+                            data_var = xr.concat(
+                                [data_historical, timeseries_scenario], dim="time"
+                            )
+                            data_var.name = (
+                                scenario  # Ensure the DataArray has the correct name
+                            )
+                            data_one_model[scenario] = data_var
+                    except Exception as e:
+                        print(
+                            f"Error processing scenario {scenario} for {model} {ens_mem}: {e}"
                         )
+                        # Continue to next scenario if one fails
+            else:
+                print(
+                    f"Scenario {scenario} or member {ens_mem} not available for model {model}. Skipping scenario."
+                )
+
         return data_one_model
 
     @staticmethod
-    def get_gwl(smoothed: pd.DataFrame, degree: float) -> pd.DataFrame:
+    def get_gwl(smoothed: pd.DataFrame, degree: float) -> pd.Series:
         """
-        Computes the timestamp when a given GWL is first reached.
+        Computes the timestamp when each scenario first reaches a given GWL.
 
-        Parameters:
+        Parameters
         ----------
-        smoothed : pandas.DataFrame
-            DataFrame containing global mean temperature time series for multiple scenarios
+        smoothed : pd.DataFrame
+            DataFrame where columns are scenarios and rows are smoothed temperature anomalies indexed by time.
         degree : float
-            The global warming level to detect
+            The global warming level (anomaly in degrees C) to detect.
 
-        Returns:
+        Returns
         -------
-        pandas.DataFrame
-            Table with timestamps for when each scenario first crosses the specified warming level
+        pd.Series
+            Series indexed by scenario name, containing the first timestamp
+            when the warming level `degree` is crossed. Returns pd.NaT for
+            scenarios that never cross the level.
         """
 
-        def get_wl_timestamp(scenario: str, degree: float) -> pd.Timestamp:
-            """
-            Find the timestamp that first crosses the given degree.
-            Return np.nan if none of the timestamps pass this degree level.
-            """
-            if any(scenario >= degree):
-                wl_ts = scenario[scenario >= degree].index[0]
-                return wl_ts
+        def get_wl_timestamp(
+            scenario_series: pd.Series, degree_threshold: float
+        ) -> pd.Timestamp:
+            """Find the first timestamp crossing the degree threshold."""
+            crossing_times = scenario_series[scenario_series >= degree_threshold].index
+            if not crossing_times.empty:
+                return crossing_times[0]
             else:
-                return np.nan
+                return pd.NaT  # Use NaT for not reached
 
-        gwl = smoothed.apply(lambda scenario: get_wl_timestamp(scenario, degree))
-        return gwl
+        # Apply the helper function to each column (scenario)
+        gwl_series = smoothed.apply(
+            lambda scenario_col: get_wl_timestamp(scenario_col, degree)
+        )
+        return gwl_series  # Return a Series, not a DataFrame
 
-    def get_gwl_table_one(
-        self, model_config: dict, reference_period: dict
-    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+    def get_gwl_table_for_single_model_and_ensemble(
+        self,
+        model_config: Dict[str, Union[str, List[str]]],
+        reference_period: Dict[str, str],
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """
-        Generates a GWL table for a single model and ensemble member.
+        Generates GWL table and smoothed anomaly data for one model ensemble member.
 
-        Parameters:
+        Calculates temperature anomalies relative to the reference period, smooths them,
+        finds GWL crossing times, and returns both the GWL table and the smoothed data.
+
+        Parameters
         ----------
         model_config : dict
-            Dictionary containing 'variable', 'model', 'ens_mem', and 'scenarios' keys
+            Configuration dictionary specifying 'variable', 'model', 'ens_mem', 'scenarios'.
         reference_period : dict
-            Dictionary containing 'start_year' and 'end_year' keys
+            Dictionary with 'start_year' and 'end_year' (YYYYMMDD format) for the baseline.
 
-        Returns:
+        Returns
         -------
-        tuple
-            DataFrame containing warming levels and DataFrame with global mean temperature time series
+        tuple[pd.DataFrame, pd.DataFrame]
+            - gwlevels: DataFrame indexed by scenario, columns are GWLs (1.5, 2.0, ...),
+                        values are timestamps of first crossing (or NaT).
+            - final_model: DataFrame of smoothed temperature anomalies, indexed by time,
+                           columns named '{ens_mem}_{scenario}'.
+            Returns (empty DataFrame, empty DataFrame) if processing fails.
         """
-        model = model_config["model"]
-        ens_mem = model_config["ens_mem"]
-        start_year = reference_period["start_year"]
-        end_year = reference_period["end_year"]
+        model: str = model_config["model"]
+        ens_mem: str = model_config["ens_mem"]
+        start_year: str = reference_period["start_year"]
+        end_year: str = reference_period["end_year"]
 
         data_one_model = self.build_timeseries(model_config)
-        try:
-            anom = data_one_model - data_one_model.sel(
-                time=slice(start_year, end_year)
-            ).mean("time")
-        except:
-            # some calendars won't allow a 31st of the month end date
-            end_year = str(
-                (pd.to_datetime(end_year) - pd.DateOffset(days=1)).date()
-            ).replace("-", "")
-            anom = data_one_model - data_one_model.sel(
-                time=slice(start_year, end_year)
-            ).mean("time")
+        if not data_one_model.data_vars:  # Check if dataset is empty
+            print(
+                f"Build timeseries returned empty dataset for {model} {ens_mem}. Cannot generate GWL table."
+            )
+            return pd.DataFrame(), pd.DataFrame()
 
+        try:
+            # Calculate anomaly relative to reference period mean
+            ref_slice = slice(start_year, end_year)
+            try:
+                ref_mean = data_one_model.sel(time=ref_slice).mean("time")
+            except Exception:  # Handle potential calendar issues with end date
+                end_date_adjusted = str(
+                    (pd.to_datetime(end_year) - pd.DateOffset(days=1)).date()
+                ).replace("-", "")
+                ref_slice_adjusted = slice(start_year, end_date_adjusted)
+                ref_mean = data_one_model.sel(time=ref_slice_adjusted).mean("time")
+            anom = data_one_model - ref_mean
+        except Exception as e:
+            print(f"Error calculating anomaly for {model} {ens_mem}: {e}")
+            return pd.DataFrame(), pd.DataFrame()
+
+        # Apply 20-year centered rolling mean for smoothing
         smoothed = anom.rolling(time=20 * 12, center=True).mean("time")
 
-        ### one_model is a dataframe of times and warming levels by scenario
-        one_model = (
-            smoothed.to_array(dim="scenario", name=model)
-            .dropna("time", how="all")
-            .to_pandas()  # Dropping time slices that are NaN across all SSPs
+        # Convert smoothed data to pandas DataFrame
+        one_model_smoothed_df = (
+            smoothed.to_array(
+                dim="scenario", name=model
+            )  # Combine scenarios into one DataArray
+            .dropna(
+                "time", how="all"
+            )  # Drop times where all scenarios are NaN (usually ends due to rolling mean)
+            .to_pandas()  # Convert to DataFrame [time x scenario]
         )
-        gwlevels = pd.DataFrame()
-        try:
-            for level in [1.5, 2, 2.5, 3, 4]:
-                gwlevels[level] = self.get_gwl(one_model.T, level)
-        except Exception as e:
-            print(
-                model, ens_mem, " problems"
-            )  # helps EC-Earth3 not be skipped altogether
-            print(e)
 
-        # Modifying and returning one_model to be seen as a WL table
-        final_model = one_model
-        final_model.columns = ens_mem + "_" + final_model.columns
+        if one_model_smoothed_df.empty:
+            print(
+                f"Smoothed data is empty for {model} {ens_mem}. Cannot calculate GWLs."
+            )
+            return pd.DataFrame(), pd.DataFrame()
+
+        # Calculate GWL crossing times for standard levels
+        gwlevels = pd.DataFrame(
+            index=one_model_smoothed_df.columns
+        )  # Index by scenario
+        gwlevels.index.name = "scenario"  # Explicitly name the index
+        try:
+            for level in [1.5, 2.0, 2.5, 3.0, 4.0]:
+                # Pass transposed DataFrame [scenario x time] to get_gwl
+                gwlevels[level] = self.get_gwl(one_model_smoothed_df, level)
+        except Exception as e:
+            print(f"Error calculating GWL crossings for {model} {ens_mem}: {e}")
+            # Return potentially partial results or empty frame if error was early
+            return gwlevels, pd.DataFrame()  # Return empty for final_model on error
+
+        # Prepare the final smoothed anomaly DataFrame with renamed columns
+        final_model = one_model_smoothed_df.copy()
+        final_model.columns = [f"{ens_mem}_{col}" for col in final_model.columns]
+
         return gwlevels, final_model
 
     def get_gwl_table(
-        self, model_config: dict, reference_period: dict
-    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        self,
+        model_config: Dict[str, Union[str, List[str]]],
+        reference_period: Dict[str, str],
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """
-        Generates GWL tables for a model across all its ensemble members.
+        Generates aggregated GWL tables across all available ensemble members for a model.
 
-        Parameters:
+        Iterates through ensemble members listed in `sims_on_aws`, calls
+        `get_gwl_table_for_single_model_and_ensemble` for each, and concatenates
+        the results.
+
+        Parameters
         ----------
         model_config : dict
-            Dictionary containing 'variable', 'model', and 'scenarios' keys
+            Configuration dictionary specifying 'variable', 'model', 'scenarios'.
+            'ens_mem' will be added internally for each member.
         reference_period : dict
-            Dictionary containing 'start_year' and 'end_year' keys
+            Dictionary with 'start_year' and 'end_year' for the baseline.
 
-        Returns:
+        Returns
         -------
-        tuple
-            DataFrame containing warming levels and DataFrame with global mean temperature time series
+        tuple[pd.DataFrame, pd.DataFrame]
+            - gwlevels_concat: DataFrame containing GWL crossing times, indexed by
+                                MultiIndex (ensemble_member, scenario), columns are GWLs.
+            - wl_data_tbl_sim: DataFrame of concatenated smoothed anomalies, indexed by time,
+                                columns named by scenario only (duplicates possible).
+            Returns (empty DataFrame, empty DataFrame) if no valid members are found or processed.
         """
-        model = model_config["model"]
-        scenarios = model_config["scenarios"]
+        model: str = model_config["model"]
+        scenarios: List[str] = model_config["scenarios"]
 
-        ens_mem_list = (
-            self.sims_on_aws.T[model]["ssp370"].copy() if "ssp370" in scenarios else []
+        # Determine the list of ensemble members to process based on a representative scenario (e.g., ssp370)
+        # Assumes member availability is consistent across relevant scenarios used in generate_gwl_file
+        lookup_scenario = "ssp370"  # Or another common scenario expected to be present
+        if (
+            model in self.sims_on_aws.index
+            and lookup_scenario in self.sims_on_aws.columns
+        ):
+            ens_mem_list: List[str] = self.sims_on_aws.loc[model, lookup_scenario]
+            if not isinstance(ens_mem_list, list):
+                ens_mem_list = []  # Handle case where it might not be a list
+        else:
+            ens_mem_list: List[str] = []
+
+        print(
+            f"Model: {model}. Found {len(ens_mem_list)} ensemble members for scenario {lookup_scenario}."
         )
-        # "historical" gives same list as "ssp370"
-        print(f"Number of ensemble members: {len(ens_mem_list)}")
+        if not ens_mem_list:
+            print(
+                f"No ensemble members found for {model} based on {lookup_scenario}. Cannot generate GWL table."
+            )
+            return pd.DataFrame(), pd.DataFrame()
 
-        # Combining all the ensemble members for a given model
-        gwlevels_tbl, wl_data_tbls = [], []
+        # Process each ensemble member
+        gwlevels_results: List[pd.DataFrame] = []
+        wl_data_results: List[pd.DataFrame] = []
+        successful_ens_mems: List[str] = []
+
         for i, ens_mem in enumerate(ens_mem_list):
-            print(f"Getting gwl table for ensemble member {ens_mem}...")
+            print(f"Processing ensemble member {i+1}/{len(ens_mem_list)}: {ens_mem}...")
             try:
                 member_config = model_config.copy()
                 member_config["ens_mem"] = ens_mem
 
-                gwlevels, wl_data_tbl = self.get_gwl_table_one(
-                    member_config, reference_period
+                gwlevels_single, wl_data_single = (
+                    self.get_gwl_table_for_single_model_and_ensemble(
+                        member_config, reference_period
+                    )
                 )
-                gwlevels_tbl.append(gwlevels)
-                wl_data_tbls.append(wl_data_tbl)
-            except Exception as e:
-                print(f"Cannot get gwl table for {i}th ensemble member {ens_mem}")
-                print(e)
 
-        if gwlevels_tbl and wl_data_tbls:
-            # Renaming columns of all ensemble members within model
-            wl_data_tbl_sim = pd.concat(wl_data_tbls, axis=1)
-            wl_data_tbl_sim.columns = model + "_" + wl_data_tbl_sim.columns
-            return pd.concat(gwlevels_tbl, keys=ens_mem_list), wl_data_tbl_sim
+                # Check if results are valid before appending
+                if not gwlevels_single.empty and not wl_data_single.empty:
+                    gwlevels_results.append(gwlevels_single)
+                    wl_data_results.append(wl_data_single)
+                    successful_ens_mems.append(ens_mem)
+                else:
+                    print(f"Skipping member {ens_mem} due to empty results.")
+
+            except Exception as e:
+                print(f"Error processing ensemble member {ens_mem}: {e}. Skipping.")
+
+        # Concatenate results if any were successful
+        if successful_ens_mems:
+            try:
+                # Concatenate GWL tables, using successful members as keys for the outer index level
+                gwlevels_concat = pd.concat(
+                    gwlevels_results,
+                    keys=successful_ens_mems,
+                    names=["ensemble_member", "scenario"],
+                )
+
+                # Concatenate smoothed anomaly tables
+                # The keys ensure correct alignment if indices differ slightly
+                wl_data_tbl_sim_raw = pd.concat(
+                    wl_data_results, axis=1, keys=successful_ens_mems
+                )
+
+                # Rename columns to just the scenario name (level 1 of the MultiIndex)
+                wl_data_tbl_sim = wl_data_tbl_sim_raw.copy()
+                wl_data_tbl_sim.columns = wl_data_tbl_sim_raw.columns.get_level_values(
+                    1
+                )
+
+                print(
+                    f"Successfully processed {len(successful_ens_mems)} ensemble members for {model}."
+                )
+                return gwlevels_concat, wl_data_tbl_sim
+            except Exception as e:
+                print(f"Error during final concatenation for {model}: {e}")
+                return pd.DataFrame(), pd.DataFrame()  # Return empty on concat error
         else:
-            print(f"No valid ensemble members for model {model}")
+            print(f"No ensemble members processed successfully for model {model}.")
             return pd.DataFrame(), pd.DataFrame()
 
     def generate_gwl_file(
-        self, models: list[str], scenarios: list[str], reference_periods: list[dict]
-    ):
+        self,
+        models: List[str],
+        scenarios: List[str],
+        reference_periods: List[Dict[str, str]],
+    ) -> None:
         """
-        Generates global warming level (GWL) reference files for specified models.
+        Generates and saves the GWL reference CSV files for specified configurations.
 
-        Parameters:
+        Iterates through models and reference periods, calls `get_gwl_table` to
+        aggregate results across ensemble members, and writes the final GWL
+        crossing time table to a CSV file.
+
+        Parameters
         ----------
-        models : list
-            List of model names to process
-        scenarios : list
-            List of scenario names to include
-        reference_periods : list
-            List of dictionaries with 'start_year' and 'end_year' keys
+        models : list[str]
+            List of model names (source_id) to process.
+        scenarios : list[str]
+            List of SSP scenario names (experiment_id) to include in the analysis.
+            Note: The current implementation primarily uses 'ssp370' to find members
+            and expects data for the listed scenarios to exist for those members.
+        reference_periods : list[dict]
+            List of dictionaries, each defining a reference period with
+            'start_year' and 'end_year' (YYYYMMDD format).
         """
-        variable = "tas"
+        variable: str = "tas"  # Hardcoded to 'tas' for temperature anomalies
 
         for period in reference_periods:
-            start_year = period["start_year"]
-            end_year = period["end_year"]
+            start_year: str = period["start_year"]
+            end_year: str = period["end_year"]
+            ref_period_str = f"{start_year[:4]}-{end_year[:4]}"
+            print(
+                f"\n--- Generating GWL table for reference period: {ref_period_str} ---"
+            )
 
-            print("Generate all WL table {}-{}".format(start_year[:4], end_year[:4]))
-            all_wl_data_tbls = pd.DataFrame()
-            all_gw_tbls, all_gw_data_tbls = [], []
+            all_gw_tables_for_period: List[pd.DataFrame] = []
+            processed_models: List[str] = (
+                []
+            )  # Keep track of models successfully processed for this period
 
-            # Extracts GWL information for each model
+            # Process each model
             for i, model in enumerate(models):
-                print(f"\n...Model {i} {model}...\n")
+                print(f"\nProcessing Model {i+1}/{len(models)}: {model}...")
 
                 model_config = {
                     "variable": variable,
                     "model": model,
-                    "scenarios": scenarios,
+                    "scenarios": scenarios,  # Pass all requested scenarios
                 }
 
-                gw_tbl, wl_data_tbl_sim = self.get_gwl_table(model_config, period)
+                # Get aggregated GWL table for the model across its members
+                gw_table_model, _ = self.get_gwl_table(
+                    model_config, period
+                )  # Ignore the smoothed data here
 
-                if not gw_tbl.empty:
-                    all_gw_tbls.append(gw_tbl)
-                    all_gw_data_tbls.append(wl_data_tbl_sim)
+                if not gw_table_model.empty:
+                    all_gw_tables_for_period.append(gw_table_model)
+                    processed_models.append(
+                        model
+                    )  # Add model name for final concatenation keys
+                else:
+                    print(
+                        f"No GWL data generated for model {model} for period {ref_period_str}."
+                    )
 
-                    try:
-                        all_wl_data_tbls = pd.concat(
-                            [all_wl_data_tbls, wl_data_tbl_sim], axis=1
-                        )
-                    except ValueError as e:  # Change Exception to ValueError
-                        print(
-                            f"\n Model {model} is skipped. Its table cannot be concatenated as its datetime indices are different: \n"
-                        )
-                        print(e)
+            # Concatenate results from all models for this reference period
+            if all_gw_tables_for_period:
+                # Concatenate using model names as the outermost index level
+                final_gwl_table = pd.concat(
+                    all_gw_tables_for_period,
+                    keys=processed_models,
+                    names=["GCM", "ensemble_member", "scenario"],
+                )
 
-            # Creating WL lookup table if results were found
-            if all_gw_tbls:
-                all_gw_levels = pd.concat(all_gw_tbls, keys=models)
-                all_gw_levels.index = pd.MultiIndex.from_tuples(
-                    all_gw_levels.index, names=["GCM", "run", "scenario"]
-                )
-                write_csv_file(
-                    all_gw_levels,
-                    "data/gwl_{}-{}ref_EC-Earth3_ssp370.csv".format(
-                        start_year[:4], end_year[:4]
-                    ),
-                )
-                print(
-                    f"Successfully wrote warming level file for {start_year[:4]}-{end_year[:4]}"
-                )
+                # Define output filename (consider making scenario part dynamic if needed)
+                # Assuming a primary scenario focus for naming, e.g., ssp370
+                primary_scenario = scenarios[0] if scenarios else "unknown_scenario"
+                filename = f"data/gwl_{ref_period_str}ref_{models[0]}_{primary_scenario}.csv"  # Naming based on first model/scenario
+
+                # Write to CSV
+                try:
+                    write_csv_file(final_gwl_table, filename)
+                    print(f"\nSuccessfully wrote GWL file: {filename}")
+                except Exception as e:
+                    print(f"\nError writing CSV file {filename}: {e}")
             else:
                 print(
-                    f"No warming level data was generated for {start_year[:4]}-{end_year[:4]}"
+                    f"\nNo GWL data generated for any model for reference period {ref_period_str}."
                 )
 
 
-def main():
+def main() -> None:
     """
-    Main function to run the GWL generator for EC-Earth3 model.
+    Main execution function.
+
+    Loads the CMIP6 catalog, initializes the GWLGenerator, defines the
+    models, scenarios, and reference periods to process, and calls
+    generate_gwl_file to produce the output CSV.
     """
     # Load CMIP6 data catalog
-    df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
+    try:
+        df = pd.read_csv("https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv")
+    except Exception as e:
+        print(f"Error loading CMIP6 catalog: {e}")
+        return
 
     # Initialize the GWL generator
-    gwl_generator = GWLGenerator(df)
+    try:
+        gwl_generator = GWLGenerator(df)
+    except Exception as e:
+        print(f"Error initializing GWLGenerator: {e}")
+        return
 
-    # Configure parameters
-    models = ["EC-Earth3"]
-    scenarios = ["ssp370"]
-    reference_periods = [{"start_year": "19810101", "end_year": "20101231"}]
+    # --- Configuration ---
+    models_to_process: List[str] = ["EC-Earth3"]
+    scenarios_to_process: List[str] = [
+        "ssp370"
+    ]  # Primarily used for member lookup and output naming convention
+    reference_periods_to_process: List[Dict[str, str]] = [
+        {"start_year": "19810101", "end_year": "20101231"}
+    ]
+    # --- End Configuration ---
 
     # Generate GWL files
-    gwl_generator.generate_gwl_file(models, scenarios, reference_periods)
+    try:
+        gwl_generator.generate_gwl_file(
+            models_to_process, scenarios_to_process, reference_periods_to_process
+        )
+    except Exception as e:
+        print(f"Error generating GWL file: {e}")
+        return
 
 
 if __name__ == "__main__":

--- a/tests/util/test_generate_gwl_tables_unc.py
+++ b/tests/util/test_generate_gwl_tables_unc.py
@@ -1,0 +1,404 @@
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from climakitae.util.generate_gwl_tables_unc import (
+    GWLGenerator,
+    main,
+    make_weighted_timeseries,
+)
+
+
+@pytest.fixture
+def mock_cmip6_df():
+    """Creates a mock CMIP6 DataFrame for testing."""
+    data = {
+        "zstore": [
+            "s3://bucket/path1",  # hist r1
+            "s3://bucket/path2",  # hist r2
+            "s3://bucket/path3",  # ssp370 r1
+            "s3://bucket/path4",  # ssp370 r2
+            "s3://bucket/path5",  # ssp585 r1
+            "s3://bucket/path6",  # ssp585 r2
+            "s3://bucket/path7",  # ssp126 r1
+            "s3://bucket/path8",  # ssp245 r1
+        ],
+        "table_id": ["Amon"] * 8,
+        "variable_id": ["tas"] * 8,
+        "experiment_id": [
+            "historical",
+            "historical",
+            "ssp370",
+            "ssp370",
+            "ssp585",
+            "ssp585",
+            "ssp126",
+            "ssp245",
+        ],
+        "source_id": ["EC-Earth3"] * 8,
+        "member_id": [
+            "r1i1p1f1",
+            "r2i1p1f1",
+            "r1i1p1f1",
+            "r2i1p1f1",
+            "r1i1p1f1",
+            "r2i1p1f1",
+            "r1i1p1f1",
+            "r1i1p1f1",
+        ],
+    }
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def mock_generator(mock_cmip6_df):
+    """Creates a GWLGenerator instance with mocked dependencies."""
+    with patch("s3fs.S3FileSystem") as mock_s3fs:
+        # Create a mock instance for the S3FileSystem
+        mock_fs_instance = MagicMock()
+        # Configure the mock S3FileSystem class to return our instance
+        mock_s3fs.return_value = mock_fs_instance
+
+        # Mock get_sims_on_aws to avoid complex mocking within __init__
+        with patch.object(
+            GWLGenerator, "get_sims_on_aws", autospec=True
+        ) as mock_get_sims:
+            # Define a simple mock sims_on_aws DataFrame structure
+            sims_data = {
+                "historical": [["r1i1p1f1", "r2i1p1f1"]],
+                "ssp585": [["r1i1p1f1", "r2i1p1f1"]],
+                "ssp370": [["r1i1p1f1", "r2i1p1f1"]],
+                "ssp245": [["r1i1p1f1"]],
+                "ssp126": [["r1i1p1f1"]],
+            }
+            # Use a specific index name for clarity if needed, otherwise default is fine
+            mock_sims_on_aws = pd.DataFrame(sims_data, index=["EC-Earth3"])
+            mock_get_sims.return_value = mock_sims_on_aws
+
+            # Now instantiate GWLGenerator. __init__ will use the mocked s3fs and get_sims_on_aws
+            generator = GWLGenerator(mock_cmip6_df)
+
+            # Although __init__ uses the mocks, let's explicitly ensure the instance
+            # has the correct mock objects assigned for clarity in tests.
+            # __init__ should have already assigned the mock_fs_instance.
+            # If sims_on_aws=None was passed (default), __init__ calls get_sims_on_aws
+            # and assigns its return value (mock_sims_on_aws).
+            assert generator.fs is mock_fs_instance
+            assert generator.sims_on_aws is mock_sims_on_aws
+
+            # Make the mock fs instance's get_mapper return a unique mock per call
+            # to allow asserting calls with different arguments if needed,
+            # or just return a single mock if the return value doesn't matter.
+            # For simplicity here, let's assume the return value itself isn't critical
+            # for the build_timeseries logic, just that it's called.
+            mock_fs_instance.get_mapper = MagicMock(return_value="mock_mapper_path")
+
+            return generator
+
+
+class TestGWLGenerator:
+
+    @patch("s3fs.S3FileSystem")
+    @patch("climakitae.util.generate_gwl_tables_unc.GWLGenerator.get_sims_on_aws")
+    def test_init(self, mock_get_sims_on_aws, mock_s3fs):
+        """
+        Test of init method.
+
+        Test that df is assigned correctly.
+        Test that sims_on_aws is assigned correctly.
+        Test that fs is assigned correctly.
+        """
+
+        # Create a mock DataFrame
+        df = {"GWL": [1.5, 2.0, 2.5], "Year": [2000, 2001, 2002]}
+
+        # Mock the return value of get_sims_on_aws
+        mock_get_sims_on_aws.return_value = "mock_sims_on_aws"
+        # Mock the S3FileSystem instance
+        mock_s3fs.return_value = "mock_fs"
+
+        # Create an instance of GWLGenerator
+        generator = GWLGenerator(df)
+
+        # Assert that the attributes are assigned correctly
+        assert generator.df == df
+        assert generator.sims_on_aws == "mock_sims_on_aws"
+        assert generator.fs == "mock_fs"
+
+    def test_get_sims_on_aws(self):
+        """Test the get_sims_on_aws method for filtering and structuring simulation data."""
+        # --- Mock Input DataFrame (self.df) ---
+        # More complex df to test filtering logic
+        data = {
+            "zstore": [f"s3://path{i}" for i in range(15)],
+            "table_id": ["Amon"] * 14 + ["Omon"],  # Include one wrong table_id
+            "variable_id": ["tas"] * 13 + ["tos", "tas"],  # Include wrong variable_id
+            "experiment_id": [
+                "historical",
+                "historical",
+                "ssp370",
+                "ssp585",  # ModelA (hist+ssp, r1 overlap)
+                "historical",
+                "ssp126",
+                "ssp245",  # ModelB (hist+ssp, no overlap)
+                "historical",
+                "historical",  # ModelC (hist only)
+                "ssp370",
+                "ssp585",  # ModelD (ssp only)
+                "historical",
+                "ssp370",  # ModelE (hist+ssp, r1 overlap, tas)
+                "historical",  # ModelF (hist only, Omon)
+                "historical",  # ModelA (hist only, Omon)
+            ],
+            "source_id": [
+                "ModelA",
+                "ModelA",
+                "ModelA",
+                "ModelA",
+                "ModelB",
+                "ModelB",
+                "ModelB",
+                "ModelC",
+                "ModelC",
+                "ModelD",
+                "ModelD",
+                "ModelE",
+                "ModelE",  # ModelE tas
+                "ModelF",  # ModelF Omon
+                "ModelA",  # ModelA tas again for Omon test
+            ],
+            "member_id": [
+                "r1",
+                "r2",
+                "r1",
+                "r1",  # ModelA
+                "r1",
+                "r2",
+                "r2",  # ModelB
+                "r1",
+                "r2",  # ModelC
+                "r1",
+                "r2",  # ModelD
+                "r1",
+                "r1",  # ModelE tas
+                "r1",  # ModelF Omon
+                "r1",  # ModelA Omon tas
+            ],
+        }
+        mock_df = pd.DataFrame(data)
+
+        # --- Instantiate Generator (without mocking get_sims_on_aws itself) ---
+        # We need to call the actual method, so we only mock s3fs if needed,
+        # but here we don't even need s3fs for this specific method test.
+        # We pass sims_on_aws=True temporarily to prevent __init__ from calling
+        # the method we want to test. Then we set it back to None.
+        generator = GWLGenerator(mock_df, sims_on_aws=True)
+        generator.sims_on_aws = None  # Reset so the method runs
+
+        # --- Call the Method ---
+        result_df = generator.get_sims_on_aws()
+
+        # --- Assertions ---
+        assert isinstance(result_df, pd.DataFrame)
+
+        # Expected models: A, B, E (C dropped - no SSP, D dropped - no hist, F ignored - wrong table/var)
+        expected_index = pd.Index(
+            ["ModelA", "ModelB", "ModelE"], name="source_id"
+        ).sort_values()
+        pd.testing.assert_index_equal(result_df.index.sort_values(), expected_index)
+
+        expected_columns = ["historical", "ssp585", "ssp370", "ssp245", "ssp126"]
+        pd.testing.assert_index_equal(result_df.columns, pd.Index(expected_columns))
+
+        # Check cell values (lists should be sorted for consistent comparison)
+        # ModelA: hist r1, r2; ssp370 r1; ssp585 r1. Keep hist r1 only.
+        assert sorted(result_df.loc["ModelA", "historical"]) == ["r1"]
+        assert sorted(result_df.loc["ModelA", "ssp585"]) == ["r1"]
+        assert sorted(result_df.loc["ModelA", "ssp370"]) == ["r1"]
+        assert sorted(result_df.loc["ModelA", "ssp245"]) == []
+        assert sorted(result_df.loc["ModelA", "ssp126"]) == []
+
+        # ModelB: hist r1; ssp126 r2; ssp245 r2. No overlap, hist should be empty.
+        assert sorted(result_df.loc["ModelB", "historical"]) == []
+        assert sorted(result_df.loc["ModelB", "ssp585"]) == []
+        assert sorted(result_df.loc["ModelB", "ssp370"]) == []
+        assert sorted(result_df.loc["ModelB", "ssp245"]) == ["r2"]
+        assert sorted(result_df.loc["ModelB", "ssp126"]) == ["r2"]
+
+        # ModelE: hist r1; ssp370 r1. Keep hist r1.
+        assert sorted(result_df.loc["ModelE", "historical"]) == ["r1"]
+        assert sorted(result_df.loc["ModelE", "ssp585"]) == []
+        assert sorted(result_df.loc["ModelE", "ssp370"]) == ["r1"]
+        assert sorted(result_df.loc["ModelE", "ssp245"]) == []
+        assert sorted(result_df.loc["ModelE", "ssp126"]) == []
+
+    def test_build_timeseries_basic(self, mock_generator):
+        """Test the basic functionality of build_timeseries, including isel."""
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "ens_mem": "r1i1p1f1",  # Added required ens_mem
+            "scenarios": [
+                "ssp370",
+                "ssp585",
+            ],  # Use scenarios from mock_gwl_generator fixture
+        }
+
+        # --- Mock Data ---
+        # Mock data arrays returned by make_weighted_timeseries
+        historical_time = pd.date_range("1850-01-01", periods=50, freq="MS")
+        # Use a length that will be affected by isel(time=slice(0, 1032)) for testing
+        ssp_time_full = pd.date_range("2015-01-01", periods=1100, freq="MS")
+        ssp_time_sliced = ssp_time_full[:1032]  # The expected time coord after isel
+
+        historical_array = xr.DataArray(
+            np.random.rand(len(historical_time)),
+            coords=[historical_time],
+            dims=["time"],
+            name="hist_ts",
+        ).sortby("time")
+        # These represent the data *after* make_weighted_timeseries is called
+        ssp370_array = xr.DataArray(
+            np.random.rand(len(ssp_time_sliced)) * 2,
+            coords=[ssp_time_sliced],
+            dims=["time"],
+            name="ssp370_ts",
+        ).sortby("time")
+        ssp585_array = xr.DataArray(
+            np.random.rand(len(ssp_time_sliced)) * 3,
+            coords=[ssp_time_sliced],
+            dims=["time"],
+            name="ssp585_ts",
+        ).sortby("time")
+
+        # Mock zarr open results (need __enter__ for context manager)
+        # We mock the object returned by the context manager directly
+        mock_historical_temp_ctx = MagicMock(spec=xr.Dataset)  # Mock as Dataset
+        mock_historical_temp_ctx.__getitem__.return_value = (
+            "mock_hist_data"  # What make_weighted_timeseries receives
+        )
+
+        mock_ssp370_temp_ctx = MagicMock(spec=xr.Dataset)
+        # Mock the isel call specifically to return itself for chaining
+        mock_ssp370_temp_ctx.isel.return_value = mock_ssp370_temp_ctx
+        mock_ssp370_temp_ctx.__getitem__.return_value = "mock_ssp370_data"
+
+        mock_ssp585_temp_ctx = MagicMock(spec=xr.Dataset)
+        mock_ssp585_temp_ctx.isel.return_value = mock_ssp585_temp_ctx
+        mock_ssp585_temp_ctx.__getitem__.return_value = "mock_ssp585_data"
+
+        # Mock the context manager return values
+        mock_historical_open = MagicMock()
+        mock_historical_open.__enter__.return_value = mock_historical_temp_ctx
+        mock_ssp370_open = MagicMock()
+        mock_ssp370_open.__enter__.return_value = mock_ssp370_temp_ctx
+        mock_ssp585_open = MagicMock()
+        mock_ssp585_open.__enter__.return_value = mock_ssp585_temp_ctx
+
+        # Mock concatenated results
+        # Note: The actual concat happens inside the loop, one scenario at a time
+        mock_concatenated_370 = xr.concat([historical_array, ssp370_array], dim="time")
+        mock_concatenated_585 = xr.concat([historical_array, ssp585_array], dim="time")
+
+        # --- Patching ---
+        with patch(
+            "xarray.open_zarr",
+            # Order matters: historical, ssp370, ssp585
+            side_effect=[mock_historical_open, mock_ssp370_open, mock_ssp585_open],
+        ) as mock_open_zarr, patch(
+            "climakitae.util.generate_gwl_tables_unc.make_weighted_timeseries",
+            # Order matters: historical, ssp370, ssp585
+            side_effect=[historical_array, ssp370_array, ssp585_array],
+        ) as mock_make_ts, patch(
+            "xarray.decode_cf",
+            side_effect=lambda ds: ds,  # Pass through mock dataset context
+        ) as mock_decode, patch(
+            "xarray.concat",
+            # Order matters: ssp370 concat, ssp585 concat
+            side_effect=[mock_concatenated_370, mock_concatenated_585],
+        ) as mock_concat:
+
+            # --- Call Method ---
+            result_ds = mock_generator.build_timeseries(model_config)
+
+            # --- Assertions ---
+            # Check calls to fs.get_mapper (using the mock_gwl_generator's fs)
+            # Paths correspond to mock_cmip6_df fixture data
+            assert mock_generator.fs.get_mapper.call_count == 3
+            mock_generator.fs.get_mapper.assert_has_calls(
+                [
+                    call("s3://bucket/path1"),  # historical r1i1p1f1
+                    call("s3://bucket/path3"),  # ssp370 r1i1p1f1
+                    call("s3://bucket/path5"),  # ssp585 r1i1p1f1
+                ],
+                any_order=False,
+            )
+
+            # Check open_zarr calls
+            assert mock_open_zarr.call_count == 3
+            # Check args for each call (hist doesn't decode_times=False)
+            mock_open_zarr.assert_has_calls(
+                [
+                    call(mock_generator.fs.get_mapper.return_value),  # hist call
+                    call(
+                        mock_generator.fs.get_mapper.return_value,
+                        decode_times=False,
+                    ),  # ssp370 call
+                    call(
+                        mock_generator.fs.get_mapper.return_value,
+                        decode_times=False,
+                    ),  # ssp585 call
+                ]
+            )
+
+            # Check isel calls (only on scenario data context managers)
+            mock_ssp370_temp_ctx.isel.assert_called_once_with(time=slice(0, 1032))
+            mock_ssp585_temp_ctx.isel.assert_called_once_with(time=slice(0, 1032))
+            mock_historical_temp_ctx.isel.assert_not_called()  # Should not be called on historical
+
+            # Check make_weighted_timeseries calls
+            assert mock_make_ts.call_count == 3
+            mock_make_ts.assert_has_calls(
+                [
+                    call("mock_hist_data"),
+                    call("mock_ssp370_data"),
+                    call("mock_ssp585_data"),
+                ]
+            )
+
+            # Check decode_cf calls (only on scenario data context managers, after isel)
+            assert mock_decode.call_count == 2
+            mock_decode.assert_has_calls(
+                [
+                    call(mock_ssp370_temp_ctx),  # Called on the result of isel
+                    call(mock_ssp585_temp_ctx),  # Called on the result of isel
+                ]
+            )
+
+            # Check concat calls
+            assert mock_concat.call_count == 2
+            # Check first concat call (ssp370)
+            concat_args_370, concat_kwargs_370 = mock_concat.call_args_list[0]
+            assert len(concat_args_370[0]) == 2  # List of two arrays
+            xr.testing.assert_equal(concat_args_370[0][0], historical_array)
+            # The second item should be the *sorted* ssp370_array (sorting happens in the code)
+            xr.testing.assert_equal(concat_args_370[0][1], ssp370_array)
+            assert concat_kwargs_370["dim"] == "time"
+            # Check second concat call (ssp585)
+            concat_args_585, concat_kwargs_585 = mock_concat.call_args_list[1]
+            assert len(concat_args_585[0]) == 2
+            xr.testing.assert_equal(concat_args_585[0][0], historical_array)
+            xr.testing.assert_equal(concat_args_585[0][1], ssp585_array)
+            assert concat_kwargs_585["dim"] == "time"
+
+            # Check the final result dataset
+            assert isinstance(result_ds, xr.Dataset)
+            assert list(result_ds.data_vars.keys()) == [
+                "ssp370",
+                "ssp585",
+            ]  # Check data variables
+            xr.testing.assert_equal(result_ds["ssp370"], mock_concatenated_370)
+            xr.testing.assert_equal(result_ds["ssp585"], mock_concatenated_585)

--- a/tests/util/test_generate_gwl_tables_unc.py
+++ b/tests/util/test_generate_gwl_tables_unc.py
@@ -893,7 +893,7 @@ class TestGWLGenerator:
                     reference_period,
                 ),
             ]
-            mock_get_single.assert_has_calls(expected_calls)
+            mock_get_single.assert_has_calls(expected_calls, any_order=True)
 
             # Check aggregated gwlevels DataFrame
             assert isinstance(gwlevels_agg, pd.DataFrame)

--- a/tests/util/test_generate_gwl_tables_unc.py
+++ b/tests/util/test_generate_gwl_tables_unc.py
@@ -1,8 +1,10 @@
+from typing import Dict, List, Tuple
 from unittest.mock import MagicMock, call, patch
 
 import numpy as np
 import pandas as pd
 import pytest
+import s3fs  # Import needed for type hinting
 import xarray as xr
 
 from climakitae.util.generate_gwl_tables_unc import (
@@ -13,7 +15,7 @@ from climakitae.util.generate_gwl_tables_unc import (
 
 
 @pytest.fixture
-def mock_cmip6_df():
+def mock_cmip6_df() -> pd.DataFrame:
     """Creates a mock CMIP6 DataFrame for testing."""
     data = {
         "zstore": [
@@ -54,19 +56,15 @@ def mock_cmip6_df():
 
 
 @pytest.fixture
-def mock_generator(mock_cmip6_df):
-    """Creates a GWLGenerator instance with mocked dependencies."""
+def mock_generator(mock_cmip6_df: pd.DataFrame) -> GWLGenerator:
+    """Creates a GWLGenerator instance with mocked S3FileSystem and get_sims_on_aws."""
     with patch("s3fs.S3FileSystem") as mock_s3fs:
-        # Create a mock instance for the S3FileSystem
-        mock_fs_instance = MagicMock()
-        # Configure the mock S3FileSystem class to return our instance
-        mock_s3fs.return_value = mock_fs_instance
+        mock_fs_instance = mock_s3fs.return_value
 
-        # Mock get_sims_on_aws to avoid complex mocking within __init__
         with patch.object(
             GWLGenerator, "get_sims_on_aws", autospec=True
         ) as mock_get_sims:
-            # Define a simple mock sims_on_aws DataFrame structure
+            # Define a mock sims_on_aws DataFrame structure
             sims_data = {
                 "historical": [["r1i1p1f1", "r2i1p1f1"]],
                 "ssp585": [["r1i1p1f1", "r2i1p1f1"]],
@@ -74,84 +72,78 @@ def mock_generator(mock_cmip6_df):
                 "ssp245": [["r1i1p1f1"]],
                 "ssp126": [["r1i1p1f1"]],
             }
-            # Use a specific index name for clarity if needed, otherwise default is fine
             mock_sims_on_aws = pd.DataFrame(sims_data, index=["EC-Earth3"])
             mock_get_sims.return_value = mock_sims_on_aws
 
-            # Now instantiate GWLGenerator. __init__ will use the mocked s3fs and get_sims_on_aws
+            # Instantiate GWLGenerator; __init__ uses the mocks
             generator = GWLGenerator(mock_cmip6_df)
 
-            # Although __init__ uses the mocks, let's explicitly ensure the instance
-            # has the correct mock objects assigned for clarity in tests.
-            # __init__ should have already assigned the mock_fs_instance.
-            # If sims_on_aws=None was passed (default), __init__ calls get_sims_on_aws
-            # and assigns its return value (mock_sims_on_aws).
+            # Verify mocks are assigned correctly within the instance
             assert generator.fs is mock_fs_instance
             assert generator.sims_on_aws is mock_sims_on_aws
 
-            # Make the mock fs instance's get_mapper return a unique mock per call
-            # to allow asserting calls with different arguments if needed,
-            # or just return a single mock if the return value doesn't matter.
-            # For simplicity here, let's assume the return value itself isn't critical
-            # for the build_timeseries logic, just that it's called.
+            # Mock the get_mapper method
             mock_fs_instance.get_mapper = MagicMock(return_value="mock_mapper_path")
 
             return generator
 
 
 class TestGWLGenerator:
+    """Tests for the GWLGenerator class methods."""
 
     @patch("s3fs.S3FileSystem")
     @patch("climakitae.util.generate_gwl_tables_unc.GWLGenerator.get_sims_on_aws")
-    def test_init(self, mock_get_sims_on_aws, mock_s3fs):
+    def test_init(self, mock_get_sims_on_aws: MagicMock, mock_s3fs: MagicMock):
         """
-        Test of init method.
+        Test the __init__ method of GWLGenerator.
 
-        Test that df is assigned correctly.
-        Test that sims_on_aws is assigned correctly.
-        Test that fs is assigned correctly.
+        Verifies correct assignment of df, sims_on_aws, and fs attributes.
         """
+        mock_df_data = {"GWL": [1.5, 2.0, 2.5], "Year": [2000, 2001, 2002]}
+        mock_df = pd.DataFrame(mock_df_data)
+        mock_sims_return = pd.DataFrame({"historical": [["r1"]]}, index=["ModelA"])
+        # mock_s3fs is the mock class provided by patch.
+        # mock_s3fs.return_value is the mock instance that __init__ will receive.
+        mock_fs_instance = mock_s3fs.return_value
 
-        # Create a mock DataFrame
-        df = {"GWL": [1.5, 2.0, 2.5], "Year": [2000, 2001, 2002]}
+        mock_get_sims_on_aws.return_value = mock_sims_return
+        # No need to set mock_s3fs.return_value here, patch does it.
 
-        # Mock the return value of get_sims_on_aws
-        mock_get_sims_on_aws.return_value = "mock_sims_on_aws"
-        # Mock the S3FileSystem instance
-        mock_s3fs.return_value = "mock_fs"
+        generator = GWLGenerator(mock_df)
 
-        # Create an instance of GWLGenerator
-        generator = GWLGenerator(df)
-
-        # Assert that the attributes are assigned correctly
-        assert generator.df == df
-        assert generator.sims_on_aws == "mock_sims_on_aws"
-        assert generator.fs == "mock_fs"
+        pd.testing.assert_frame_equal(generator.df, mock_df)
+        pd.testing.assert_frame_equal(generator.sims_on_aws, mock_sims_return)
+        assert (
+            generator.fs is mock_fs_instance
+        )  # Check __init__ received the correct instance
+        mock_get_sims_on_aws.assert_called_once()  # Called because sims_on_aws was None
+        mock_s3fs.assert_called_once_with(
+            anon=True
+        )  # Check S3FileSystem was instantiated
 
     def test_get_sims_on_aws(self):
         """Test the get_sims_on_aws method for filtering and structuring simulation data."""
-        # --- Mock Input DataFrame (self.df) ---
         # More complex df to test filtering logic
         data = {
             "zstore": [f"s3://path{i}" for i in range(15)],
-            "table_id": ["Amon"] * 14 + ["Omon"],  # Include one wrong table_id
-            "variable_id": ["tas"] * 13 + ["tos", "tas"],  # Include wrong variable_id
+            "table_id": ["Amon"] * 14 + ["Omon"],
+            "variable_id": ["tas"] * 13 + ["tos", "tas"],
             "experiment_id": [
                 "historical",
                 "historical",
                 "ssp370",
-                "ssp585",  # ModelA (hist+ssp, r1 overlap)
+                "ssp585",  # ModelA
                 "historical",
                 "ssp126",
-                "ssp245",  # ModelB (hist+ssp, no overlap)
+                "ssp245",  # ModelB
                 "historical",
-                "historical",  # ModelC (hist only)
+                "historical",  # ModelC
                 "ssp370",
-                "ssp585",  # ModelD (ssp only)
+                "ssp585",  # ModelD
                 "historical",
-                "ssp370",  # ModelE (hist+ssp, r1 overlap, tas)
-                "historical",  # ModelF (hist only, Omon)
-                "historical",  # ModelA (hist only, Omon)
+                "ssp370",  # ModelE
+                "historical",  # ModelF (Omon)
+                "historical",  # ModelA (Omon)
             ],
             "source_id": [
                 "ModelA",
@@ -166,9 +158,9 @@ class TestGWLGenerator:
                 "ModelD",
                 "ModelD",
                 "ModelE",
-                "ModelE",  # ModelE tas
-                "ModelF",  # ModelF Omon
-                "ModelA",  # ModelA tas again for Omon test
+                "ModelE",
+                "ModelF",
+                "ModelA",
             ],
             "member_id": [
                 "r1",
@@ -183,28 +175,22 @@ class TestGWLGenerator:
                 "r1",
                 "r2",  # ModelD
                 "r1",
-                "r1",  # ModelE tas
-                "r1",  # ModelF Omon
-                "r1",  # ModelA Omon tas
+                "r1",  # ModelE
+                "r1",  # ModelF
+                "r1",  # ModelA
             ],
         }
         mock_df = pd.DataFrame(data)
 
-        # --- Instantiate Generator (without mocking get_sims_on_aws itself) ---
-        # We need to call the actual method, so we only mock s3fs if needed,
-        # but here we don't even need s3fs for this specific method test.
-        # We pass sims_on_aws=True temporarily to prevent __init__ from calling
-        # the method we want to test. Then we set it back to None.
-        generator = GWLGenerator(mock_df, sims_on_aws=True)
-        generator.sims_on_aws = None  # Reset so the method runs
+        # Instantiate Generator, bypassing __init__'s call to the method
+        generator = GWLGenerator(mock_df, sims_on_aws=True)  # Pass dummy value
+        generator.sims_on_aws = None  # Reset so the actual method runs
 
-        # --- Call the Method ---
         result_df = generator.get_sims_on_aws()
 
-        # --- Assertions ---
         assert isinstance(result_df, pd.DataFrame)
 
-        # Expected models: A, B, E (C dropped - no SSP, D dropped - no hist, F ignored - wrong table/var)
+        # Expected models: A, B, E (C dropped - no SSP, D dropped - no hist, F ignored)
         expected_index = pd.Index(
             ["ModelA", "ModelB", "ModelE"], name="source_id"
         ).sort_values()
@@ -214,45 +200,40 @@ class TestGWLGenerator:
         pd.testing.assert_index_equal(result_df.columns, pd.Index(expected_columns))
 
         # Check cell values (lists should be sorted for consistent comparison)
-        # ModelA: hist r1, r2; ssp370 r1; ssp585 r1. Keep hist r1 only.
+        # ModelA: hist r1, r2; ssp370 r1; ssp585 r1. Keep hist r1 only (present in SSPs).
         assert sorted(result_df.loc["ModelA", "historical"]) == ["r1"]
         assert sorted(result_df.loc["ModelA", "ssp585"]) == ["r1"]
         assert sorted(result_df.loc["ModelA", "ssp370"]) == ["r1"]
-        assert sorted(result_df.loc["ModelA", "ssp245"]) == []
-        assert sorted(result_df.loc["ModelA", "ssp126"]) == []
+        assert result_df.loc["ModelA", "ssp245"] == []  # Check empty list directly
+        assert result_df.loc["ModelA", "ssp126"] == []
 
         # ModelB: hist r1; ssp126 r2; ssp245 r2. No overlap, hist should be empty.
-        assert sorted(result_df.loc["ModelB", "historical"]) == []
-        assert sorted(result_df.loc["ModelB", "ssp585"]) == []
-        assert sorted(result_df.loc["ModelB", "ssp370"]) == []
+        assert result_df.loc["ModelB", "historical"] == []
+        assert result_df.loc["ModelB", "ssp585"] == []
+        assert result_df.loc["ModelB", "ssp370"] == []
         assert sorted(result_df.loc["ModelB", "ssp245"]) == ["r2"]
         assert sorted(result_df.loc["ModelB", "ssp126"]) == ["r2"]
 
         # ModelE: hist r1; ssp370 r1. Keep hist r1.
         assert sorted(result_df.loc["ModelE", "historical"]) == ["r1"]
-        assert sorted(result_df.loc["ModelE", "ssp585"]) == []
+        assert result_df.loc["ModelE", "ssp585"] == []
         assert sorted(result_df.loc["ModelE", "ssp370"]) == ["r1"]
-        assert sorted(result_df.loc["ModelE", "ssp245"]) == []
-        assert sorted(result_df.loc["ModelE", "ssp126"]) == []
+        assert result_df.loc["ModelE", "ssp245"] == []
+        assert result_df.loc["ModelE", "ssp126"] == []
 
-    def test_build_timeseries_basic(self, mock_generator):
-        """Test the basic functionality of build_timeseries, including isel."""
-        model_config = {
+    def test_build_timeseries_basic(self, mock_generator: GWLGenerator):
+        """Test basic functionality of build_timeseries, including data loading and concatenation."""
+        model_config: Dict = {
             "variable": "tas",
             "model": "EC-Earth3",
-            "ens_mem": "r1i1p1f1",  # Added required ens_mem
-            "scenarios": [
-                "ssp370",
-                "ssp585",
-            ],  # Use scenarios from mock_gwl_generator fixture
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp370", "ssp585"],
         }
 
-        # --- Mock Data ---
         # Mock data arrays returned by make_weighted_timeseries
         historical_time = pd.date_range("1850-01-01", periods=50, freq="MS")
-        # Use a length that will be affected by isel(time=slice(0, 1032)) for testing
         ssp_time_full = pd.date_range("2015-01-01", periods=1100, freq="MS")
-        ssp_time_sliced = ssp_time_full[:1032]  # The expected time coord after isel
+        ssp_time_sliced = ssp_time_full[:1032]  # Expected time coord after isel
 
         historical_array = xr.DataArray(
             np.random.rand(len(historical_time)),
@@ -260,7 +241,6 @@ class TestGWLGenerator:
             dims=["time"],
             name="hist_ts",
         ).sortby("time")
-        # These represent the data *after* make_weighted_timeseries is called
         ssp370_array = xr.DataArray(
             np.random.rand(len(ssp_time_sliced)) * 2,
             coords=[ssp_time_sliced],
@@ -274,59 +254,59 @@ class TestGWLGenerator:
             name="ssp585_ts",
         ).sortby("time")
 
-        # Mock zarr open results (need __enter__ for context manager)
-        # We mock the object returned by the context manager directly
-        mock_historical_temp_ctx = MagicMock(spec=xr.Dataset)  # Mock as Dataset
-        mock_historical_temp_ctx.__getitem__.return_value = (
-            "mock_hist_data"  # What make_weighted_timeseries receives
+        # Mock zarr open results (mocking the context manager's return value)
+        mock_historical_ds_ctx = MagicMock(spec=xr.Dataset)
+        mock_historical_ds_ctx.__getitem__.return_value = (
+            "mock_hist_data_array"  # What make_weighted_timeseries receives
         )
 
-        mock_ssp370_temp_ctx = MagicMock(spec=xr.Dataset)
-        # Mock the isel call specifically to return itself for chaining
-        mock_ssp370_temp_ctx.isel.return_value = mock_ssp370_temp_ctx
-        mock_ssp370_temp_ctx.__getitem__.return_value = "mock_ssp370_data"
+        mock_ssp370_ds_ctx_raw = MagicMock(spec=xr.Dataset)  # Before isel/decode
+        mock_ssp370_ds_ctx_processed = MagicMock(spec=xr.Dataset)  # After isel/decode
+        mock_ssp370_ds_ctx_raw.isel.return_value = (
+            mock_ssp370_ds_ctx_processed  # isel returns the processed mock
+        )
+        mock_ssp370_ds_ctx_processed.__getitem__.return_value = "mock_ssp370_data_array"
 
-        mock_ssp585_temp_ctx = MagicMock(spec=xr.Dataset)
-        mock_ssp585_temp_ctx.isel.return_value = mock_ssp585_temp_ctx
-        mock_ssp585_temp_ctx.__getitem__.return_value = "mock_ssp585_data"
+        mock_ssp585_ds_ctx_raw = MagicMock(spec=xr.Dataset)
+        mock_ssp585_ds_ctx_processed = MagicMock(spec=xr.Dataset)
+        mock_ssp585_ds_ctx_raw.isel.return_value = mock_ssp585_ds_ctx_processed
+        mock_ssp585_ds_ctx_processed.__getitem__.return_value = "mock_ssp585_data_array"
 
-        # Mock the context manager return values
+        # Mock the context manager __enter__ return values
         mock_historical_open = MagicMock()
-        mock_historical_open.__enter__.return_value = mock_historical_temp_ctx
+        mock_historical_open.__enter__.return_value = mock_historical_ds_ctx
         mock_ssp370_open = MagicMock()
-        mock_ssp370_open.__enter__.return_value = mock_ssp370_temp_ctx
+        mock_ssp370_open.__enter__.return_value = (
+            mock_ssp370_ds_ctx_raw  # open_zarr returns the raw mock
+        )
         mock_ssp585_open = MagicMock()
-        mock_ssp585_open.__enter__.return_value = mock_ssp585_temp_ctx
+        mock_ssp585_open.__enter__.return_value = mock_ssp585_ds_ctx_raw
 
         # Mock concatenated results
-        # Note: The actual concat happens inside the loop, one scenario at a time
         mock_concatenated_370 = xr.concat([historical_array, ssp370_array], dim="time")
         mock_concatenated_585 = xr.concat([historical_array, ssp585_array], dim="time")
 
-        # --- Patching ---
-        with patch(
-            "xarray.open_zarr",
-            # Order matters: historical, ssp370, ssp585
-            side_effect=[mock_historical_open, mock_ssp370_open, mock_ssp585_open],
-        ) as mock_open_zarr, patch(
-            "climakitae.util.generate_gwl_tables_unc.make_weighted_timeseries",
-            # Order matters: historical, ssp370, ssp585
-            side_effect=[historical_array, ssp370_array, ssp585_array],
-        ) as mock_make_ts, patch(
-            "xarray.decode_cf",
-            side_effect=lambda ds: ds,  # Pass through mock dataset context
-        ) as mock_decode, patch(
-            "xarray.concat",
-            # Order matters: ssp370 concat, ssp585 concat
-            side_effect=[mock_concatenated_370, mock_concatenated_585],
-        ) as mock_concat:
-
-            # --- Call Method ---
+        with (
+            patch(
+                "xarray.open_zarr",
+                side_effect=[mock_historical_open, mock_ssp370_open, mock_ssp585_open],
+            ) as mock_open_zarr,
+            patch(
+                "climakitae.util.generate_gwl_tables_unc.make_weighted_timeseries",
+                side_effect=[historical_array, ssp370_array, ssp585_array],
+            ) as mock_make_ts,
+            patch(
+                "xarray.decode_cf", side_effect=lambda ds: ds
+            ) as mock_decode,  # Pass through the already-mocked dataset
+            patch(
+                "xarray.concat",
+                side_effect=[mock_concatenated_370, mock_concatenated_585],
+            ) as mock_concat,
+        ):
             result_ds = mock_generator.build_timeseries(model_config)
 
-            # --- Assertions ---
-            # Check calls to fs.get_mapper (using the mock_gwl_generator's fs)
-            # Paths correspond to mock_cmip6_df fixture data
+            # Assertions
+            # Check fs.get_mapper calls (using mock_generator's fs)
             assert mock_generator.fs.get_mapper.call_count == 3
             mock_generator.fs.get_mapper.assert_has_calls(
                 [
@@ -339,42 +319,39 @@ class TestGWLGenerator:
 
             # Check open_zarr calls
             assert mock_open_zarr.call_count == 3
-            # Check args for each call (hist doesn't decode_times=False)
             mock_open_zarr.assert_has_calls(
                 [
                     call(mock_generator.fs.get_mapper.return_value),  # hist call
                     call(
-                        mock_generator.fs.get_mapper.return_value,
-                        decode_times=False,
+                        mock_generator.fs.get_mapper.return_value, decode_times=False
                     ),  # ssp370 call
                     call(
-                        mock_generator.fs.get_mapper.return_value,
-                        decode_times=False,
+                        mock_generator.fs.get_mapper.return_value, decode_times=False
                     ),  # ssp585 call
                 ]
             )
 
-            # Check isel calls (only on scenario data context managers)
-            mock_ssp370_temp_ctx.isel.assert_called_once_with(time=slice(0, 1032))
-            mock_ssp585_temp_ctx.isel.assert_called_once_with(time=slice(0, 1032))
-            mock_historical_temp_ctx.isel.assert_not_called()  # Should not be called on historical
+            # Check isel calls (only on raw scenario datasets)
+            mock_ssp370_ds_ctx_raw.isel.assert_called_once_with(time=slice(0, 1032))
+            mock_ssp585_ds_ctx_raw.isel.assert_called_once_with(time=slice(0, 1032))
+            mock_historical_ds_ctx.isel.assert_not_called()
 
             # Check make_weighted_timeseries calls
             assert mock_make_ts.call_count == 3
             mock_make_ts.assert_has_calls(
                 [
-                    call("mock_hist_data"),
-                    call("mock_ssp370_data"),
-                    call("mock_ssp585_data"),
+                    call("mock_hist_data_array"),
+                    call("mock_ssp370_data_array"),
+                    call("mock_ssp585_data_array"),
                 ]
             )
 
-            # Check decode_cf calls (only on scenario data context managers, after isel)
+            # Check decode_cf calls (only on processed scenario datasets)
             assert mock_decode.call_count == 2
             mock_decode.assert_has_calls(
                 [
-                    call(mock_ssp370_temp_ctx),  # Called on the result of isel
-                    call(mock_ssp585_temp_ctx),  # Called on the result of isel
+                    call(mock_ssp370_ds_ctx_processed),  # Called on the result of isel
+                    call(mock_ssp585_ds_ctx_processed),
                 ]
             )
 
@@ -382,10 +359,11 @@ class TestGWLGenerator:
             assert mock_concat.call_count == 2
             # Check first concat call (ssp370)
             concat_args_370, concat_kwargs_370 = mock_concat.call_args_list[0]
-            assert len(concat_args_370[0]) == 2  # List of two arrays
+            assert len(concat_args_370[0]) == 2
             xr.testing.assert_equal(concat_args_370[0][0], historical_array)
-            # The second item should be the *sorted* ssp370_array (sorting happens in the code)
-            xr.testing.assert_equal(concat_args_370[0][1], ssp370_array)
+            xr.testing.assert_equal(
+                concat_args_370[0][1], ssp370_array
+            )  # Sorting happens in build_timeseries
             assert concat_kwargs_370["dim"] == "time"
             # Check second concat call (ssp585)
             concat_args_585, concat_kwargs_585 = mock_concat.call_args_list[1]
@@ -396,39 +374,1119 @@ class TestGWLGenerator:
 
             # Check the final result dataset
             assert isinstance(result_ds, xr.Dataset)
-            assert list(result_ds.data_vars.keys()) == [
-                "ssp370",
-                "ssp585",
-            ]  # Check data variables
+            assert list(result_ds.data_vars.keys()) == ["ssp370", "ssp585"]
             xr.testing.assert_equal(result_ds["ssp370"], mock_concatenated_370)
             xr.testing.assert_equal(result_ds["ssp585"], mock_concatenated_585)
 
+    def test_build_timeseries_historical_load_error(self, mock_generator):
+        # Setup a model_config that will match a row in mock_generator.df
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp370"],
+        }
+        # Patch xr.open_zarr to raise an exception
+        with patch("xarray.open_zarr", side_effect=Exception("Simulated error")):
+            result = mock_generator.build_timeseries(model_config)
+            assert isinstance(result, xr.Dataset)
+            assert not result.data_vars  # Should be empty due to error
+
+    def test_build_timeseries_no_historical_data(self, mock_generator):
+        """
+        Test build_timeseries returns empty Dataset if no historical data is found (df_hist is empty).
+        This covers lines 236-237 in generate_gwl_tables_unc.py.
+        """
+        model_config = {
+            "variable": "tas",
+            "model": "NonexistentModel",
+            "ens_mem": "rX",
+            "scenarios": ["ssp370"],
+        }
+        # The mock_generator.df fixture does not contain this model/member, so df_hist will be empty.
+        result = mock_generator.build_timeseries(model_config)
+        assert isinstance(result, xr.Dataset)
+        assert not result.data_vars  # Should be empty due to no historical data
+
+    def test_build_timeseries_scenario_load_error(self, mock_generator):
+        """
+        Test build_timeseries handles errors when loading scenario data.
+        This covers lines 359-362 in generate_gwl_tables_unc.py.
+        """
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp370"],
+        }
+
+        # Mock that will succeed for historical but fail for scenario
+        historical_array = xr.DataArray(
+            np.random.rand(10),
+            coords=[pd.date_range("1850-01-01", periods=10, freq="MS")],
+            dims=["time"],
+            name="historical",
+        )
+
+        # Create mock objects and context managers
+        mock_historical_ds = MagicMock(spec=xr.Dataset)
+        mock_historical_ds.__getitem__.return_value = MagicMock()
+
+        mock_historical_open = MagicMock()
+        mock_historical_open.__enter__.return_value = mock_historical_ds
+
+        def side_effect_function(mapper, **kwargs):
+            if "path1" in str(mapper):  # Historical path
+                return mock_historical_open
+            else:  # Scenario path
+                raise Exception("Simulated scenario error")
+
+        with (
+            patch("xarray.open_zarr", side_effect=side_effect_function),
+            patch(
+                "climakitae.util.generate_gwl_tables_unc.make_weighted_timeseries",
+                return_value=historical_array,
+            ),
+        ):
+            result = mock_generator.build_timeseries(model_config)
+
+            # Should return a Dataset with no scenario data since scenario loading failed
+            assert isinstance(result, xr.Dataset)
+            assert len(result.data_vars) == 0  # No scenario data added
+
+    def test_build_timeseries_scenario_data_error(self, mock_generator):
+        """
+        Test build_timeseries error handling when scenario data fails.
+        This covers lines 281-287 in generate_gwl_tables_unc.py.
+        """
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp370", "ssp585"],
+        }
+
+        # Create mock arrays
+        historical_array = xr.DataArray(
+            np.random.rand(10),
+            coords=[pd.date_range("1850-01-01", periods=10, freq="MS")],
+            dims=["time"],
+            name="historical",
+        )
+
+        # Create mock objects for historical and scenario datasets
+        mock_historical_ds = MagicMock(spec=xr.Dataset)
+        mock_historical_ds.__getitem__.return_value = "mock_historical_data"
+
+        mock_historical_open = MagicMock()
+        mock_historical_open.__enter__.return_value = mock_historical_ds
+
+        # This mock will raise an exception for scenario in open_zarr to test the exception handling
+        def side_effect_open_zarr(mapper, **kwargs):
+            if "path1" in str(mapper):  # historical path
+                return mock_historical_open
+            else:  # scenario paths
+                raise Exception("Simulated scenario data error")
+
+        with (
+            patch("xarray.open_zarr", side_effect=side_effect_open_zarr),
+            patch(
+                "climakitae.util.generate_gwl_tables_unc.make_weighted_timeseries",
+                return_value=historical_array,
+            ),
+        ):
+            result = mock_generator.build_timeseries(model_config)
+
+            # Should return a Dataset with no data vars since all scenarios failed
+            assert isinstance(result, xr.Dataset)
+            assert len(result.data_vars) == 0
+
     def test_get_gwl(self):
         """
-        Test of get_gwl method.
+        Test the static get_gwl method.
 
-        Test that correct timestamps are returned when scenarios cross warming levels.
-        Test that np.nan is returned when a scenario doesn't cross the warming level.
+        Verifies correct timestamp identification for GWL crossing and
+        handling of scenarios that never cross (returning NaT).
         """
-        # Create mock DataFrame with temperature scenarios
         index = pd.date_range(start="2000-01-01", periods=5, freq="YE")
         data = {
-            "scenario1": pd.Series([0.8, 1.2, 1.6, 1.9, 2.1], index=index),
-            "scenario2": pd.Series([0.7, 0.9, 1.1, 1.3, 1.4], index=index),
+            "scenario1": pd.Series(
+                [0.8, 1.2, 1.6, 1.9, 2.1], index=index
+            ),  # Crosses 1.0, 1.5
+            "scenario2": pd.Series(
+                [0.7, 0.9, 1.1, 1.3, 1.4], index=index
+            ),  # Crosses 1.0
         }
         smoothed = pd.DataFrame(data)
 
-        # Test with warming level that both scenarios eventually cross
+        # Test level crossed by both
         result1 = GWLGenerator.get_gwl(smoothed, 1.0)
+        assert isinstance(result1, pd.Series)
         assert result1["scenario1"] == pd.Timestamp("2001-12-31")
         assert result1["scenario2"] == pd.Timestamp("2002-12-31")
 
-        # Test with warming level that only one scenario crosses
+        # Test level crossed by only one
         result2 = GWLGenerator.get_gwl(smoothed, 1.5)
         assert result2["scenario1"] == pd.Timestamp("2002-12-31")
-        assert pd.isna(result2["scenario2"])
+        assert pd.isna(result2["scenario2"])  # Check for NaT/nan
 
-        # Test with warming level that no scenario crosses
+        # Test level crossed by none
         result3 = GWLGenerator.get_gwl(smoothed, 2.5)
         assert pd.isna(result3["scenario1"])
         assert pd.isna(result3["scenario2"])
+
+    def test_get_gwl_table_for_single_model_and_ensemble(
+        self, mock_generator: GWLGenerator
+    ):
+        """
+        Test get_gwl_table_for_single_model_and_ensemble method.
+
+        Covers basic functionality, anomaly calculation, smoothing, GWL detection,
+        and exception handling for date selection.
+        """
+        model_config: Dict = {
+            "variable": "tas",
+            "model": "TestModel",
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp245", "ssp585"],
+        }
+        reference_period: Dict[str, str] = {
+            "start_year": "18500101",
+            "end_year": "19001231",
+        }  # Use YYYYMMDD
+
+        # Mock data for the Dataset returned by build_timeseries
+        time_range = pd.date_range(start="1850-01-01", end="2100-12-31", freq="MS")
+        ssp245_data = np.linspace(0, 3, len(time_range))  # Linear warming 0 to 3 deg
+        ssp585_data = np.linspace(0, 5, len(time_range))  # Linear warming 0 to 5 deg
+        mock_built_ds = xr.Dataset(
+            {"ssp245": (["time"], ssp245_data), "ssp585": (["time"], ssp585_data)},
+            coords={"time": time_range},
+        )
+
+        # Mock the DataFrame resulting from smoothing and converting to pandas
+        # This represents `one_model_smoothed_df` inside the function
+        mock_smoothed_df = pd.DataFrame(
+            {
+                "ssp245": np.linspace(0.5, 2.5, 20),  # Simplified smoothed data
+                "ssp585": np.linspace(0.8, 4.0, 20),
+            },
+            index=pd.date_range(
+                start="2010-01-01", periods=20, freq="YE"
+            ),  # Example index after smoothing
+        )
+
+        # Mock the return value of the static get_gwl method
+        def mock_gwl_function(df: pd.DataFrame, level: float) -> pd.Series:
+            # Simulate realistic return values based on mock_smoothed_df
+            timestamps = {
+                1.5: {
+                    "ssp245": pd.Timestamp("2015-12-31"),
+                    "ssp585": pd.Timestamp("2013-12-31"),
+                },
+                2.0: {
+                    "ssp245": pd.Timestamp("2018-12-31"),
+                    "ssp585": pd.Timestamp("2015-12-31"),
+                },
+                2.5: {
+                    "ssp245": pd.Timestamp("2020-12-31"),
+                    "ssp585": pd.Timestamp("2017-12-31"),
+                },
+                3.0: {"ssp245": pd.NaT, "ssp585": pd.Timestamp("2019-12-31")},
+                4.0: {"ssp245": pd.NaT, "ssp585": pd.Timestamp("2022-12-31")},
+            }
+            if level in timestamps:
+                # Ensure the Series index matches the input DataFrame columns
+                return pd.Series(timestamps[level], index=df.columns)
+            else:
+                return pd.Series([pd.NaT] * len(df.columns), index=df.columns)
+
+        with (
+            patch.object(
+                mock_generator, "build_timeseries", return_value=mock_built_ds
+            ) as mock_build_ts,
+            # Patch the static method via the class
+            patch.object(
+                GWLGenerator, "get_gwl", side_effect=mock_gwl_function
+            ) as mock_get_gwl_static,
+            # Mock the intermediate conversion to pandas after smoothing
+            patch.object(
+                xr.DataArray, "to_pandas", return_value=mock_smoothed_df
+            ) as mock_to_pandas,
+        ):
+            # --- Call 1: Normal reference period ---
+            gwlevels, final_model = (
+                mock_generator.get_gwl_table_for_single_model_and_ensemble(
+                    model_config, reference_period
+                )
+            )
+
+            # Assertions for Call 1
+            mock_build_ts.assert_called_once_with(model_config)
+            mock_to_pandas.assert_called_once()  # Check conversion after smoothing
+            assert mock_get_gwl_static.call_count == 5  # Called for 5 levels
+
+            # Check gwlevels DataFrame structure and content
+            assert isinstance(gwlevels, pd.DataFrame)
+            expected_gwl_cols = [1.5, 2.0, 2.5, 3.0, 4.0]
+            pd.testing.assert_index_equal(
+                gwlevels.columns, pd.Index(expected_gwl_cols, dtype=float)
+            )
+            expected_gwl_index = pd.Index(
+                ["ssp245", "ssp585"], name="scenario"
+            )  # Should be indexed by scenario
+            pd.testing.assert_index_equal(gwlevels.index, expected_gwl_index)
+            assert gwlevels.loc["ssp245", 1.5] == pd.Timestamp("2015-12-31")
+            assert pd.isna(gwlevels.loc["ssp245", 3.0])
+            assert gwlevels.loc["ssp585", 4.0] == pd.Timestamp("2022-12-31")
+
+            # Check final_model DataFrame structure (smoothed anomalies)
+            assert isinstance(final_model, pd.DataFrame)
+            expected_final_cols = ["r1i1p1f1_ssp245", "r1i1p1f1_ssp585"]
+            pd.testing.assert_index_equal(
+                final_model.columns, pd.Index(expected_final_cols)
+            )
+            # Check if it's the same data as mock_smoothed_df (before column rename)
+            final_model_renamed = final_model.rename(
+                columns=lambda x: x.split("_", 1)[1]
+            )
+            final_model_renamed.columns.name = None
+            mock_smoothed_df.columns.name = None
+            pd.testing.assert_frame_equal(
+                final_model_renamed,
+                mock_smoothed_df,
+            )
+
+            # --- Call 2: Test exception handling path for reference period ---
+            mock_build_ts.reset_mock()
+            mock_get_gwl_static.reset_mock()
+            mock_to_pandas.reset_mock()
+
+            # Simulate sel failing first time, succeeding second time
+            # We need to mock sel here specifically for the exception handling test path
+            with patch.object(
+                xr.Dataset,
+                "sel",
+                side_effect=[
+                    KeyError("Invalid date format"),  # First call raises error
+                    mock_built_ds.isel(
+                        time=slice(0, 5)
+                    ),  # Second call returns a valid Dataset
+                ],
+            ):
+                reference_period_problem = {
+                    "start_year": "1850",
+                    "end_year": "1900-12-31",
+                }  # Invalid format
+
+                gwlevels_2, final_model_2 = (
+                    mock_generator.get_gwl_table_for_single_model_and_ensemble(
+                        model_config, reference_period_problem
+                    )
+                )
+
+                # Assertions for Call 2
+                assert isinstance(
+                    gwlevels_2, pd.DataFrame
+                )  # Should still return valid structure
+                assert isinstance(final_model_2, pd.DataFrame)
+                pd.testing.assert_index_equal(
+                    final_model_2.columns, pd.Index(expected_final_cols)
+                )
+
+    def test_get_gwl_table_for_single_model_and_ensemble_reference_period_error(
+        self, mock_generator
+    ):
+        """
+        Test error handling when reference period selection fails with calendar issues.
+        This covers lines 413-416 in generate_gwl_tables_unc.py.
+        """
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp370"],
+        }
+        reference_period = {"start_year": "19810101", "end_year": "20101231"}
+
+        # Create mocked dataset with time coordinates that will trigger calendar adjustment
+        time_range = pd.date_range(start="1850-01-01", end="2100-12-31", freq="MS")
+        mock_ds = xr.Dataset(
+            {"ssp370": (["time"], np.random.rand(len(time_range)))},
+            coords={"time": time_range},
+        )
+
+        # Instead of replacing mock_ds.sel, patch xarray's Dataset.sel method
+        with (
+            patch.object(mock_generator, "build_timeseries", return_value=mock_ds),
+            patch.object(
+                xr.Dataset,
+                "sel",
+                side_effect=[
+                    KeyError("Invalid date"),  # First sel fails
+                    mock_ds.isel(time=slice(0, 5)),  # Second sel succeeds
+                ],
+            ),
+        ):
+            # Call the method
+            gwlevels, final_model = (
+                mock_generator.get_gwl_table_for_single_model_and_ensemble(
+                    model_config, reference_period
+                )
+            )
+
+            # Verify the first call failed and second worked
+            assert not gwlevels.empty  # Should have results since second sel worked
+
+    def test_get_gwl_table_for_single_model_and_ensemble_anomaly_error(
+        self, mock_generator
+    ):
+        """Test error handling when calculating anomalies fails."""
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp370"],
+        }
+        reference_period = {
+            "start_year": "19810101",
+            "end_year": "20101231",
+        }
+
+        # Mock a non-empty dataset return from build_timeseries
+        mock_ds = xr.Dataset(
+            {
+                "ssp370": (["time"], np.array([1.0, 2.0])),
+            },
+            coords={"time": pd.date_range("2000-01-01", periods=2)},
+        )
+
+        with (
+            patch.object(mock_generator, "build_timeseries", return_value=mock_ds),
+            patch.object(
+                xr.Dataset, "sel", side_effect=Exception("Reference period error")
+            ),
+        ):
+            gwlevels, final_model = (
+                mock_generator.get_gwl_table_for_single_model_and_ensemble(
+                    model_config, reference_period
+                )
+            )
+
+            # Should return empty DataFrames due to anomaly calculation error
+            assert isinstance(gwlevels, pd.DataFrame)
+            assert gwlevels.empty
+            assert isinstance(final_model, pd.DataFrame)
+            assert final_model.empty
+
+    def test_get_gwl_table_for_single_model_and_ensemble_empty_smoothed(
+        self, mock_generator
+    ):
+        """Test handling of empty smoothed data after processing."""
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp370"],
+        }
+        reference_period = {
+            "start_year": "19810101",
+            "end_year": "20101231",
+        }
+
+        # Create a mock dataset where all values will be NaN after smoothing
+        mock_ds = xr.Dataset(
+            {
+                "ssp370": (["time"], np.array([np.nan, np.nan])),
+            },
+            coords={"time": pd.date_range("2000-01-01", periods=2)},
+        )
+
+        # Mock empty smoothed DataFrame
+        empty_df = pd.DataFrame()
+
+        # Instead of patching the rolling method, mock the entire smoothing operation
+        with (
+            patch.object(mock_generator, "build_timeseries", return_value=mock_ds),
+            patch.object(xr.Dataset, "sel", return_value=mock_ds),
+            patch.object(xr.Dataset, "rolling", return_value=MagicMock()),
+            patch("xarray.DataArray.to_pandas", return_value=empty_df),
+        ):
+            gwlevels, final_model = (
+                mock_generator.get_gwl_table_for_single_model_and_ensemble(
+                    model_config, reference_period
+                )
+            )
+
+            # Should return empty DataFrames due to empty smoothed data
+            assert isinstance(gwlevels, pd.DataFrame)
+            assert gwlevels.empty
+            assert isinstance(final_model, pd.DataFrame)
+            assert final_model.empty
+
+    def test_get_gwl_table_for_single_model_and_ensemble_gwl_error(
+        self, mock_generator
+    ):
+        """Test error handling when calculating GWL crossings fails."""
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "ens_mem": "r1i1p1f1",
+            "scenarios": ["ssp370"],
+        }
+        reference_period = {
+            "start_year": "19810101",
+            "end_year": "20101231",
+        }
+
+        # Mock non-empty smoothed DataFrame
+        smoothed_df = pd.DataFrame(
+            {"ssp370": [1.0, 1.5, 2.0]}, index=pd.date_range("2000-01-01", periods=3)
+        )
+
+        with (
+            patch.object(mock_generator, "build_timeseries", return_value=xr.Dataset()),
+            patch.object(xr.DataArray, "to_pandas", return_value=smoothed_df),
+            patch.object(
+                GWLGenerator, "get_gwl", side_effect=Exception("GWL calculation error")
+            ),
+        ):
+            gwlevels, final_model = (
+                mock_generator.get_gwl_table_for_single_model_and_ensemble(
+                    model_config, reference_period
+                )
+            )
+
+            # Should return potentially partial gwlevels and empty final_model
+            assert isinstance(gwlevels, pd.DataFrame)
+            assert isinstance(final_model, pd.DataFrame)
+            assert final_model.empty  # final_model should be empty on error
+
+    def test_get_gwl_table(self, mock_generator: GWLGenerator):
+        """
+        Test the get_gwl_table method for aggregating results across ensemble members.
+
+        Covers:
+        1. Basic aggregation with multiple members.
+        2. Handling exceptions during single member processing.
+        3. Returning empty DataFrames when no members succeed or are found.
+        """
+        model_config: Dict = {
+            "variable": "tas",
+            "model": "TestModel",
+            "scenarios": ["ssp370", "ssp585"],
+        }
+        reference_period: Dict[str, str] = {
+            "start_year": "18500101",
+            "end_year": "19001231",
+        }
+
+        # Mock sims_on_aws to list members for the model
+        mock_generator.sims_on_aws = pd.DataFrame(
+            {
+                "historical": [
+                    ["r1", "r2", "r3"]
+                ],  # Need historical for consistency check in get_sims_on_aws if called
+                "ssp370": [["r1", "r2", "r3"]],
+                "ssp585": [["r1", "r2", "r3"]],
+                "ssp126": [[]],
+                "ssp245": [[]],
+            },
+            index=pd.Index(["TestModel"], name="source_id"),
+        )
+        # Ensure the lookup scenario 'ssp370' exists
+        assert "ssp370" in mock_generator.sims_on_aws.columns
+
+        # Mock return values for get_gwl_table_for_single_model_and_ensemble
+        # Member r1 (success)
+        gwlevels_r1 = pd.DataFrame(
+            {
+                1.5: [pd.Timestamp("2030-01-01"), pd.Timestamp("2025-01-01")],
+                2.0: [pd.Timestamp("2045-01-01"), pd.Timestamp("2040-01-01")],
+            },
+            index=pd.Index(["ssp370", "ssp585"], name="scenario"),
+        )
+        timeseries_r1 = pd.DataFrame(
+            {"r1_ssp370": np.linspace(0, 3, 20), "r1_ssp585": np.linspace(0, 4, 20)},
+            index=pd.date_range(start="2000-01-01", periods=20, freq="YE"),
+        )
+
+        # Member r2 (failure) - simulated by raising Exception
+
+        # Member r3 (success)
+        gwlevels_r3 = pd.DataFrame(
+            {
+                1.5: [pd.Timestamp("2032-01-01"), pd.Timestamp("2027-01-01")],
+                2.0: [pd.Timestamp("2047-01-01"), pd.Timestamp("2042-01-01")],
+            },
+            index=pd.Index(["ssp370", "ssp585"], name="scenario"),
+        )
+        timeseries_r3 = pd.DataFrame(
+            {
+                "r3_ssp370": np.linspace(0, 3.2, 20),
+                "r3_ssp585": np.linspace(0, 4.2, 20),
+            },
+            index=pd.date_range(start="2000-01-01", periods=20, freq="YE"),
+        )
+
+        # --- Test Case 1: Basic aggregation with one failure ---
+        with patch.object(
+            mock_generator,
+            "get_gwl_table_for_single_model_and_ensemble",
+            side_effect=[
+                (gwlevels_r1, timeseries_r1),
+                Exception("Simulated processing failure for r2"),
+                (gwlevels_r3, timeseries_r3),
+            ],
+        ) as mock_get_single:
+
+            gwlevels_agg, timeseries_agg = mock_generator.get_gwl_table(
+                model_config, reference_period
+            )
+
+            # Assert calls to the single-member function
+            assert mock_get_single.call_count == 3
+            expected_calls = [
+                call(
+                    {
+                        "variable": "tas",
+                        "model": "TestModel",
+                        "scenarios": ["ssp370", "ssp585"],
+                        "ens_mem": "r1",
+                    },
+                    reference_period,
+                ),
+                call(
+                    {
+                        "variable": "tas",
+                        "model": "TestModel",
+                        "scenarios": ["ssp370", "ssp585"],
+                        "ens_mem": "r2",
+                    },
+                    reference_period,
+                ),
+                call(
+                    {
+                        "variable": "tas",
+                        "model": "TestModel",
+                        "scenarios": ["ssp370", "ssp585"],
+                        "ens_mem": "r3",
+                    },
+                    reference_period,
+                ),
+            ]
+            mock_get_single.assert_has_calls(expected_calls)
+
+            # Check aggregated gwlevels DataFrame
+            assert isinstance(gwlevels_agg, pd.DataFrame)
+            expected_gwl_index = pd.MultiIndex.from_tuples(
+                [
+                    ("r1", "ssp370"),
+                    ("r1", "ssp585"),
+                    ("r3", "ssp370"),
+                    ("r3", "ssp585"),
+                ],
+                names=["ensemble_member", "scenario"],
+            )
+            pd.testing.assert_index_equal(gwlevels_agg.index, expected_gwl_index)
+            expected_gwl_cols = [1.5, 2.0]  # Based on mock data
+            pd.testing.assert_index_equal(
+                gwlevels_agg.columns, pd.Index(expected_gwl_cols, dtype=float)
+            )
+            assert gwlevels_agg.loc[("r1", "ssp370"), 1.5] == pd.Timestamp("2030-01-01")
+            assert gwlevels_agg.loc[("r3", "ssp585"), 2.0] == pd.Timestamp("2042-01-01")
+
+            # Check aggregated timeseries DataFrame
+            assert isinstance(timeseries_agg, pd.DataFrame)
+            # Columns should include ensemble member prefix
+            expected_ts_cols = ["r1_ssp370", "r1_ssp585", "r3_ssp370", "r3_ssp585"]
+            pd.testing.assert_index_equal(
+                timeseries_agg.columns, pd.Index(expected_ts_cols)
+            )
+            # Check a value to ensure concatenation worked as expected
+            # Value from r3_ssp370, first element
+            assert timeseries_agg["r3_ssp370"].iloc[0] == 0.0
+            # Check a value from r1_ssp585, last element
+            assert timeseries_agg["r1_ssp585"].iloc[-1] == 4.0
+
+        # --- Test Case 2: All members fail ---
+        with patch.object(
+            mock_generator,
+            "get_gwl_table_for_single_model_and_ensemble",
+            side_effect=Exception("All failed"),  # All calls raise an exception
+        ) as mock_get_single_fail:
+
+            empty_gwlevels, empty_timeseries = mock_generator.get_gwl_table(
+                model_config, reference_period
+            )
+
+            assert mock_get_single_fail.call_count == 3  # Still attempts all members
+            assert empty_gwlevels.empty
+            assert empty_timeseries.empty
+
+        # --- Test Case 3: No members found initially ---
+        # Modify sims_on_aws to have no members for the lookup scenario
+        mock_generator.sims_on_aws.loc["TestModel", "ssp370"] = []
+
+        with patch.object(
+            mock_generator, "get_gwl_table_for_single_model_and_ensemble"
+        ) as mock_get_single_no_members:
+
+            no_member_gwlevels, no_member_timeseries = mock_generator.get_gwl_table(
+                model_config, reference_period
+            )
+
+            mock_get_single_no_members.assert_not_called()  # Should not be called if list is empty
+            assert no_member_gwlevels.empty
+            assert no_member_timeseries.empty
+
+    def test_get_gwl_table_concat_error(self, mock_generator):
+        """
+        Test error handling in get_gwl_table during final concatenation.
+        This covers lines 465-467 in generate_gwl_tables_unc.py.
+        """
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "scenarios": ["ssp370"],
+        }
+        reference_period = {"start_year": "19810101", "end_year": "20101231"}
+
+        # Mock sims_on_aws to list members for the model
+        mock_generator.sims_on_aws = pd.DataFrame(
+            {
+                "historical": [["r1", "r2"]],
+                "ssp370": [["r1", "r2"]],
+            },
+            index=pd.Index(["EC-Earth3"], name="source_id"),
+        )
+
+        # Create mock return values
+        gwlevels_r1 = pd.DataFrame(
+            {
+                1.5: [pd.Timestamp("2030-01-01")],
+            },
+            index=pd.Index(["ssp370"], name="scenario"),
+        )
+        timeseries_r1 = pd.DataFrame(
+            {"r1_ssp370": np.linspace(0, 3, 10)},
+            index=pd.date_range(start="2000-01-01", periods=10, freq="YE"),
+        )
+
+        gwlevels_r2 = pd.DataFrame(
+            {
+                1.5: [pd.Timestamp("2032-01-01")],
+            },
+            # Different column name will cause concat to fail
+            index=pd.Index(["different_scenario"], name="scenario"),
+        )
+        timeseries_r2 = pd.DataFrame(
+            {"r2_ssp370": np.linspace(0, 3.2, 10)},
+            index=pd.date_range(start="2000-01-01", periods=10, freq="YE"),
+        )
+
+        # Patch pd.concat to simulate a failure during concatenation
+        with (
+            patch.object(
+                mock_generator,
+                "get_gwl_table_for_single_model_and_ensemble",
+                side_effect=[
+                    (gwlevels_r1, timeseries_r1),
+                    (gwlevels_r2, timeseries_r2),
+                ],
+            ),
+            patch(
+                "pandas.concat",
+                side_effect=Exception("Concat error: inconsistent indexes"),
+            ),
+        ):
+            gwlevels_agg, timeseries_agg = mock_generator.get_gwl_table(
+                model_config, reference_period
+            )
+
+            # Should return empty DataFrames when concatenation fails
+            assert isinstance(gwlevels_agg, pd.DataFrame)
+            assert gwlevels_agg.empty
+            assert isinstance(timeseries_agg, pd.DataFrame)
+            assert timeseries_agg.empty
+
+    def test_generate_gwl_file(self, mock_generator: GWLGenerator):
+        """Test the generate_gwl_file method for orchestrating and writing results."""
+        # Input configuration
+        models_list: List[str] = ["EC-Earth3"]
+        scenarios_list: List[str] = ["ssp370"]
+        ref_periods_list: List[Dict[str, str]] = [
+            {"start_year": "19810101", "end_year": "20101231"}
+        ]
+        ref_period_str = "1981-2010"  # Expected string format
+
+        # Mock return value for get_gwl_table (aggregated results)
+        # GWL table (MultiIndex: member, scenario)
+        mock_agg_gwlevels_index = pd.MultiIndex.from_tuples(
+            [("r1i1p1f1", "ssp370")], names=["ensemble_member", "scenario"]
+        )
+        mock_agg_gwlevels = pd.DataFrame(
+            {1.5: [pd.Timestamp("2030-01-01")], 2.0: [pd.Timestamp("2045-01-01")]},
+            index=mock_agg_gwlevels_index,
+        )
+        # Smoothed timeseries (columns are scenarios) - this is ignored by generate_gwl_file
+        mock_agg_timeseries = pd.DataFrame(
+            {"ssp370": np.linspace(0, 3, 20)},
+            index=pd.date_range(start="2000-01-01", periods=20, freq="YE"),
+        )
+
+        # Expected final DataFrame structure to be written to CSV
+        expected_final_gwl_index = pd.MultiIndex.from_tuples(
+            [("EC-Earth3", "r1i1p1f1", "ssp370")],
+            names=["GCM", "ensemble_member", "scenario"],
+        )
+        expected_final_gwl_df = pd.DataFrame(
+            {1.5: [pd.Timestamp("2030-01-01")], 2.0: [pd.Timestamp("2045-01-01")]},
+            index=expected_final_gwl_index,
+        )
+        expected_filename = (
+            f"data/gwl_{ref_period_str}ref_{models_list[0]}_{scenarios_list[0]}.csv"
+        )
+
+        with (
+            patch.object(
+                mock_generator,
+                "get_gwl_table",
+                return_value=(mock_agg_gwlevels, mock_agg_timeseries),
+            ) as mock_get_gwl_table,
+            patch(
+                "climakitae.util.generate_gwl_tables_unc.write_csv_file"
+            ) as mock_write_csv,
+        ):
+            mock_generator.generate_gwl_file(
+                models_list, scenarios_list, ref_periods_list
+            )
+
+            # Assert get_gwl_table was called correctly
+            mock_get_gwl_table.assert_called_once()
+            call_args, call_kwargs = mock_get_gwl_table.call_args
+            expected_model_config_call = {
+                "variable": "tas",  # Hardcoded in generate_gwl_file
+                "model": "EC-Earth3",
+                "scenarios": ["ssp370"],
+            }
+            assert call_args[0] == expected_model_config_call
+            assert call_args[1] == ref_periods_list[0]
+
+            # Assert write_csv_file was called correctly
+            mock_write_csv.assert_called_once()
+            write_call_args, write_call_kwargs = mock_write_csv.call_args
+            # Check the DataFrame passed to write_csv_file
+            pd.testing.assert_frame_equal(write_call_args[0], expected_final_gwl_df)
+            # Check the filename passed to write_csv_file
+            assert write_call_args[1] == expected_filename
+
+    def test_generate_gwl_file_empty_results(self, mock_generator: GWLGenerator):
+        """Test generate_gwl_file when get_gwl_table returns empty DataFrames."""
+        models_list = ["EC-Earth3"]
+        scenarios_list = ["ssp370"]
+        ref_periods_list = [{"start_year": "19810101", "end_year": "20101231"}]
+
+        # Mock get_gwl_table to return empty DataFrames
+        with patch.object(
+            mock_generator,
+            "get_gwl_table",
+            return_value=(pd.DataFrame(), pd.DataFrame()),
+        ) as mock_get_gwl_table:
+            # Should not raise any exceptions, just print message about no data
+            mock_generator.generate_gwl_file(
+                models_list, scenarios_list, ref_periods_list
+            )
+            mock_get_gwl_table.assert_called_once()
+
+    def test_generate_gwl_file_csv_write_error(self, mock_generator: GWLGenerator):
+        """Test generate_gwl_file handling CSV writing errors."""
+        models_list = ["EC-Earth3"]
+        scenarios_list = ["ssp370"]
+        ref_periods_list = [{"start_year": "19810101", "end_year": "20101231"}]
+
+        # Create valid GWL table to test CSV writing path
+        mock_agg_gwlevels_index = pd.MultiIndex.from_tuples(
+            [("r1i1p1f1", "ssp370")], names=["ensemble_member", "scenario"]
+        )
+        mock_agg_gwlevels = pd.DataFrame(
+            {1.5: [pd.Timestamp("2030-01-01")]},
+            index=mock_agg_gwlevels_index,
+        )
+
+        with (
+            patch.object(
+                mock_generator,
+                "get_gwl_table",
+                return_value=(mock_agg_gwlevels, pd.DataFrame()),
+            ),
+            patch(
+                "climakitae.util.generate_gwl_tables_unc.write_csv_file",
+                side_effect=Exception("CSV write error"),
+            ) as mock_write_csv,
+        ):
+            # Should catch the exception and print error message
+            mock_generator.generate_gwl_file(
+                models_list, scenarios_list, ref_periods_list
+            )
+            mock_write_csv.assert_called_once()
+
+    def test_generate_gwl_file_multiple_periods(self, mock_generator: GWLGenerator):
+        """Test generate_gwl_file with multiple reference periods."""
+        models_list = ["EC-Earth3", "CMCC-ESM2"]
+        scenarios_list = ["ssp370"]
+        ref_periods_list = [
+            {"start_year": "19810101", "end_year": "20101231"},
+            {"start_year": "19510101", "end_year": "19801231"},
+        ]
+
+        # Create valid GWL table to test the processing path
+        mock_agg_gwlevels_index = pd.MultiIndex.from_tuples(
+            [("r1i1p1f1", "ssp370")], names=["ensemble_member", "scenario"]
+        )
+        mock_agg_gwlevels = pd.DataFrame(
+            {1.5: [pd.Timestamp("2030-01-01")]},
+            index=mock_agg_gwlevels_index,
+        )
+
+        with (
+            patch.object(
+                mock_generator,
+                "get_gwl_table",
+                return_value=(mock_agg_gwlevels, pd.DataFrame()),
+            ) as mock_get_gwl_table,
+            patch(
+                "climakitae.util.generate_gwl_tables_unc.write_csv_file"
+            ) as mock_write_csv,
+        ):
+            mock_generator.generate_gwl_file(
+                models_list, scenarios_list, ref_periods_list
+            )
+
+            # Should be called for each model and reference period
+            assert mock_get_gwl_table.call_count == 4  # 2 models × 2 periods
+
+    def test_generate_gwl_file_error_handling(self, mock_generator):
+        """
+        Test error handling in generate_gwl_file method.
+        This covers line 501 in generate_gwl_tables_unc.py.
+        """
+        models_list = ["EC-Earth3"]
+        scenarios_list = ["ssp370"]
+        ref_periods_list = [{"start_year": "19810101", "end_year": "20101231"}]
+
+        # Create a model_config dictionary to match what would be created in generate_gwl_file
+        model_config = {
+            "variable": "tas",
+            "model": "EC-Earth3",
+            "scenarios": ["ssp370"],
+        }
+
+        # Mock get_gwl_table to throw an exception on call
+        with patch.object(
+            mock_generator,
+            "get_gwl_table",
+        ) as mock_get_table:
+            # Configure the mock to raise an exception
+            mock_get_table.side_effect = Exception("Error in get_gwl_table")
+
+            # Since the method doesn't catch this exception (which is what we're trying to test)
+            # we need to catch it in the test to verify it's thrown
+            try:
+                mock_generator.generate_gwl_file(
+                    models_list, scenarios_list, ref_periods_list
+                )
+            except Exception as e:
+                # Verify that the exception came from our mocked method
+                assert str(e) == "Error in get_gwl_table"
+
+            # Verify our mock was called
+            mock_get_table.assert_called_once_with(model_config, ref_periods_list[0])
+
+    def test_generate_gwl_file_csv_write_specific_error(self, mock_generator):
+        """
+        Test specific CSV writing error in generate_gwl_file.
+        This covers lines 532-534 in generate_gwl_tables_unc.py.
+        """
+        models_list = ["EC-Earth3"]
+        scenarios_list = ["ssp370"]
+        ref_periods_list = [{"start_year": "19810101", "end_year": "20101231"}]
+
+        # Create valid GWL tables for concatenation
+        mock_agg_gwlevels_index = pd.MultiIndex.from_tuples(
+            [("r1i1p1f1", "ssp370")], names=["ensemble_member", "scenario"]
+        )
+        mock_agg_gwlevels = pd.DataFrame(
+            {1.5: [pd.Timestamp("2030-01-01")]},
+            index=mock_agg_gwlevels_index,
+        )
+
+        with (
+            # Return valid data from get_gwl_table
+            patch.object(
+                mock_generator,
+                "get_gwl_table",
+                return_value=(mock_agg_gwlevels, pd.DataFrame()),
+            ),
+            # But make write_csv_file fail with a specific error
+            patch(
+                "climakitae.util.generate_gwl_tables_unc.write_csv_file",
+                side_effect=IOError("Permission denied"),
+            ),
+        ):
+            # Should catch the IOError and print an error message
+            mock_generator.generate_gwl_file(
+                models_list, scenarios_list, ref_periods_list
+            )
+
+
+# Example test for main function (optional, depends on desired coverage)
+@patch("climakitae.util.generate_gwl_tables_unc.pd.read_csv")
+@patch("climakitae.util.generate_gwl_tables_unc.GWLGenerator")
+def test_main(mock_gwl_generator_class: MagicMock, mock_read_csv: MagicMock):
+    """Test the main execution function."""
+    mock_df = MagicMock(spec=pd.DataFrame)
+    mock_read_csv.return_value = mock_df
+
+    mock_gwl_instance = MagicMock(spec=GWLGenerator)
+    mock_gwl_generator_class.return_value = mock_gwl_instance
+
+    main()
+
+    mock_read_csv.assert_called_once_with(
+        "https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv"
+    )
+    mock_gwl_generator_class.assert_called_once_with(mock_df)
+    mock_gwl_instance.generate_gwl_file.assert_called_once_with(
+        ["EC-Earth3"],
+        ["ssp370"],
+        [{"start_year": "19810101", "end_year": "20101231"}],
+    )
+
+
+@patch("climakitae.util.generate_gwl_tables_unc.pd.read_csv")
+def test_main_csv_error(mock_read_csv):
+    """Test the main function when CSV loading fails."""
+    mock_read_csv.side_effect = Exception("Network error")
+
+    # The main function should catch the exception and return early
+    main()
+    mock_read_csv.assert_called_once_with(
+        "https://cmip6-pds.s3.amazonaws.com/pangeo-cmip6.csv"
+    )
+
+
+@patch("climakitae.util.generate_gwl_tables_unc.pd.read_csv")
+@patch("climakitae.util.generate_gwl_tables_unc.GWLGenerator")
+def test_main_gwl_generator_init_error(mock_gwl_generator_class, mock_read_csv):
+    """Test the main function when GWLGenerator initialization fails."""
+    mock_df = MagicMock(spec=pd.DataFrame)
+    mock_read_csv.return_value = mock_df
+
+    # Simulate an error initializing the GWLGenerator
+    mock_gwl_generator_class.side_effect = Exception("Initialization error")
+
+    # The main function should catch the exception and return early
+    main()
+    mock_read_csv.assert_called_once()
+    mock_gwl_generator_class.assert_called_once_with(mock_df)
+
+
+@patch("climakitae.util.generate_gwl_tables_unc.pd.read_csv")
+@patch("climakitae.util.generate_gwl_tables_unc.GWLGenerator")
+def test_main_generate_gwl_file_error(mock_gwl_generator_class, mock_read_csv):
+    """Test the main function when generate_gwl_file raises an exception."""
+    mock_df = MagicMock(spec=pd.DataFrame)
+    mock_read_csv.return_value = mock_df
+
+    mock_gwl_instance = MagicMock(spec=GWLGenerator)
+    mock_gwl_instance.generate_gwl_file.side_effect = Exception("GWL generation error")
+    mock_gwl_generator_class.return_value = mock_gwl_instance
+
+    # The main function should handle this exception internally (no exception raised)
+    # Wrap in try/except to catch any unhandled exceptions
+    try:
+        main()
+    except Exception as e:
+        pytest.fail(f"main() raised {type(e).__name__} unexpectedly: {e}")
+
+    # Verify the mocks were called correctly
+    mock_read_csv.assert_called_once()
+    mock_gwl_generator_class.assert_called_once_with(mock_df)
+    mock_gwl_instance.generate_gwl_file.assert_called_once_with(
+        ["EC-Earth3"], ["ssp370"], [{"start_year": "19810101", "end_year": "20101231"}]
+    )
+
+
+@patch("climakitae.util.generate_gwl_tables_unc.pd.read_csv")
+@patch("climakitae.util.generate_gwl_tables_unc.GWLGenerator")
+def test_main_load_error_line_673(mock_gwl_generator_class, mock_read_csv):
+    """
+    Test edge case error in main function where the catalog fails to load.
+    This covers line 673 in generate_gwl_tables_unc.py.
+    """
+    # When the CSV load raises a specific exception (IOError)
+    mock_read_csv.side_effect = IOError("Failed to connect to S3")
+
+    # The function should handle this gracefully
+    main()  # No exception should propagate out
+
+    # Verify that GWLGenerator was never constructed since the load failed
+    mock_gwl_generator_class.assert_not_called()
+
+
+# Test for make_weighted_timeseries utility function
+def test_make_weighted_timeseries():
+    """Test the make_weighted_timeseries utility function."""
+    # Create a sample DataArray
+    times = pd.date_range("2000-01-01", periods=3)
+    lats = np.arange(0, 90, 30)
+    lons = np.arange(0, 120, 60)
+    data = np.random.rand(len(times), len(lats), len(lons))
+    temp_da = xr.DataArray(
+        data, coords=[times, lats, lons], dims=["time", "lat", "lon"], name="tas"
+    )
+
+    # Expected weights (sqrt(cos(lat))) - unnormalized
+    # cos(0)=1, cos(30)=sqrt(3)/2, cos(60)=1/2
+    # sqrt(1)=1, sqrt(sqrt(3)/2)~0.93, sqrt(1/2)~0.707
+    # Sum ~ 2.637
+    # Normalized weights ~ [0.379, 0.353, 0.268]
+
+    result_ts = make_weighted_timeseries(temp_da)
+
+    # Check output type and shape
+    assert isinstance(result_ts, xr.DataArray)
+    assert result_ts.dims == ("time",)
+    assert len(result_ts["time"]) == len(times)
+
+    # Check calculation for the first time step (manual verification)
+    expected_t0 = (
+        (data[0, 0, :] * np.sqrt(np.cos(np.deg2rad(lats[0])))).mean()
+        + (data[0, 1, :] * np.sqrt(np.cos(np.deg2rad(lats[1])))).mean()
+        + (data[0, 2, :] * np.sqrt(np.cos(np.deg2rad(lats[2])))).mean()
+    )
+    # Need to apply normalization from the function
+    weights = np.sqrt(np.cos(np.deg2rad(lats)))
+    normalized_weights = weights / np.sum(weights)
+    expected_t0_normalized = (
+        (data[0, 0, :].mean() * normalized_weights[0])
+        + (data[0, 1, :].mean() * normalized_weights[1])
+        + (data[0, 2, :].mean() * normalized_weights[2])
+    )
+
+    np.testing.assert_allclose(result_ts[0].item(), expected_t0_normalized)
+
+    # Test with 'latitude' and 'longitude' coordinate names
+    temp_da_renamed = temp_da.rename({"lat": "latitude", "lon": "longitude"})
+    result_ts_renamed = make_weighted_timeseries(temp_da_renamed)
+    assert result_ts_renamed.dims == ("time",)
+    np.testing.assert_allclose(result_ts_renamed[0].item(), expected_t0_normalized)
+
+    # Test raises ValueError if coords are missing
+    temp_da_no_coords = xr.DataArray(data, dims=["time", "y", "x"])
+    with pytest.raises(
+        ValueError,
+        match="Input DataArray must have latitude and longitude coordinates.",
+    ):
+        make_weighted_timeseries(temp_da_no_coords)

--- a/tests/util/test_generate_gwl_tables_unc.py
+++ b/tests/util/test_generate_gwl_tables_unc.py
@@ -234,7 +234,7 @@ class TestGWLGenerator:
         """Test basic functionality of build_timeseries, including data loading and concatenation."""
         model_config: Dict = {
             "variable": "tas",
-            "model": self.TEST_MODEL,
+            "model": TEST_MODEL,
             "ens_mem": "r1i1p1f1",
             "scenarios": ["ssp370", "ssp585"],
         }


### PR DESCRIPTION
## Summary of changes and related issue
Complete refactor of `climakitae.util.generate_gwl_tables_unc` to enable testing.
Test suite at 95% coverage for `climakitae.util.generate_gwl_tables_unc`.

## Relevant motivation and context
Code for `generate_gwl_tables_unc` was previously a bunch of nested functions inside `main()` preventing effective testing. This was done in order to increase the ability to share information between functions, so the obvious choice for a refactor was to build a class that generates this file. So now we have a class that generates this file.

And tests because tests are good.

## How to test 
### Testing `generate_gwl_tables_unc`
navigate to your local installation of `climakitae` (an env where you've run `pip install .` or `pip install climakitae`).
move into the utils folder and run
`python generate_gwl_tables_unc.py --test`
if you do not provide the test flag it will attempt to run all 57 ensemble members which takes between 1 and 2 hours.

### Testing the tests
in a separate dev testing environment, where you have not run `pip install .` or `pip install climakitae`
```bash
pytest tests/util/test_generate_gwl_tables_unc.py --cov=climakitae.util.generate_gwl_tables_unc --cov-report term-missing
```

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
