### PR TITLE
Add `all_touched` spatial filtering option to `DataParameters`, `get_data`, `data_load`

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1834,6 +1834,7 @@ def get_data(
     stations=None,
     warming_level_window=None,
     warming_level_months=None,
+    all_touched=False,
 ):
     # Need to add error handing for bad variable input
     """Retrieve formatted data from the Analytics Engine data catalog using a simple function.
@@ -1896,6 +1897,8 @@ def get_data(
         Default to all months in a year: [1,2,3,4,5,6,7,8,9,10,11,12]
         For example, you may want to set warming_level_months=[12,1,2] to perform the analysis for the winter season.
         Only valid for approach = "Warming Level" and data_type = "Stations"
+    all_touched: boolean
+        spatial subset option for within or touching selection
 
     Returns
     -------
@@ -2195,6 +2198,14 @@ def get_data(
     # Cached area should be a list even if its just a single string value (i.e. [str])
     cached_area = [cached_area] if type(cached_area) != list else cached_area
 
+    # If all_touched is None set to False
+    if all_touched == None:
+        all_touched = False
+    
+    # Check if all_touched boolean
+    if all_touched not in [True, False]:
+        raise ValueError("all_touched must be a boolean")
+
     # Make sure approach matches the scenario setting
     # See function documentation for more details
     approach, scenario, warming_level, time_slice = _error_handling_approach_inputs(
@@ -2276,6 +2287,7 @@ def get_data(
         "latitude": latitude,
         "longitude": longitude,
         "stations": stations,
+        "all_touched": all_touched,
     }
 
     scenario_ssp, scenario_historical = _get_scenario_ssp_scenario_historical(
@@ -2330,6 +2342,7 @@ def get_data(
         selections.variable_type = selections_dict["variable_type"]
         selections.variable = selections_dict["variable"]
         selections.units = selections_dict["units"]
+        selections.all_touched = selections_dict["all_touched"]
 
         # Setting the values like this enables us to take advantage of the default settings in DataParameters without having to manually set defaults in this function
         if selections_dict["warming_level"] is not None:

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -700,6 +700,8 @@ class DataParameters(param.Parameterized):
             self._geography_choose[self.area_subset].keys()
         )
 
+        self.all_touched = False
+
         # Set data params
         (
             self.scenario_options,

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -2201,7 +2201,7 @@ def get_data(
     # If all_touched is None set to False
     if all_touched == None:
         all_touched = False
-    
+
     # Check if all_touched boolean
     if all_touched not in [True, False]:
         raise ValueError("all_touched must be a boolean")

--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -587,6 +587,8 @@ class DataParameters(param.Parameterized):
     warming_level_months: array
         months of year to use for computing warming levels
         default to entire calendar year: 1,2,3,4,5,6,7,8,9,10,11,12
+    all_touched: boolean
+        spatial subset option for within or touching selection
     """
 
     # Unit conversion options for each unit
@@ -660,6 +662,8 @@ class DataParameters(param.Parameterized):
         default=list(np.arange(1, 13)),  # All 12 months of the year
         objects=list(np.arange(1, 13)),  # All 12 months of the year
     )
+
+    all_touched = param.Boolean(False)
 
     # User warnings
     _info_about_station_data = "This method retrieves gridded model data that is bias-corrected using historical weather station data at that point. This process can start from any model grid-spacing."

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -277,6 +277,7 @@ def _spatial_subset(dset, selections):
             clipped area of dset
         """
         try:
+            print(all_touched) # DEBUG
             dset = dset.rio.clip(geometries=ds_region, crs=4326, drop=True, all_touched=all_touched)
 
         except NoDataInBounds as e:

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -277,7 +277,6 @@ def _spatial_subset(dset, selections):
             clipped area of dset
         """
         try:
-            print(all_touched)  # DEBUG
             dset = dset.rio.clip(
                 geometries=ds_region, crs=4326, drop=True, all_touched=all_touched
             )

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -277,8 +277,10 @@ def _spatial_subset(dset, selections):
             clipped area of dset
         """
         try:
-            print(all_touched) # DEBUG
-            dset = dset.rio.clip(geometries=ds_region, crs=4326, drop=True, all_touched=all_touched)
+            print(all_touched)  # DEBUG
+            dset = dset.rio.clip(
+                geometries=ds_region, crs=4326, drop=True, all_touched=all_touched
+            )
 
         except NoDataInBounds as e:
             # Catch small geometry error

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -259,7 +259,7 @@ def _spatial_subset(dset, selections):
         subsetted area of dset
     """
 
-    def _clip_to_geometry(dset, ds_region):
+    def _clip_to_geometry(dset, ds_region, all_touched):
         """Clip to geometry if large enough
 
         Parameters
@@ -268,6 +268,8 @@ def _spatial_subset(dset, selections):
             one dataset from the catalog
         ds_region: shapely.geometry.polygon.Polygon
             area to clip to
+        all_touched: boolean
+            select within or touching area
 
         Returns
         -------
@@ -275,7 +277,7 @@ def _spatial_subset(dset, selections):
             clipped area of dset
         """
         try:
-            dset = dset.rio.clip(geometries=ds_region, crs=4326, drop=True)
+            dset = dset.rio.clip(geometries=ds_region, crs=4326, drop=True, all_touched=all_touched)
 
         except NoDataInBounds as e:
             # Catch small geometry error
@@ -284,7 +286,7 @@ def _spatial_subset(dset, selections):
 
         return dset
 
-    def _clip_to_geometry_loca(dset, ds_region):
+    def _clip_to_geometry_loca(dset, ds_region, all_touched):
         """Clip to geometry, adding missing grid info
             because crs and x, y are missing from LOCA datasets
             Otherwise rioxarray will raise this error:
@@ -296,6 +298,8 @@ def _spatial_subset(dset, selections):
             one dataset from the catalog
         ds_region: shapely.geometry.polygon.Polygon
             area to clip to
+        all_touched: boolean
+            select within or touching area
 
         Returns
         -------
@@ -304,7 +308,7 @@ def _spatial_subset(dset, selections):
         """
         dset = dset.rename({"lon": "x", "lat": "y"})
         dset = dset.rio.write_crs("epsg:4326", inplace=True)
-        dset = _clip_to_geometry(dset, ds_region)
+        dset = _clip_to_geometry(dset, ds_region, all_touched)
         dset = dset.rename({"x": "lon", "y": "lat"}).drop("spatial_ref")
         return dset
 
@@ -312,9 +316,9 @@ def _spatial_subset(dset, selections):
 
     if ds_region is not None:  # Perform subsetting
         if selections.downscaling_method == "Dynamical":
-            dset = _clip_to_geometry(dset, ds_region)
+            dset = _clip_to_geometry(dset, ds_region, selections.all_touched)
         else:
-            dset = _clip_to_geometry_loca(dset, ds_region)
+            dset = _clip_to_geometry_loca(dset, ds_region, selections.all_touched)
 
     return dset
 


### PR DESCRIPTION
## Summary of changes and related issue
This PR adds the option to select cells that are touching the selection area as opposed to only withing the selection area. Adds `all_touched` option to `DataParameters`, `get_data` and then that logic is processed in `data_load` depending on the option.

## Relevant motivation and context
Users have requested the ability to select cells touching the edge of their service area. Should fix the not selecting any cell if the latitude, longitude box is too small as well.

## How to test 
Check out branch on HUB and run through the basic_data_access notebook and add the optional parameter.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
