### PR TITLE
Add clip_to_shapefile function

### DIFF
--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pyproj
 import rioxarray as rio
 from shapely.geometry import mapping
+from typing import Any
 import xarray as xr
 from timezonefinder import TimezoneFinder
 
@@ -1190,7 +1191,7 @@ def stack_sims_across_locs(ds):
 def clip_to_shapefile(
     data: xr.Dataset | xr.DataArray,
     shapefile_path: str,
-    feature: tuple[str, str | int | float | bool | list[str | int | float | bool]] = (),
+    feature: tuple[str, Any] = (),
     name: str = "user-defined",
     **kwargs,
 ) -> xr.Dataset | xr.DataArray:

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -1,9 +1,11 @@
 import os
 import numpy as np
 import datetime
+import geopandas as gpd
 import xarray as xr
 import pyproj
 import rioxarray as rio
+from shapely.geometry import mapping
 import pandas as pd
 import copy
 import intake
@@ -1112,3 +1114,64 @@ def stack_sims_across_locs(ds):
         for sim_name in ds["simulation"]
     ]
     return ds
+
+def clip_to_shapefile(data: xr.Dataset | xr.DataArray, shapefile_path: str, feature: tuple[str,str | int | float | bool | list[str | int | float | bool]]=(), name: str = "custom", **kwargs) -> xr.Dataset | xr.DataArray:
+    """Use a shapefile to select an area subset of AE data.
+
+    Parameters
+    ----------
+    data : xr.Dataset | xr.DataArray
+        Data to be clipped.
+    shapefile_path: str
+        Filepath to shapefile. Shapefile must include valid CRS.
+    feature: tuple(str, str | int | float | list)
+        Tuple containing attribute name and value(s) for target feature(s) (optional).
+    name: str
+        Location name to record in data attributes if 'feature' parameter is not set (optional).
+    **kwargs
+        Additional arguments to pass to the rioxarray clip function
+
+    Returns
+    -------
+    clipped : xr.Dataset | xr.DataArray
+        Returns same type as 'data', but grid is clipped to shapefile feature(s).
+    """
+    if data.rio.crs is None:
+        raise RuntimeError("No CRS found on input parameter 'data'. Use rioxarray write_crs() method to set CRS.")
+
+    region = gpd.read_file(shapefile_path)
+
+    if region.crs is None:
+        raise RuntimeError("No CRS found on data read from shapefile. Verify that shapefile contains valid CRS information.")
+
+    # Select only user provided feature
+    if feature:
+        try:
+            print("Selecting feature",feature)
+            if isinstance(feature[1],list):
+                region = region[region[feature[0]].isin(feature[1])]
+            else:
+                region = region[region[feature[0]] == feature[1]]
+            if len(region) == 0: # No features found
+                raise Exception
+        except Exception as err:
+            raise RuntimeError("Could not select feature {0} in {1} ".format(feature,shapefile_path)) from err
+
+    try:
+        clipped = data.rio.clip(region.geometry.apply(mapping), region.crs, drop=True, **kwargs)
+    except rio.exceptions.NoDataInBounds as err:
+        msg = "Can't clip feature. Your grid resolution may be too low for your shapefile feature, or your shapefile's CRS may be incorrectly set."
+        raise RuntimeError(msg) from err
+    except Exception as err:
+        raise RuntimeError from err
+
+    if feature:
+        if isinstance(feature[1],list):
+            location = [str(item) for item in feature[1]]
+        else:
+            location = [str(feature[1])]
+    else:
+        location = [name]
+    clipped.attrs["location_subset"] = location
+        
+    return clipped

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -1191,7 +1191,7 @@ def clip_to_shapefile(
     data: xr.Dataset | xr.DataArray,
     shapefile_path: str,
     feature: tuple[str, str | int | float | bool | list[str | int | float | bool]] = (),
-    name: str = "custom",
+    name: str = "user-defined",
     **kwargs,
 ) -> xr.Dataset | xr.DataArray:
     """Use a shapefile to select an area subset of AE data.
@@ -1249,7 +1249,7 @@ def clip_to_shapefile(
         msg = "Can't clip feature. Your grid resolution may be too low for your shapefile feature, or your shapefile's CRS may be incorrectly set."
         raise RuntimeError(msg) from err
     except Exception as err:
-        raise RuntimeError from err
+        raise err
 
     if feature:
         if isinstance(feature[1], list):

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -1239,10 +1239,14 @@ def clip_to_shapefile(
             else:
                 region = region[region[feature[0]] == feature[1]]
             if len(region) == 0:  # No features found
-                raise Exception
+                raise ValueError("None of the requested features were found.")
+        except ValueError as err:
+            raise err
         except Exception as err:
             raise RuntimeError(
-                "Could not select feature {0} in {1} ".format(feature, shapefile_path)
+                "Could not select one or more feature(s) {0} in {1} ".format(
+                    feature, shapefile_path
+                )
             ) from err
 
     try:

--- a/climakitae/util/utils.py
+++ b/climakitae/util/utils.py
@@ -1196,6 +1196,9 @@ def clip_to_shapefile(
 ) -> xr.Dataset | xr.DataArray:
     """Use a shapefile to select an area subset of AE data.
 
