### PR TITLE
Test Coverage for `explore.warming`

### DIFF
--- a/climakitae/explore/warming.py
+++ b/climakitae/explore/warming.py
@@ -170,9 +170,29 @@ def relabel_axis(all_sims_dim: Iterable) -> List[str]:
 
     Examples
     --------
-    >>> all_sims_dim = [xr.DataArray([("sim1", "scenario1")]), xr.DataArray([("sim2", "scenario2")])]
-    >>> relabel_axis(all_sims_dim)
-    ['sim1_scenario1', 'sim2_scenario2']
+    >>> import xarray as xr
+    >>> # The input `all_sims_dim` is typically an xarray.DataArray
+    >>> # representing a coordinate, often created by stacking dimensions.
+    >>> # For example, if `ds` is a Dataset with 'simulation' and 'scenario'
+    >>> # coordinates, then `ds.stack(all_sims=('simulation', 'scenario'))['all_sims']`
+    >>> # would be such an input.
+    >>>
+    >>> # Create an example of such an xarray.DataArray:
+    >>> simulation_scenario_pairs = [
+    ...     ('ModelA_run1', 'SSP1-2.6'),
+    ...     ('ModelB_run2', 'SSP5-8.5')
+    ... ]
+    >>> # This DataArray holds the coordinate values (the tuples).
+    >>> all_sims_coordinate = xr.DataArray(
+    ...     data=simulation_scenario_pairs,
+    ...     dims=['all_sims'],
+    ...     name='all_sims_stacked_coordinate'
+    ... )
+    >>> # The function iterates over `all_sims_coordinate`. Each element `one`
+    >>> # (as in the function's loop) is a 0-D xarray.DataArray containing one tuple.
+    >>> # For the first pair, `one.values.item()` would yield ('ModelA_run1', 'SSP1-2.6').
+    >>> relabel_axis(all_sims_coordinate)
+    ['ModelA_run1_SSP1-2.6', 'ModelB_run2_SSP5-8.5']
     """
     new_arr = []
     for one in all_sims_dim:


### PR DESCRIPTION
## Summary of changes and related issue
Some minor changes to `explore.warming` and 91% test coverage.

## Relevant motivation and context
Trying to hit goal of ~85% test coverage

## How to test 
```bash
pip install pytest-cov
pytest tests/warming/test_warming.py --cov=climakitae.explore.warming --cov-report term-missing
```
Probably should investigate which of these to put into the advanced testing category. Some of them take a bit to run.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
  - [x] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
