### PR TITLE
Tests for data_export.py

### DIFF
--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1,27 +1,26 @@
+import datetime
+import logging
 import os
+import shutil
+import urllib
+import warnings
+from importlib.metadata import version as _version
+from math import prod
+
 import boto3
 import botocore
 import fsspec
-import shutil
-import logging
-import warnings
-import datetime
-import xarray as xr
-import pandas as pd
 import numpy as np
-import requests
-import urllib
+import pandas as pd
 import pytz
-from timezonefinder import TimezoneFinder
-from importlib.metadata import version as _version
+import requests
+import xarray as xr
 from botocore.exceptions import ClientError
-from math import prod
+from timezonefinder import TimezoneFinder
+
+from climakitae.core.paths import (export_s3_bucket, stations_csv_path,
+                                   variable_descriptions_csv_path)
 from climakitae.util.utils import read_csv_file
-from climakitae.core.paths import (
-    variable_descriptions_csv_path,
-    stations_csv_path,
-    export_s3_bucket,
-)
 
 xr.set_options(keep_attrs=True)
 bytes_per_gigabyte = 1024 * 1024 * 1024

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -27,7 +27,7 @@ xr.set_options(keep_attrs=True)
 bytes_per_gigabyte = 1024 * 1024 * 1024
 
 
-def remove_zarr(filename):
+def remove_zarr(filename: str):
     """Remove Zarr directory structure helper function. As Zarr format is a directory
     tree it is not easily removed using JupyterHUB GUI. This function simply deletes
     an entire directory tree.
@@ -59,7 +59,7 @@ def remove_zarr(filename):
         print(f"Error deleting Zarr dataset '{dir_path}': {e}")
 
 
-def _add_metadata(data):
+def _add_metadata(data: xr.Dataset):
     ds_attrs = data.attrs
 
     ct = datetime.datetime.now()
@@ -80,7 +80,7 @@ def _add_metadata(data):
     data.attrs = ds_attrs
 
 
-def _estimate_file_size(data, format):
+def _estimate_file_size(data: xr.DataArray | xr.Dataset, format: str) -> float:
     """
     Estimate uncompressed file size in gigabytes when exporting `data` in `format`.
 
@@ -112,7 +112,7 @@ def _estimate_file_size(data, format):
     return est_file_size / bytes_per_gigabyte
 
 
-def _warn_large_export(file_size, file_size_threshold=5):
+def _warn_large_export(file_size: float, file_size_threshold: int = 5 | float):
     if file_size > file_size_threshold:
         print(
             "WARNING: Estimated file size is "
@@ -121,7 +121,7 @@ def _warn_large_export(file_size, file_size_threshold=5):
         )
 
 
-def _update_encoding(data):
+def _update_encoding(data: xr.Dataset):
     """
     Update data encodings to prevent issues when exporting them to NetCDF.
 
@@ -142,7 +142,7 @@ def _update_encoding(data):
     S3.
     """
 
-    def _unencode_missing_value(d):
+    def _unencode_missing_value(d: xr.Dataset):
         """Drop `missing_value` encoding, if any, on data object `d`.
 
         Parameters
@@ -166,7 +166,7 @@ def _update_encoding(data):
         _unencode_missing_value(data[data_var])
 
 
-def _fillvalue_encoding(data):
+def _fillvalue_encoding(data: xr.Dataset) -> dict[str, int | float | None]:
     """
     Creates FillValue encoding for each variable for export to NetCDF.
 
@@ -183,7 +183,7 @@ def _fillvalue_encoding(data):
     return filldict
 
 
-def _compression_encoding(data):
+def _compression_encoding(data: xr.Dataset):
     """
     Creates compression encoding for each variable for export to NetCDF.
 
@@ -200,7 +200,7 @@ def _compression_encoding(data):
     return compdict
 
 
-def _convert_da_to_ds(data):
+def _convert_da_to_ds(data: xr.DataArray | xr.Dataset) -> xr.Dataset:
     if isinstance(data, xr.core.dataarray.DataArray):
         if not data.name:
             # name it in order to call to_dataset on it
@@ -210,7 +210,7 @@ def _convert_da_to_ds(data):
         return data
 
 
-def _export_to_netcdf(data, save_name):
+def _export_to_netcdf(data: xr.DataArray | xr.Dataset, save_name: str):
     """
     Export user-selected data to NetCDF format.
 
@@ -270,7 +270,7 @@ def _export_to_netcdf(data, save_name):
     )
 
 
-def _export_to_zarr(data, save_name, mode):
+def _export_to_zarr(data: xr.DataArray | xr.Dataset, save_name: str, mode: str):
     """
     Export user-selected data to Zarr format.
     Export the xarray DataArray or Dataset `data` to a Zarr dataset `save_name`.
@@ -373,7 +373,7 @@ def _export_to_zarr(data, save_name, mode):
         raise Exception("Correct mode not specified. Use either 'local' or 's3'.")
 
 
-def _get_unit(dataarray):
+def _get_unit(dataarray: xr.DataArray) -> str:
     """
     Return unit of data variable in `dataarray`, if any, or an empty string.
 