+    By default, this function will clip the data to the area covered by all features in
+    the shapefile. To clip to specific features, use the `feature` keyword.
+
     Parameters
     ----------
     data : xr.Dataset | xr.DataArray

--- a/tests/util/test_utils.py
+++ b/tests/util/test_utils.py
@@ -1641,6 +1641,10 @@ class TestConvertToLocalTime:
         assert result.attrs["location_subset"] == ["user-defined"]
         assert result.shape == (5, 4)
 
+        with patch("geopandas.read_file", return_value=gdf):
+            result = clip_to_shapefile(data, "not_a_file.shp", ("Area", "Box1"))
+        assert result.attrs["location_subset"] == ["Box1"]
+
         # Input data lacks CRS
         with pytest.raises(RuntimeError):
             result = clip_to_shapefile(xr.Dataset(), "not_a_file.shp")

--- a/tests/util/test_utils.py
+++ b/tests/util/test_utils.py
@@ -8,8 +8,8 @@ import numpy as np
 import pandas as pd
 import pyproj
 import pytest
-from shapely.geometry import box
 import xarray as xr
+from shapely.geometry import box
 
 from climakitae.util.utils import (  # stack_sims_across_locs, # TODO: Uncomment when implemented
     _get_cat_subset,
@@ -1652,11 +1652,6 @@ class TestConvertToLocalTime:
                 result = clip_to_shapefile(data, "not_a_file.shp")
 
         # "Shapefile" feature too small relative to grid
-        df = pd.DataFrame(
-            {
-                "Area": ["Box1"],
-            }
-        )
         geometry = [box(-121.39, 38.52, -121.31, 38.56)]
         gdf = gpd.GeoDataFrame(df, geometry=geometry, crs="EPSG:4326")
         with patch("geopandas.read_file", return_value=gdf):

--- a/tests/util/test_utils.py
+++ b/tests/util/test_utils.py
@@ -1614,47 +1614,51 @@ class TestConvertToLocalTime:
     def test_clip_to_shapefile(self):
         # Dataset to trim
         data = xr.DataArray(
-            data = np.zeros((10,10)),
-            coords = {"lat": np.linspace(38.0,38.9,num=10),
-                      "lon": np.linspace(-121.9,-121.0,num=10)},
+            data=np.zeros((10, 10)),
+            coords={
+                "lat": np.linspace(38.0, 38.9, num=10),
+                "lon": np.linspace(-121.9, -121.0, num=10),
+            },
         )
-        data = data.rio.set_spatial_dims(y_dim="lat",x_dim="lon")
+        data = data.rio.set_spatial_dims(y_dim="lat", x_dim="lon")
         data = data.rio.write_crs("EPSG:4326")
         # Mock shapefile inputs with this:
-        df = pd.DataFrame({"Area": ["Box1"],})
-        geometry=[box(-121.6, 38.3, -121.2, 38.8)]
-        gdf = gpd.GeoDataFrame(
-            df, geometry=geometry, crs="EPSG:4326"
+        df = pd.DataFrame(
+            {
+                "Area": ["Box1"],
+            }
         )
+        geometry = [box(-121.6, 38.3, -121.2, 38.8)]
+        gdf = gpd.GeoDataFrame(df, geometry=geometry, crs="EPSG:4326")
         # This should clip successfully
-        with patch("geopandas.read_file",return_value=gdf):
-            result = clip_to_shapefile(data,"not_a_file.shp")
+        with patch("geopandas.read_file", return_value=gdf):
+            result = clip_to_shapefile(data, "not_a_file.shp")
 
-        assert result["lat"].min().item() == pytest.approx(38.3,1e-6)
-        assert result["lat"].max().item() == pytest.approx(38.7,1e-6)
-        assert result["lon"].min().item() == pytest.approx(-121.6,1e-6)
-        assert result["lon"].max().item() == pytest.approx(-121.3,1e-6)
+        assert result["lat"].min().item() == pytest.approx(38.3, 1e-6)
+        assert result["lat"].max().item() == pytest.approx(38.7, 1e-6)
+        assert result["lon"].min().item() == pytest.approx(-121.6, 1e-6)
+        assert result["lon"].max().item() == pytest.approx(-121.3, 1e-6)
         assert result.attrs["location_subset"] == ["user-defined"]
-        assert result.shape == (5,4)
+        assert result.shape == (5, 4)
 
         # Input data lacks CRS
         with pytest.raises(RuntimeError):
-            result = clip_to_shapefile(xr.Dataset(),"not_a_file.shp")
+            result = clip_to_shapefile(xr.Dataset(), "not_a_file.shp")
 
         # "Shapefile" data lacks CRS
-        gdf = gpd.GeoDataFrame(
-            df, geometry=geometry, crs=None
-        )
-        with patch("geopandas.read_file",return_value=gdf):
+        gdf = gpd.GeoDataFrame(df, geometry=geometry, crs=None)
+        with patch("geopandas.read_file", return_value=gdf):
             with pytest.raises(RuntimeError):
-                result = clip_to_shapefile(data,"not_a_file.shp")
+                result = clip_to_shapefile(data, "not_a_file.shp")
 
         # "Shapefile" feature too small relative to grid
-        df = pd.DataFrame({"Area": ["Box1"],})
-        geometry=[box(-121.39, 38.52, -121.31, 38.56)]
-        gdf = gpd.GeoDataFrame(
-            df, geometry=geometry, crs="EPSG:4326"
+        df = pd.DataFrame(
+            {
+                "Area": ["Box1"],
+            }
         )
-        with patch("geopandas.read_file",return_value=gdf):
+        geometry = [box(-121.39, 38.52, -121.31, 38.56)]
+        gdf = gpd.GeoDataFrame(df, geometry=geometry, crs="EPSG:4326")
+        with patch("geopandas.read_file", return_value=gdf):
             with pytest.raises(RuntimeError):
-                result = clip_to_shapefile(data,"not_a_file.shp")
+                result = clip_to_shapefile(data, "not_a_file.shp")


### PR DESCRIPTION
## Summary of changes and related issue
This PR adds `clip_to_shapefile` to util.utils and adds corresponding unit tests. This function uses rioxarray.clip under-the-hood and should work on any shapefile with a valid CRS. Rioxarray already does a lot of data validation and checking so the only validation I'm doing is making sure the input datasets have a CRS set. I add some helpful hints for common errors, which are often due to issues with the CRS or the grid size.

## Relevant motivation and context
This change gives AE users the ability to clip AE data to a shapefile of their choosing. 

## How to test 
```
pip install pytest
pytest tests/util/test_utils.py
```
Testers can also grab a shapefile and try out the function in AE. Install this branch first.
Here's an example with the [TIGER/Line county shapefile](https://www.census.gov/cgi-bin/geo/shapefiles/index.php?year=2024&layergroup=ZIP+Code+Tabulation+Areas).
```
from climakitae.util.utils import clip_to_shapefile
from climakitae.core.data_interface import get_data
# 3km is small enough to fit in most counties in CA
data = get_data(
    variable = "Precipitation (total)", 
    downscaling_method = "Statistical", 
    resolution = "3 km", 
    timescale = "monthly", 
    scenario = "Historical Climate"
)
# file from https://www.census.gov/cgi-bin/geo/shapefiles/index.php?year=2024&layergroup=ZIP+Code+Tabulation+Areas
shapefile_path="../../shapefiles/tl_2024_us_zcta520.zip"
# can change "95912" to any valid zip code
feature=("ZCTA5CE20",'95912')
# selecting just one time slice for quick demo
tmp=data.sel({"simulation":'LOCA2_IPSL-CM6A-LR_r10i1p1f1'}).isel({"time":0})
clipped = clip_to_shapefile(tmp,shapefile_path,feature=feature)
clipped.plot()

# Pass all-touched keyword (or any other keyword to rio.clip)
#clipped = clip_to_shapefile(tmp,shapefile_path,feature=feature,all_touched=True)
#clipped.plot()
```

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
