### PR TITLE
[FEATURE] Automatic test coverage monitoring with `codecov.io`

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -33,8 +33,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest cftime
+        pip install pytest cftime pytest-cov
     - name: Install climakitae
       run: pip install . --no-deps
     - name: Test with pytest
-      run: pytest --no-header -vv
+      run: pytest --no-header -vv --cov --cov-branch --cov-report=xml
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: cal-adapt/climakitae

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Climakitae
 
+[![codecov](https://codecov.io/gh/cal-adapt/climakitae/branch/main/graph/badge.svg)](https://codecov.io/gh/cal-adapt/climakitae)
 [![CI](https://github.com/cal-adapt/climakitae/workflows/ci-main/badge.svg)](https://github.com/cal-adapt/climakitae/actions/workflows/ci-main.yml)
 [![Documentation Status](https://readthedocs.org/projects/climakitae/badge/?version=latest)](https://climakitae.readthedocs.io/en/latest/?badge=latest)
 [![PyPI version](https://badge.fury.io/py/climakitae.svg)](https://badge.fury.io/py/climakitae)
 [![Python](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 
 **A powerful Python toolkit for climate data analysis and retrieval from the Cal-Adapt Analytics Engine (AE).**
 


### PR DESCRIPTION
## Summary of changes and related issue
main ci workflow now writes an xml report and ships that report off to [codecov.io](https://app.codecov.io/gh/cal-adapt/climakitae] for monitoring via a dashboard. Readme now also features a badge that gives an overall summary of the code coverage as reported back by codecov.

## Relevant motivation and context
This allows us to stop running our code coverage manually and gives us a monitored history of coverage starting today. This will make project management easier and reduce dev time spent running the report code by hand.

## How to test 
Head over to the [branch](https://github.com/cal-adapt/climakitae/tree/feature/code-cov) and double check that the badge at the top of the README displays correctly. And head to the dashboard linked above to browse around and look at the report.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
  - [x] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