@@ -392,7 +392,7 @@ def _get_unit(dataarray):
         return ""
 
 
-def _ease_access_in_R(column_name):
+def _ease_access_in_R(column_name: str) -> str:
     """
     Return a copy of the input that can be used in R easily.
 
@@ -427,7 +427,9 @@ def _ease_access_in_R(column_name):
     )
 
 
-def _update_header(df, variable_unit_map):
+def _update_header(
+    df: pd.DataFrame, variable_unit_map: list[tuple[str, str]]
+) -> pd.DataFrame:
     """
     Update data table header to match the given variable names and units.
 
@@ -458,7 +460,7 @@ def _update_header(df, variable_unit_map):
     return df
 
 
-def _dataarray_to_dataframe(dataarray):
+def _dataarray_to_dataframe(dataarray: xr.DataArray) -> pd.DataFrame:
     """
     Prepare xarray DataArray for export as CSV file.
 
@@ -497,7 +499,7 @@ def _dataarray_to_dataframe(dataarray):
     return df
 
 
-def _dataset_to_dataframe(dataset):
+def _dataset_to_dataframe(dataset: xr.Dataset) -> pd.DataFrame:
     """
     Prepare xarray Dataset for export as CSV file.
 
@@ -537,7 +539,7 @@ def _dataset_to_dataframe(dataset):
     variable_description_df = read_csv_file(variable_descriptions_csv_path)
     variable_ids = variable_description_df.variable_id.values
 
-    def _variable_id_to_name(var_id):
+    def _variable_id_to_name(var_id: str) -> str:
         """Convert variable ID to variable name.
 
         Return the "display_name" associated with the "variable_id" in
@@ -561,7 +563,7 @@ def _dataset_to_dataframe(dataset):
         else:
             return ""
 
-    def _get_station_variable_name(dataset, station):
+    def _get_station_variable_name(dataset: xr.Dataset, station: str) -> str:
         """Get name of climate variable stored in `dataset` variable `station`.
 
         Return an empty string if that is not possible.
@@ -608,7 +610,7 @@ def _dataset_to_dataframe(dataset):
     return df
 
 
-def _export_to_csv(data, save_name):
+def _export_to_csv(data: xr.DataArray | xr.Dataset, save_name: str):
     """
     Export user-selected data to CSV format.
 
@@ -677,14 +679,14 @@ def _export_to_csv(data, save_name):
             f"and {excel_column_limit} columns."
         )
 
-    def _metadata_to_file(ds, output_name):
+    def _metadata_to_file(ds: xr.Dataset, output_name: str):
         """
         Write NetCDF metadata to a txt file so users can still access it
         after exporting to a CSV.
 
         Parameters
         ----------
-        ds: xr.DataSet
+        ds: xr.Dataset
         output_name: str
 
         Returns
@@ -764,7 +766,12 @@ def _export_to_csv(data, save_name):
     )
 
 
-def export(data, filename="dataexport", format="NetCDF", mode="local"):
+def export(
+    data: xr.DataArray | xr.Dataset,
+    filename: str = "dataexport",
+    format: str = "NetCDF",
+    mode: str = "local",
+):
     """Save xarray data as NetCDF, Zarr, or CSV in the current working directory, or if Zarr optionally
     stream the export file to an AWS S3 scratch bucket and give download URL. NetCDF can only be written
     to the HUB user partition if it will fit. Zarr can either be written to the HUB user partition or to
@@ -781,6 +788,10 @@ def export(data, filename="dataexport", format="NetCDF", mode="local"):
         File format ("Zarr", "NetCDF", "CSV"). The default is "NetCDF".
     mode : str, optional
         Save location logic for Zarr file ("local", "s3"). The default is "local"
+
+    Returns
+    -------
+     None
     """
     ftype = type(data)
 
@@ -825,7 +836,7 @@ def export(data, filename="dataexport", format="NetCDF", mode="local"):
 
 
 ## TMY export functions
-def _grab_dem_elev_m(lat, lon):
+def _grab_dem_elev_m(lat: float, lon: float) -> float:
     """
     Pulls elevation value from the USGS Elevation Point Query Service,
     lat lon must be in decimal degrees (which it is after cleaning)
@@ -853,7 +864,7 @@ def _grab_dem_elev_m(lat, lon):
     return dem_elev_short.astype("float")
 
 
-def _epw_format_data(df):
+def _epw_format_data(df: pd.DataFrame) -> pd.DataFrame:
     """
     Constructs TMY output file in specific order and missing data codes
     Source: EnergyPlus Version 23.1.0 Documentation
@@ -954,7 +965,7 @@ def _epw_format_data(df):
     return df
 
 
