### PR TITLE
[BUGFIX] get block max with xy improper nan handling

### DIFF
--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -1,5 +1,7 @@
 """Helper functions for performing analyses related to thresholds"""
 
+import warnings
+
 import numpy as np
 import scipy
 import statsmodels as sm
@@ -226,8 +228,10 @@ def get_block_maxima(
                 bms = dropped_bms
             else:
                 # For other dimension combinations, be conservative and don't drop
-                print(
-                    f"WARNING: Found NaN values in block maxima but unable to determine appropriate dropping strategy for dimensions {bms.dims}. Keeping all data."
+                warnings.warn(
+                    f"\n\nWARNING: Found NaN values in block maxima but unable to determine appropriate dropping strategy for dimensions {bms.dims}"
+                    "\nNo NaN values will be dropped from the block maxima DataArray."
+                    "\nPlease inspect the data and handle NaN values appropriately before proceeding."
                 )
 
     return bms


### PR DESCRIPTION
## Summary of changes and related issue
Addresses the problems raised in [this issue
](https://github.com/cal-adapt/climakitae/issues/597)

## Relevant motivation and context
`get_block_maxima()` was returning empty arrays when passing ranged x and y values. This was happening due to improper nan handling where any time slice that contained any NaN was being dropped. The function now properly handles NaNs and will not return an empty array for the test scenario.

## How to test 
Run the test suite if you'd like but it runs successfully in the workflow here. 
To test you can unzip and upload the attached files on the jupyter hub and run it.
[test_block_max.zip](https://github.com/user-attachments/files/21126430/test_block_max.zip)


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
