### PR TITLE
Fix Unit Conversion Raise Error Test

### DIFF
--- a/tests/data_load/test_data_load.py
+++ b/tests/data_load/test_data_load.py
@@ -122,7 +122,7 @@ class TestDataLoadHidden:
         assert result is None
 
         # Edit a unit to cause exception
-        selections.variable_options_df.loc[29, "unit"] = "C"
+        selections.variable_options_df.loc[34, "unit"] = "C"
         with pytest.raises(ValueError):
             result = _check_valid_unit_selection(selections)
 


### PR DESCRIPTION
## Summary of changes and related issue
This pull request makes a small adjustment to the unit selection test in `tests/data_load/test_data_load.py`. The change updates the index used when editing the `variable_options_df` DataFrame to trigger an exception, ensuring the test targets the correct data row.

## Relevant motivation and context
A test was failing

## How to test 
1) confirm that all tests have passed in the ci
2) confirm the fixed test runs on your machine:
```bash
pytest tests/data_load/test_data_load.py::TestDataLoadHidden::test__check_valid_unit_selection -v
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
  - [x] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
