### PR TITLE
Improve wording in readthedocs page ("alpha release") 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,10 +6,10 @@ Climakitae Documentation
 
 .. note::
 
-   This project is actively in development working towards an alpha release.
+   This project is actively in development, so the functionality documented here may evolve over time. We strive to keep our documentation up to date and appreciate your patience as we continue improving and streamlining the codebase.
 
 Climakitae provides a python toolkit for retrieving and performing 
-scientific analyses with data from the Cal-Adapt Analytics Engine. 
+scientific analyses with climate data from the Cal-Adapt Analytics Engine. 
 
 .. grid:: 1 1 2 2
     :gutter: 2


### PR DESCRIPTION
## Summary of changes and related issue
Remove outdated text about "working toward an alpha release" in our readthedocs page 

## Relevant motivation and context
Out of date text

## How to test 
Confirm that you like the updated text. The new text is in the "notes" box. 

You can build the docs on your local machine if you'd like. Follow the instructions [here](https://github.com/cal-adapt/climakitae/blob/main/docs/README.md). 

Or, here's a screenshot of what it looks like: 
<img width="1421" alt="new_note" src="https://github.com/user-attachments/assets/92c79937-c75b-47ae-b9a6-24ab8946b0c0" />


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
