### PR TITLE
Bug fix: Set FFWI to TRUE

### DIFF
--- a/climakitae/data/variable_descriptions.csv
+++ b/climakitae/data/variable_descriptions.csv
@@ -80,7 +80,7 @@ hursmax,Statistical,"daily, monthly",percent,Maximum relative humidity,The maxim
 wspeed,Statistical,"daily, monthly",m s-1,Wind speed at 10m,Wind speed at 10 meters above the Earth's surface. Computed by taking the vector magnitude of the west-east (u) component of wind and the north-south (v) component of wind.,ae_orange,TRUE,None
 rsds,Statistical,"daily, monthly",W/m2,Shortwave flux at the surface,Shortwave radiation from the sun that reaches Earth's surface. ,ae_orange,TRUE,None
 noaa_heat_index_derived,Dynamical,hourly,degF,NOAA Heat Index,"Operational measure of what the the temperature ""feels like"" to the human body.",ae_orange,TRUE,"t2, q2, psfc"
-ffwi,Dynamical,hourly,[0 to 100],Fosberg fire weather index,Operational fire weather index using meteorological inputs (temperature / relative humidity / windspeed) to quantify fire risk. Large values imply a higher risk value.,ae_orange,FALSE,None
+ffwi,Dynamical,hourly,[0 to 100],Fosberg fire weather index,Operational fire weather index using meteorological inputs (temperature / relative humidity / windspeed) to quantify fire risk. Large values imply a higher risk value.,ae_orange,TRUE,None
 cf,Dynamical,hourly,[0 to 1],Capacity factor,The ratio of power produced to the nameplate capacity. Power production can be estimated by multiplying capacity factor by nameplate capacity.,ae_orange,FALSE,None
 gen,Dynamical,hourly,MW,Power generation,Power generation by the panel or turbine array. ,ae_orange,FALSE,None
 effective_temp_index_derived,Dynamical,daily,K,Effective Temperature,The sum of half of yesterday's effective temperature and half of the current day's actual temperature. Accounts for previous day's temperature due to consumer behavior and perception of the weather. ,ae_orange,TRUE,t2


### PR DESCRIPTION
## Summary of changes and related issue
Sets derived FFWI to true so it is retrievable via `get_data` and via GUI. 

## Relevant motivation and context
Could not retrieve data. 

## How to test 
Test in GUI and `get_data`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
