### PR TITLE
Fix unit conversion bug for derived variables

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -1332,13 +1332,13 @@ def read_catalog_from_select(selections: "DataParameters") -> xr.DataArray:
                 )
 
         # ------ Set attributes ------
-        # Reset selections to user's original selections
-        selections.variable_id = [orig_var_id_selection]
-        selections.units = orig_unit_selection
-
         # Convert units before copying data attributes
         da = convert_units(da, selected_units=orig_unit_selection)
         da.name = orig_variable_selection  # Set name of DataArray
+
+        # Reset selections to user's original selections
+        selections.variable_id = [orig_var_id_selection]
+        selections.units = orig_unit_selection
 
         # Some of the derived variables may be constructed from data that comes from the same institution
         # The dev team hasn't looked into this yet -- opportunity for future improvement

--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -1332,18 +1332,18 @@ def read_catalog_from_select(selections: "DataParameters") -> xr.DataArray:
                 )
 
         # ------ Set attributes ------
+        # Reset selections to user's original selections
+        selections.variable_id = [orig_var_id_selection]
+        selections.units = orig_unit_selection
+
+        # Convert units before copying data attributes
+        da = convert_units(da, selected_units=orig_unit_selection)
+        da.name = orig_variable_selection  # Set name of DataArray
+
         # Some of the derived variables may be constructed from data that comes from the same institution
         # The dev team hasn't looked into this yet -- opportunity for future improvement
         data_attrs = data_attrs | {"institution": "Multiple"}
         da.attrs = data_attrs
-
-        # Convert units
-        da = convert_units(da, selected_units=orig_unit_selection)
-        da.name = orig_variable_selection  # Set name of DataArray
-
-        # Reset selections to user's original selections
-        selections.variable_id = [orig_var_id_selection]
-        selections.units = orig_unit_selection
 
     # Rotate wind vectors
     elif (


### PR DESCRIPTION
## Summary of changes and related issue
Fixing a bug where the dew point temperature derived data would not successfully have units converted to selected units. This bug may potentially affected other derived variables. 

I've rearranged L1335-1346 so that the unit conversion happens before copying the data attributes from the selections object. This is because the data array units would be overwritten by the units in the selections object, which affected the subsequent unit conversion.

## Relevant motivation and context
Need to be able to request dew point temperature in units other than K.

## How to test 
Try loading dew point temperature or other derived variables in different units:
```
from climakitae.core.data_interface import get_data
dewpt_data = get_data(
    variable="Dew point temperature",
    resolution="9 km",
    timescale="hourly",
    data_type="Gridded",
    units="degC",
    latitude=(33.93816 - 0.05, 33.93816 + 0.05),
    longitude=(-118.3866 - 0.06, -118.3866 + 0.06),
    area_average="Yes",
    scenario=["Historical Climate", "SSP 3-7.0"],
    time_slice=(
        1990,
        1991,
    )
)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
  - [x] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
