### PR TITLE
Ensure WL data does not start before 1981

### DIFF
--- a/climakitae/util/warming_levels.py
+++ b/climakitae/util/warming_levels.py
@@ -110,6 +110,9 @@ def _get_sliced_data(y, level, gwl_times, months, window):
         start_year = centered_year - window
         end_year = centered_year + (window - 1)
 
+        if start_year < 1981:
+            start_year = 1981
+
         sliced = y.sel(time=slice(str(start_year), str(end_year)))
 
         # Creating a mask for timestamps that are within the desired months


### PR DESCRIPTION
## Summary of changes and related issue
Ensure that WL data does not start before 1981, since AE catalog data starts in Sept 1980 (can throw off WL calculations since the actual time axis is removed in WL data objects, so it is difficult to determine what month the data starts in).

## Relevant motivation and context
We want to look at temporal trends in WL data that make sense if a dummy time is added to the WL obj, which means that we need to make sure data starts at Jan 1.

## How to test 
Pull Air Temperature at 2m data for EC-Earth3, EC-Earth3-Veg, or any GCM, at a WL that reaches that level of warming before 1995. Then, plot the data on a time axis and make sure that the cycle is following proper trends (i.e. add dummy time to wl to the data object, and make sure winter is the coldest and summer is the hottest).

**Alternatively**, this [notebook](https://github.com/user-attachments/files/21419711/fix_start_time.ipynb.zip) pulls 0.8 WL data, visualizes Air Temp at 2m trends across WRF simulations for you. If you run this notebook in main, you should have EC-Earth3 offset from the rest of the simulations. If you run this notebook on this branch, they should all be aligned.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
