### PR TITLE
Move data load tests to advanced tier

### DIFF
--- a/tests/data_load/test_data_load.py
+++ b/tests/data_load/test_data_load.py
@@ -101,6 +101,7 @@ class TestLoad:
         assert isinstance(result.variable._data, np.ndarray)
 
 
+@pytest.mark.advanced
 class TestDataLoadHidden:
 
     def test__override_unit_defaults(self):
@@ -153,6 +154,7 @@ class TestDataLoadHidden:
         assert len(result.time) == 365 * 2
 
 
+@pytest.mark.advanced
 class TestAreaSubset:
 
     def test_area_subset_geometry_latlon(self, selections):
@@ -210,6 +212,7 @@ class TestAreaSubset:
         assert isinstance(result[0], shapely.geometry.polygon.Polygon)
 
 
+@pytest.mark.advanced
 class TestDataLoadDerived:
 
     @patch("climakitae.core.data_load._get_data_one_var", return_value=mock_data())
@@ -327,6 +330,7 @@ class TestDataLoadDerived:
         assert result.attrs["units"] == "degrees"
 
 
+@pytest.mark.advanced
 class TestReadCatalog:
     """This class is going to actually pull data from
     the catalog using various parameter choices.


### PR DESCRIPTION
## Summary of changes and related issue
Move the long-running (3+ s) tests in the data_load test submodule to the advanced tier.

## Relevant motivation and context
Streamline automated testing by removing long-running tests from default set.

## How to test 
Run tests using marker:

`pytest -vv --durations=0 -m "not advanced"`
`pytest -vv --durations=0 -m advanced`

To trigger elevated tests on GitHub PRs simply set the label to Advanced Testing.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
  - [x] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