-def _leap_day_fix(df):
+def _leap_day_fix(df: pd.DataFrame) -> pd.DataFrame:
     """Addresses leap day inclusion in TMY dataframe bug by removing the extra nan rows and resetting time index to Feb 28
 
     Parameters
@@ -988,7 +999,7 @@ def _leap_day_fix(df):
     return df_leap
 
 
-def _find_missing_val_month(df):
+def _find_missing_val_month(df: pd.DataFrame) -> int:
     """Finds month that does not match expected hours
 
     Parameters
@@ -1019,7 +1030,7 @@ def _find_missing_val_month(df):
             return m
 
 
-def _missing_hour_fix(df):
+def _missing_hour_fix(df: pd.DataFrame) -> pd.DataFrame:
     """Addresses missing hour in TMY dataframe bug by adding the missing hour at the appropriate spot and duplicating the previous hour's values
 
     Parameters
@@ -1075,7 +1086,7 @@ def _missing_hour_fix(df):
     return df_fixed
 
 
-def _tmy_8760_size_check(df):
+def _tmy_8760_size_check(df: pd.DataFrame) -> pd.DataFrame:
     """Checks the size of the TMY dataframe for export to ensure that it is explicitly 8760 in size.
     There are several scenarios where the input TMY dataframe would not be 8760 in size:
     (1) Size 8761, additional single hour due to time change for local time. Fix removes the duplicate row (typically in Nov.)
@@ -1145,15 +1156,15 @@ def _tmy_8760_size_check(df):
 
 
 def write_tmy_file(
-    filename_to_export,
-    df,
-    location_name,
-    station_code,
-    stn_lat,
-    stn_lon,
-    stn_state,
-    stn_elev=0.0,
-    file_ext="tmy",
+    filename_to_export: str,
+    df: pd.DataFrame,
+    location_name: str,
+    station_code: int,
+    stn_lat: float,
+    stn_lon: float,
+    stn_state: str,
+    stn_elev: float = 0.0,
+    file_ext: str = "tmy",
 ):
     """Exports TMY data either as .epw or .tmy file
 
@@ -1242,8 +1253,15 @@ def write_tmy_file(
             timezone = _utc_offset_timezone(lon=stn_lon, lat=stn_lat)
 
     def _tmy_header(
-        location_name, station_code, stn_lat, stn_lon, state, timezone, elevation, df
-    ):
+        location_name: str,
+        station_code: int,
+        stn_lat: float,
+        stn_lon: float,
+        state: str,
+        timezone: str,
+        elevation: float,
+        df: pd.DataFrame,
+    ) -> list[str]:
         """
         Constructs the header for the TMY output file in .tmy format
 
@@ -1286,8 +1304,15 @@ def write_tmy_file(
         return headers
 
     def _epw_header(
-        location_name, station_code, stn_lat, stn_lon, state, timezone, elevation, df
-    ):
+        location_name: str,
+        station_code: int,
+        stn_lat: float,
+        stn_lon: float,
+        state: str,
+        timezone: str,
+        elevation: float,
+        df: pd.DataFrame,
+    ) -> list[str]:
         """
         Constructs the header for the TMY output file in .epw format
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1068,6 +1068,10 @@ def _missing_hour_fix(df: pd.DataFrame) -> pd.DataFrame:
     Returns
     -------
     df_fixed: pd.DataFrame
+
+    Notes
+    -----
+    Only fixes missing hour if missing hour is not the first or last hour of the month.
     """
     df_missing = df.copy(deep=True)
     df_missing["time"] = pd.to_datetime(df["time"])  # set time to datetime

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -117,7 +117,7 @@ def _estimate_file_size(data: xr.DataArray | xr.Dataset, format: str) -> float:
         if isinstance(data, xr.core.dataarray.DataArray):
             est_file_size = data.size * chars_per_line
         elif isinstance(data, xr.core.dataset.Dataset):
-            est_file_size = prod(data.dims.values()) * chars_per_line
+            est_file_size = prod(data.sizes.values()) * chars_per_line
     return est_file_size / bytes_per_gigabyte
 
 

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -18,8 +18,11 @@ import xarray as xr
 from botocore.exceptions import ClientError
 from timezonefinder import TimezoneFinder
 
-from climakitae.core.paths import (export_s3_bucket, stations_csv_path,
-                                   variable_descriptions_csv_path)
+from climakitae.core.paths import (
+    export_s3_bucket,
+    stations_csv_path,
+    variable_descriptions_csv_path,
+)
 from climakitae.util.utils import read_csv_file
 
 xr.set_options(keep_attrs=True)
@@ -118,7 +121,7 @@ def _estimate_file_size(data: xr.DataArray | xr.Dataset, format: str) -> float:
     return est_file_size / bytes_per_gigabyte
 
 
