### PR TITLE
Fix issue with pip installing climakitae due to xclim/xsdba migration

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -3,6 +3,10 @@ from ast import literal_eval
 from datetime import timedelta
 from functools import partial
 
+# Importing DataParameters causes ImportError due to circular import
+# so only import for type checking and reference as str 'DataParameters'
+from typing import TYPE_CHECKING
+
 import dask
 import geopandas as gpd
 import numpy as np
@@ -15,8 +19,7 @@ from dask.diagnostics import ProgressBar
 from geopandas import GeoDataFrame
 from rioxarray.exceptions import NoDataInBounds
 from shapely.geometry import box
-from xclim.sdba import Grouper
-from xclim.sdba.adjustment import QuantileDeltaMapping
+from xclim.sdba import Grouper, QuantileDeltaMapping
 
 from climakitae.core.boundaries import Boundaries
 from climakitae.tools.derived_variables import (
@@ -41,10 +44,6 @@ from climakitae.util.utils import (
     timescale_to_table_id,
 )
 from climakitae.util.warming_levels import calculate_warming_level, drop_invalid_sims
-
-# Importing DataParameters causes ImportError due to circular import
-# so only import for type checking and reference as str 'DataParameters'
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from climakitae.core.data_interface import DataParameters

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,7 @@ install_requires =
     timezonefinder
     dask-geopandas
     xclim
+    
 tests_require =
     pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ install_requires =
     timezonefinder
     dask-geopandas
     xclim
-    
+    xsdba
 tests_require =
     pytest
 


### PR DESCRIPTION
## Summary of changes and related issue
Added `xsdba` to `setup.cfg` for proper pip install from cli. 

## Relevant motivation and context
`xclim` split `sdba` into it's own package, this is a temporary fix that will cause a user warning for a little bit until we do a full migration. 

## How to test 
Checkout this branch, then run the following on a linux machine:
```bash
pip install uv
uv venv --python 3.11
source .venv/bin/activate
uv pip install -e .
uv pip install climakitaegui
uv run python
>>> from climakitaegui.explore.amy import lineplot_from_amy_data
```
you should see a UserWarning and not an import error.

Once this is merged to main it should resolve the issue with the `climakitaegui` import since `climakitaegui` has `climakitae` as a dependency.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
