### PR TITLE
Fix Broken Link in Readthedocs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ scientific analyses with climate data from the Cal-Adapt Analytics Engine.
 
     .. grid-item-card:: Getting Started
         :img-top: _static/runner.svg
-        :link: https://github.com/cal-adapt/cae-notebooks/blob/main/data-access/interactive_data_access_and_viz.ipynb
+        :link: https://github.com/cal-adapt/cae-notebooks/blob/main/data-access/basic_data_access.ipynb
         :columns: 3
 
         An introductory notebook demonstrating how to get started with *climakitae* and 


### PR DESCRIPTION
## Summary of changes and related issue
Fixing broken link after `cae-notebooks` refactor.

This now points to the same `getting_started.ipynb` that it was pointing to before, but we may also want to consider point to  [this notebook instead](https://github.com/cal-adapt/cae-notebooks/blob/b372f82c6fd438e80cb232857b4095f1387dccd3//data-access/basic_data_access.ipynb), since this one shows data access with `get_data` rather than `selections.retrieve()`.

## Relevant motivation and context
Fix broken link.

## How to test 
Check if the **Getting Started** is a valid link now on the https://climakitae.readthedocs.io/en/latest/ page.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