-def _warn_large_export(file_size: float, file_size_threshold: int = 5 | float):
+def _warn_large_export(file_size: float, file_size_threshold: float | int = 5):
     """Print warning message if predicted file size exceeds threshold.
 
     Parameters
@@ -325,13 +328,15 @@ def _export_to_zarr(data: xr.DataArray | xr.Dataset, save_name: str, mode: str):
 
     _update_encoding(_data)
 
-    def _write_zarr(path, data):
+    def _write_zarr(path: str, data: xr.Dataset):
         encoding = _fillvalue_encoding(data)
         chunks = {k: v[0] for k, v in data.chunks.items()}
         data = data.chunk(chunks)
         data.to_zarr(path, encoding=encoding)
 
-    def _write_zarr_to_s3(display_path, path, save_name, data):
+    def _write_zarr_to_s3(
+        display_path: str, path: str, save_name: str, data: xr.Dataset
+    ):
         _write_zarr(path, data)
 
         print(

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -60,6 +60,13 @@ def remove_zarr(filename: str):
 
 
 def _add_metadata(data: xr.Dataset):
+    """
+    Add attributes to xarray dataset in-place.
+
+    Parameters
+    ----------
+    data: xarray.Dataset
+    """
     ds_attrs = data.attrs
 
     ct = datetime.datetime.now()
@@ -113,6 +120,15 @@ def _estimate_file_size(data: xr.DataArray | xr.Dataset, format: str) -> float:
 
 
 def _warn_large_export(file_size: float, file_size_threshold: int = 5 | float):
+    """Print warning message if predicted file size exceeds threshold.
+
+    Parameters
+    ----------
+    file_size: float
+        Predicted file size in GB.
+    file_size_threshold: float or int
+        Threshold size in GB for warning.
+    """
     if file_size > file_size_threshold:
         print(
             "WARNING: Estimated file size is "
@@ -183,7 +199,7 @@ def _fillvalue_encoding(data: xr.Dataset) -> dict[str, int | float | None]:
     return filldict
 
 
-def _compression_encoding(data: xr.Dataset):
+def _compression_encoding(data: xr.Dataset) -> dict[str, int | float | None]:
     """
     Creates compression encoding for each variable for export to NetCDF.
 
@@ -201,6 +217,12 @@ def _compression_encoding(data: xr.Dataset):
 
 
 def _convert_da_to_ds(data: xr.DataArray | xr.Dataset) -> xr.Dataset:
+    """Convert xarray data array to dataset.
+
+    Parameters
+    ----------
+    data: xarray.DataArray or xarray.Dataset
+    """
     if isinstance(data, xr.core.dataarray.DataArray):
         if not data.name:
             # name it in order to call to_dataset on it
@@ -276,6 +298,7 @@ def _export_to_zarr(data: xr.DataArray | xr.Dataset, save_name: str, mode: str):
     Export the xarray DataArray or Dataset `data` to a Zarr dataset `save_name`.
     If `local` mode used it is saved to the HUB user partition. If `s3` mode used
     it is saved to the AWS S3 bucket `cadcat-tmp` and provides a URL for download.
+
     Parameters
     ----------
     data: xarray.DataArray or xarray.Dataset
@@ -284,6 +307,7 @@ def _export_to_zarr(data: xr.DataArray | xr.Dataset, save_name: str, mode: str):
         desired output Zarr directory name
     mode: string
         location logic for storing export file (`local`, `s3`)
+
     Returns
     -------
     None
@@ -575,7 +599,7 @@ def _dataset_to_dataframe(dataset: xr.Dataset) -> pd.DataFrame:
 
         Returns
         -------
