### PR TITLE
Fix inconsistent `GWLGenerator` tests

### DIFF
--- a/climakitae/util/generate_gwl_tables_unc.py
+++ b/climakitae/util/generate_gwl_tables_unc.py
@@ -448,7 +448,6 @@ class GWLGenerator:
                 wl_data_tbls.append(wl_data_tbl)
                 successful_ens_mems.append(ens_mem)  # Append only if successful
 
-        gwlevels_tbl = [df for df in gwlevels_tbl if df is not None and not df.empty]
         if gwlevels_tbl and wl_data_tbls:
             # Renaming columns of all ensemble members within model
             try:

--- a/climakitae/util/generate_gwl_tables_unc.py
+++ b/climakitae/util/generate_gwl_tables_unc.py
@@ -450,21 +450,31 @@ class GWLGenerator:
         if gwlevels_tbl and wl_data_tbls:
             # Renaming columns of all ensemble members within model
             try:
+                # Align indexes before concatenation
+                wl_data_tbls = [
+                    df.reindex(wl_data_tbls[0].index) for df in wl_data_tbls
+                ]
                 wl_data_tbl_sim = pd.concat(wl_data_tbls, axis=1)
-            except ValueError as e:
-                print(f"Error concatenating results for model {model}: {e}")
+            except Exception as e:
+                print(f"Error concatenating timeseries results for model {model}: {e}")
                 return pd.DataFrame(), pd.DataFrame()
+
             print(model, wl_data_tbl_sim.columns)
             wl_data_tbl_sim.columns = model + "_" + wl_data_tbl_sim.columns
 
             # Use the filtered list for concatenation
             try:
+                gwlevels_tbl = [
+                    df.reindex(gwlevels_tbl[0].index) for df in gwlevels_tbl
+                ]
                 return (
                     pd.concat(gwlevels_tbl, keys=successful_ens_mems),
                     wl_data_tbl_sim,
                 )
-            except ValueError as e:
-                print(f"Error concatenating results for model {model}: {e}")
+            except Exception as e:
+                print(
+                    f"Error concatenating warming level results for model {model}: {e}"
+                )
                 return pd.DataFrame(), pd.DataFrame()
         else:
             print(f"No valid ensemble members for model {model}")

--- a/climakitae/util/generate_gwl_tables_unc.py
+++ b/climakitae/util/generate_gwl_tables_unc.py
@@ -448,6 +448,7 @@ class GWLGenerator:
                 wl_data_tbls.append(wl_data_tbl)
                 successful_ens_mems.append(ens_mem)  # Append only if successful
 
+        gwlevels_tbl = [df for df in gwlevels_tbl if df is not None and not df.empty]
         if gwlevels_tbl and wl_data_tbls:
             # Renaming columns of all ensemble members within model
             try:

--- a/climakitae/util/generate_gwl_tables_unc.py
+++ b/climakitae/util/generate_gwl_tables_unc.py
@@ -433,13 +433,14 @@ class GWLGenerator:
         # Create enumerated list for processing
         enum_ens_mem_list = list(enumerate(ens_mem_list))
 
-        # Use ThreadPoolExecutor to parallelize processing
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            results = list(executor.map(_process_ensemble_member, enum_ens_mem_list))
+        results = [
+            _process_ensemble_member(i_ens_mem) for i_ens_mem in enum_ens_mem_list
+        ]
 
         # Process results
         successful_ens_mems = []  # Track successful ensemble members
         for i, ens_mem, gwlevels, wl_data_tbl, error_msg in results:
+            print(i, ens_mem, gwlevels, wl_data_tbl)
             if error_msg:
                 print(error_msg)
             else:

--- a/tests/util/test_generate_gwl_tables_unc.py
+++ b/tests/util/test_generate_gwl_tables_unc.py
@@ -901,8 +901,8 @@ class TestGWLGenerator:
                 [
                     ("r1", "ssp370"),
                     ("r1", "ssp585"),
-                    ("r2", "ssp370"),
-                    ("r2", "ssp585"),
+                    ("r3", "ssp370"),
+                    ("r3", "ssp585"),
                 ],
                 names=[None, "scenario"],
             )
@@ -912,7 +912,7 @@ class TestGWLGenerator:
                 gwlevels_agg.columns, pd.Index(expected_gwl_cols, dtype=float)
             )
             assert gwlevels_agg.loc[("r1", "ssp370"), 1.5] == pd.Timestamp("2030-01-01")
-            assert gwlevels_agg.loc[("r2", "ssp585"), 2.0] == pd.Timestamp("2042-01-01")
+            assert gwlevels_agg.loc[("r3", "ssp585"), 2.0] == pd.Timestamp("2042-01-01")
             # Check aggregated timeseries DataFrame
             assert isinstance(timeseries_agg, pd.DataFrame)
             # Check that column prefixes are properly added

--- a/tests/util/test_generate_gwl_tables_unc.py
+++ b/tests/util/test_generate_gwl_tables_unc.py
@@ -901,8 +901,8 @@ class TestGWLGenerator:
                 [
                     ("r1", "ssp370"),
                     ("r1", "ssp585"),
-                    ("r2", "ssp370"),
-                    ("r2", "ssp585"),
+                    ("r3", "ssp370"),
+                    ("r3", "ssp585"),
                 ],
                 names=[None, "scenario"],
             )

--- a/tests/util/test_generate_gwl_tables_unc.py
+++ b/tests/util/test_generate_gwl_tables_unc.py
@@ -901,8 +901,8 @@ class TestGWLGenerator:
                 [
                     ("r1", "ssp370"),
                     ("r1", "ssp585"),
-                    ("r3", "ssp370"),
-                    ("r3", "ssp585"),
+                    ("r2", "ssp370"),
+                    ("r2", "ssp585"),
                 ],
                 names=[None, "scenario"],
             )


### PR DESCRIPTION
## Summary of changes and related issue
Fixing issue with inconsistent `GWLGenerator` tests:

1. due to what I suspect is versioning differences between my local setup and the github CI environment, there was a problem with concatenating dataframes that caused inconsistent behavior when writing the dataframes.
2. After fixing the above issue, another issue popped up. The tables were being processed in parallel and the results weren't being sorted properly leading to failed asserts because index orders weren't correct

## Relevant motivation and context
Inconsistent testing is frustrating to deal with.

## How to test 
confirm that tests run locally, and report if any further inconsistencies show up.
```bash
pip install pytest-cov
pytest tests/util/test_generate_gwl_tables_unc.py --cov=climakitae.util.generate_gwl_tables_unc --cov-report term-missing
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
  - [x] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
