### PR TITLE
Readd removed `_round_to_nearest_half`

### DIFF
--- a/climakitae/explore/agnostic.py
+++ b/climakitae/explore/agnostic.py
@@ -102,6 +102,10 @@ def year_to_warm_levels(warm_df, scenario, year):
 ##### TASK 2 #####
 
 
+def _round_to_nearest_half(number):
+    return round(number * 2) / 2
+
+
 def _get_var_info(variable, downscaling_method, wrf_timescale="monthly"):
     """Gets the variable info for the specific variable name and downscaling method"""
     var_desc_df = read_csv_file(variable_descriptions_csv_path)


### PR DESCRIPTION
## Summary of changes and related issue

Readd removed `_round_to_nearest_half` function that is actually referenced still.

## Relevant motivation and context
Fix broken code!

## How to test 
Run agnostic tools

## Type of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