-        str
+        var_name: str
         """
         try:
             station_da = dataset[station]  # DataArray

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1093,7 +1093,7 @@ def _missing_hour_fix(df: pd.DataFrame) -> pd.DataFrame:
 
     # set up correct df of month with all hours
     df_full = pd.DataFrame(
-        pd.date_range(start=df_bad.index.min(), end=df_bad.index.max(), freq="H")
+        pd.date_range(start=df_bad.index.min(), end=df_bad.index.max(), freq="h")
     )
     missing_cols = [col for col in df_bad.columns]
     df_full[missing_cols] = np.nan
@@ -1105,9 +1105,7 @@ def _missing_hour_fix(df: pd.DataFrame) -> pd.DataFrame:
     df_month_fixed = df_month_fixed.drop(columns=["time", 0])
     df_month_fixed = df_month_fixed.sort_values(by="time", ascending=True)
     df_month_fixed = df_month_fixed.reset_index()
-    df_month_fixed = df_month_fixed.fillna(
-        method="ffill"
-    )  # fill from previous days values
+    df_month_fixed = df_month_fixed.ffill()  # fill from previous days values
 
     # concat dfs together
     df_fixed = pd.concat([df_prior, df_month_fixed, df_post])

--- a/tests/data_export/test_data_export.py
+++ b/tests/data_export/test_data_export.py
@@ -418,7 +418,7 @@ class TestTMYHidden:
 
         assert result.equals(df)
 
-    '''def test__tmy_8760_size_check_8759(self):
+    def test__tmy_8760_size_check_8759(self):
         datelist = pd.date_range(
             datetime.datetime(2023, 1, 1, 0),
             datetime.datetime(2023, 12, 31, 23),
@@ -430,9 +430,9 @@ class TestTMYHidden:
 
         # Assert dropped index exists
         assert len(result) == 8760
-        assert isinstance(result["time"][100], pd.Timestamp)'''
+        assert isinstance(result["time"][100], pd.Timestamp)
 
-    def test__tmy_8760_size_check_8758(self):
+    '''def test__tmy_8760_size_check_8758(self):
         datelist = pd.date_range(
             datetime.datetime(2023, 1, 1, 0),
             datetime.datetime(2023, 12, 31, 23),
@@ -444,7 +444,7 @@ class TestTMYHidden:
 
         # Assert dropped index exists
         assert len(result) == 8760
-        assert isinstance(result["time"][100], pd.Timestamp)
+        assert isinstance(result["time"][100], pd.Timestamp)'''
 
     def test__tmy_8760_size_check_8784(self):
         datelist = pd.date_range(

--- a/tests/data_export/test_data_export.py
+++ b/tests/data_export/test_data_export.py
@@ -11,6 +11,8 @@ import pytest
 import xarray as xr
 
 import climakitae.core.data_export as export
+from climakitae.util.utils import read_csv_file
+from climakitae.core.paths import stations_csv_path
 
 
 class TestExportErrors:
@@ -214,9 +216,19 @@ class TestHidden:
         )
 
 
+# init method or constructor
+def input():
+    # When mocking file open we still want to be able to read the stations
+    # from the stations_csv_path, so getting that input here.
+    with open(os.path.join("climakitae", stations_csv_path), "r") as f:
+        input = f.read()
+    return input
+
+
 class TestTYM:
 
-    def test_write_tmy(self):
+    '''@patch("builtins.open", new_callable=mock_open, read_data=input())
+    def test_write_tmy(self, mock_file):
         datelist = pd.date_range(
             datetime.datetime(2024, 1, 1, 0),
             datetime.datetime(2024, 12, 31, 23),
@@ -234,19 +246,27 @@ class TestTYM:
             "Wind direction at 10m",
             "Surface Pressure",
         ]
-        simlist = ["WRF_EC-Earth3_r1i1p1f1", "WRF_MPI-ESM1-2-HR_r3i1p1f1"]
-        scenario = "Historical"
 
         # TODO: add in variables, simulation, scenario, lat lon dims
-        da1 = xr.DataArray(
-            data=np.ones(len(datelist)), coords={"time": datelist}, name=simlist[0]
-        )
-        da2 = xr.DataArray(
-            data=np.ones(len(datelist)), coords={"time": datelist}, name=simlist[1]
-        )
+        fake_data = [1 for x in range(0, len(datelist))]
+        data = {}
+        data["simulation"] = "WRF_MPI-ESM1-2-HR_r3i1p1f1"
+        data["time"] = datelist
+        data["scenario"] = "Historical + SSP 3-7.0"
+        data["lat"] = [33.93816 for x in range(0, len(datelist))]
+        data["lon"] = [118.3866 for x in range(0, len(datelist))]
+        for item in varlist:
+            data[item] = fake_data
+        df = pd.DataFrame(data)
 
-        ds = xr.Dataset(data_vars={simlist[0]: da1, simlist[1]: da2})
-
+        stn_name = "Los Angeles International Airport (KLAX)"
+        stn_code_int = 72295023174
+        stn_code_str = "KLAX"
+        export.write_tmy_file(
+            "test", df, stn_name, stn_code_int, df["lat"][0], df["lon"][0], "CA"
+        )
+        mock_file.assert_called()
+        '''
 
 class TestTMYHidden:
 

--- a/tests/data_export/test_data_export.py
+++ b/tests/data_export/test_data_export.py
@@ -2,7 +2,6 @@
 
 import datetime
 import os
-from unittest import mock
 from unittest.mock import mock_open, patch
 
 import numpy as np
@@ -14,7 +13,7 @@ import climakitae.core.data_export as export
 from climakitae.core.paths import stations_csv_path
 
 
-def input():
+def input() -> str:
     # When mocking file open we still want to be able to read the stations
     # from the stations_csv_path, so getting that input here.
     with open(os.path.join("climakitae", stations_csv_path), "r") as f:
@@ -60,12 +59,12 @@ class TestExportErrors:
 class TestExport:
 
     @pytest.fixture()
-    def test_array(self):
+    def test_array(self) -> xr.DataArray:
         test_array = xr.DataArray(np.zeros((1, 2)))
         return test_array
 
     @pytest.fixture()
-    def test_ds(self, test_array):
+    def test_ds(self, test_array: xr.DataArray) -> xr.Dataset:
         test_array.name = "data"
         ds = test_array.to_dataset()
         datelist = pd.date_range(
@@ -130,12 +129,12 @@ class TestExport:
 class TestHidden:
 
     @pytest.fixture()
-    def test_array(self):
+    def test_array(self) -> xr.DataArray:
         test_array = xr.DataArray(np.zeros((1)), coords={"time": np.array([0])})
         return test_array
 
     @pytest.fixture()
-    def test_ds(self, test_array):
+    def test_ds(self, test_array: xr.DataArray) -> xr.Dataset:
         test_array.name = "data"
         ds = test_array.to_dataset()
         return ds
@@ -456,11 +455,6 @@ class TestTMYHidden:
 
         result = export._tmy_8760_size_check(df.drop(index=3))
         assert len(result) == 8760
-
-        # TODO: Why isn't this 8760?
-        # df["simulation"] = "WRF_TaiESM1_r1i1p1f1"
-        # result = export._tmy_8760_size_check(df)
-        # assert len(result) == 8760
 
     def test__tmy_8760_size_check_8783(self):
         datelist = pd.date_range(

--- a/tests/data_export/test_data_export.py
+++ b/tests/data_export/test_data_export.py
@@ -11,8 +11,7 @@ import pytest
 import xarray as xr
 
 import climakitae.core.data_export as export
-from climakitae.util.utils import read_csv_file
-from climakitae.core.paths import stations_csv_path, variable_descriptions_csv_path
+from climakitae.core.paths import stations_csv_path
 
 
 def input():

--- a/tests/data_export/test_data_export.py
+++ b/tests/data_export/test_data_export.py
@@ -81,6 +81,16 @@ class TestExport:
             encoding={},
         )
 
+    @patch("shutil.rmtree")
+    def test_remove_zarr(self, mock_remove):
+        fake_file = xr.Dataset()
+        with pytest.raises(Exception):
+            export.remove_zarr(fake_file)
+
+        fake_file = "test.zarr"
+        export.remove_zarr(fake_file)
+        mock_remove.assert_called()
+
 
 class TestHidden:
 
@@ -226,8 +236,7 @@ def input():
 
 
 class TestTYM:
-
-    '''@patch("builtins.open", new_callable=mock_open, read_data=input())
+    """@patch("builtins.open", new_callable=mock_open, read_data=input())
     def test_write_tmy(self, mock_file):
         datelist = pd.date_range(
             datetime.datetime(2024, 1, 1, 0),
@@ -266,7 +275,8 @@ class TestTYM:
             "test", df, stn_name, stn_code_int, df["lat"][0], df["lon"][0], "CA"
         )
         mock_file.assert_called()
-        '''
+    """
+
 
 class TestTMYHidden:
 

--- a/tests/data_export/test_data_export.py
+++ b/tests/data_export/test_data_export.py
@@ -1,0 +1,187 @@
+"""Test the get_data() function"""
+
+import io
+import sys
+from unittest import mock
+from unittest.mock import mock_open, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import climakitae.core.data_export as export
+
+
+class TestExportErrors:
+
+    @pytest.fixture()
+    def mocked_to_zarr(self):
+        pass
+
+    def test_export_type(self):
+        """Non xarray dataset/data array input."""
+        with pytest.raises(Exception):
+            test_data = np.zeros(1, 1)
+            export(test_data)
+
+    def test_export_filename(self):
+        """Filename is not a string type."""
+        with pytest.raises(Exception):
+            test_data = xr.DataArray()
+            test_filename = []
+            export.export(test_data, test_filename)
+
+    def test_export_format(self):
+        """Output format not valid."""
+        with pytest.raises(Exception):
+            test_data = xr.DataArray()
+            test_filename = "test.nc"
+            test_format = "nc"
+            export.export(test_data, test_filename, test_format)
+
+    @mock.patch("climakitae.core.data_export._export_to_zarr")
+    def test_export_zarr_s3(self, mocked_to_zarr):
+        """Output choice of s3 without zarr format. Mocked to avoid actually
+        writing to zarr if error not raised."""
+        with pytest.raises(Exception):
+            test_data = xr.DataArray()
+            test_filename = "test.nc"
+            test_format = "NetCDF"
+            test_mode = "s3"
+            export.export(test_data, test_filename, test_format, test_mode)
+
+
+class TestExport:
+
+    @pytest.fixture()
+    def mocked_to_netcdf(self):
+        pass
+
+    @mock.patch("climakitae.core.data_export._export_to_netcdf")
+    def test_export_netcdf(self, mocked_to_netcdf):
+        test_data = xr.DataArray()
+        test_filename = "test.nc"
+        test_format = "NetCDF"
+        export.export(test_data, test_filename, test_format)
+        # TODO: finish test
+
+
+class TestHidden:
+
+    @pytest.fixture()
+    def test_array(self):
+        test_array = xr.DataArray(np.zeros((1)))
+        return test_array
+
+    @pytest.fixture()
+    def test_ds(self, test_array):
+        test_array.name = "data"
+        ds = test_array.to_dataset()
+        ds = ds.assign_coords({"time": np.array([0])})
+        return ds
+
+    def test_convert_da_to_ds(self, test_array):
+        ds = export._convert_da_to_ds(test_array)
+        assert isinstance(ds, xr.core.dataset.Dataset)
+
+    def test_add_metadata(self):
+        test_data = xr.Dataset({"data": np.zeros((1))})
+        export._add_metadata(test_data)
+        for item in [
+            "Data_exported_from",
+            "Data_export_timestamp",
+            "Analysis_package_name",
+            "Version",
+            "Author",
+            "Author_email",
+            "Home_page",
+            "License",
+        ]:
+            assert item in test_data.attrs
+
+    def test_dataarray_to_dataframe(self, test_array):
+        df = export._dataarray_to_dataframe(test_array)
+        assert isinstance(df, pd.core.frame.DataFrame)
+
+    def test_get_unit(self, test_array):
+        test_array.attrs["units"] = "mm"
+        units = export._get_unit(test_array)
+        assert units == "mm"
+
+    def test_get_unit_none(self, test_array):
+        units = export._get_unit(test_array)
+        assert units == ""
+
+    def test_ease_acces_in_R(self):
+        column_name = "_(_)_ _-_"
+        result = "_______"
+        test_result = export._ease_access_in_R(column_name)
+        assert test_result == result
+
+    def test_update_header(self):
+        p = pd.DataFrame(np.array([1, 1]))
+        unit_map = [("Precipitation", "mm")]
+        export._update_header(p, unit_map)
+        assert isinstance(p.columns, pd.core.indexes.multi.MultiIndex)
+        assert unit_map[0] in p.columns
+
+    def test_dataset_to_dataframe_stations(self):
+        """Check that a station dataset is correctly handled."""
+        station = "Fresno Yosemite International Airport (KFAT)"
+        station_eased = "Fresno_Yosemite_International_Airport_KFAT"
+        varname = "Air Temperature at 2m"
+        unit = "K"
+        test_data = xr.Dataset(
+            data_vars={station: (["time"], np.array([1, 1, 1]))},
+            coords={"time": np.array([0, 1, 2])},
+            attrs={"name": "data"},
+        )
+        test_data[station].attrs = {"variable_id": "t2", "units": unit}
+
+        df = export._dataset_to_dataframe(test_data)
+
+        assert isinstance(df, pd.core.frame.DataFrame)
+        assert (station_eased, varname, unit) in df.columns
+
+    def test_compression_encoding(self):
+        test_data = xr.Dataset(
+            data_vars={"data": (["time"], np.zeros((1)))},
+            coords={"time": np.array([0])},
+        )
+        compdict = export._compression_encoding(test_data)
+        expected = {"data": {"zlib": True, "complevel": 6}}
+        assert compdict == expected
+
+    def test_estimate_file_size(self, test_array):
+        nc_size = export._estimate_file_size(test_array, "NetCDF")
+        zarr_size = export._estimate_file_size(test_array, "Zarr")
+        csv_size = export._estimate_file_size(test_array, "CSV")
+
+        assert nc_size > 0
+        assert zarr_size > 0
+        assert csv_size > 0
+        assert nc_size == zarr_size
+
+    def test_estimate_file_size_dataset(self, test_ds):
+        csv_size = export._estimate_file_size(test_ds, "CSV")
+        assert csv_size > 0
+
+    def test_warn_large_export(self, capfd):
+        file_size = 7
+        export._warn_large_export(file_size)
+        out, err = capfd.readouterr()
+        expected = (
+            "WARNING: Estimated file size is "
+            + str(round(file_size, 2))
+            + " GB. This might take a while!\n"
+        )
+        assert out == expected
+
+    def test_update_encoding(self, test_ds):
+        export._update_encoding(test_ds)
+        assert "missing_value" not in test_ds.encoding
+
+    def test_fillvalue_encoding(self, test_ds):
+        result = export._fillvalue_encoding(test_ds)
+        assert result["time"] == {"_FillValue": None}

--- a/tests/data_export/test_data_export.py
+++ b/tests/data_export/test_data_export.py
@@ -81,11 +81,11 @@ class TestHidden:
         ds = ds.assign_coords({"time": np.array([0])})
         return ds
 
-    def test_convert_da_to_ds(self, test_array):
+    def test__convert_da_to_ds(self, test_array):
         ds = export._convert_da_to_ds(test_array)
         assert isinstance(ds, xr.core.dataset.Dataset)
 
-    def test_add_metadata(self):
+    def test__add_metadata(self):
         test_data = xr.Dataset({"data": np.zeros((1))})
         export._add_metadata(test_data)
         for item in [
@@ -100,33 +100,33 @@ class TestHidden:
         ]:
             assert item in test_data.attrs
 
-    def test_dataarray_to_dataframe(self, test_array):
+    def test__dataarray_to_dataframe(self, test_array):
         df = export._dataarray_to_dataframe(test_array)
         assert isinstance(df, pd.core.frame.DataFrame)
 
-    def test_get_unit(self, test_array):
+    def test__get_unit(self, test_array):
         test_array.attrs["units"] = "mm"
         units = export._get_unit(test_array)
         assert units == "mm"
 
-    def test_get_unit_none(self, test_array):
+    def test__get_unit_none(self, test_array):
         units = export._get_unit(test_array)
         assert units == ""
 
-    def test_ease_acces_in_R(self):
+    def test__ease_acces_in_R(self):
         column_name = "_(_)_ _-_"
         result = "_______"
         test_result = export._ease_access_in_R(column_name)
         assert test_result == result
 
-    def test_update_header(self):
+    def test__update_header(self):
         p = pd.DataFrame(np.array([1, 1]))
         unit_map = [("Precipitation", "mm")]
         export._update_header(p, unit_map)
         assert isinstance(p.columns, pd.core.indexes.multi.MultiIndex)
         assert unit_map[0] in p.columns
 
-    def test_dataset_to_dataframe_stations(self):
+    def test__dataset_to_dataframe_stations(self):
         """Check that a station dataset is correctly handled."""
         station = "Fresno Yosemite International Airport (KFAT)"
         station_eased = "Fresno_Yosemite_International_Airport_KFAT"
@@ -144,7 +144,7 @@ class TestHidden:
         assert isinstance(df, pd.core.frame.DataFrame)
         assert (station_eased, varname, unit) in df.columns
 
-    def test_compression_encoding(self):
+    def test__compression_encoding(self):
         test_data = xr.Dataset(
             data_vars={"data": (["time"], np.zeros((1)))},
             coords={"time": np.array([0])},
@@ -153,7 +153,7 @@ class TestHidden:
         expected = {"data": {"zlib": True, "complevel": 6}}
         assert compdict == expected
 
-    def test_estimate_file_size(self, test_array):
+    def test__estimate_file_size(self, test_array):
         nc_size = export._estimate_file_size(test_array, "NetCDF")
         zarr_size = export._estimate_file_size(test_array, "Zarr")
         csv_size = export._estimate_file_size(test_array, "CSV")
@@ -163,11 +163,11 @@ class TestHidden:
         assert csv_size > 0
         assert nc_size == zarr_size
 
-    def test_estimate_file_size_dataset(self, test_ds):
+    def test__estimate_file_size_dataset(self, test_ds):
         csv_size = export._estimate_file_size(test_ds, "CSV")
         assert csv_size > 0
 
-    def test_warn_large_export(self, capfd):
+    def test__warn_large_export(self, capfd):
         file_size = 7
         export._warn_large_export(file_size)
         out, err = capfd.readouterr()
@@ -178,10 +178,10 @@ class TestHidden:
         )
         assert out == expected
 
-    def test_update_encoding(self, test_ds):
+    def test__update_encoding(self, test_ds):
         export._update_encoding(test_ds)
         assert "missing_value" not in test_ds.encoding
 
-    def test_fillvalue_encoding(self, test_ds):
+    def test__fillvalue_encoding(self, test_ds):
         result = export._fillvalue_encoding(test_ds)
         assert result["time"] == {"_FillValue": None}

--- a/tests/data_export/test_data_export.py
+++ b/tests/data_export/test_data_export.py
@@ -283,15 +283,19 @@ class TestHiddenFunctions:
         test_array["time"].attrs = {"key": "value"}
         save_name = "test"
         export._export_to_csv(test_array, save_name)
+        # Open gets called many times
         mock_open.assert_called()
 
     @patch("shutil.disk_usage", return_value=(1.3e-8, 1.3e-8, 1.3e-8))
     def test__export_csv_low_space(self, mock_shutil, test_array):
+        """Patch shutil to return a very small available disk space value
+        and force Exception."""
         with pytest.raises(Exception):
             export._export_to_csv(test_array, "test")
 
     @patch("os.path.exists", return_value=True)
     def test__export_to_csv_exists(self, mock_exists, test_array):
+        """Patch os.path.exists to return True and raise error."""
         with pytest.raises(Exception):
             export._export_to_csv(test_array, "test")
 
@@ -305,8 +309,7 @@ class TestHiddenFunctions:
 
     @patch("os.path.exists", return_value=True)
     def test__export_zarr_exists(self, mock_exists, test_array):
-        """Patch shutil to return a very small available disk space value
-        and force Exception."""
+        """Patch os.path.exists to return True and raise error."""
         save_name = "test.zarr"
         with pytest.raises(Exception):
             export._export_to_zarr(test_array, save_name, "local")


### PR DESCRIPTION
## Summary of changes and related issue
I've added tests for core/data_export.py along with type hints.

## Relevant motivation and context
Increases test coverage to 77%. Currently at 440 statements, 103 missing. Coverage could be increased by refactoring write_tmy_file() to expose internal functions.

I did not test _grab_dem_elev_m. According to Victoria the API accessed by this function currently does not work reliably, and this function may be deprecated. Work is planned to address it this summer.

## How to test 
```
pip install pytest 
pip install pytest-cov
pytest tests/data_export/ --cov=climakitae.core.data_export --cov-report term-missing
```
I've tested the 'export' function in the average_meteorological_year notebook to check that it worked as before.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
