### PR TITLE
Threshold tools: catch value error in confidence interval calculation

### DIFF
--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -754,17 +754,22 @@ def _get_return_variable(
         except (ValueError, ZeroDivisionError):
             return_variable = np.nan
 
-        conf_int_lower_limit, conf_int_upper_limit = _conf_int(
-            bms=bms,
-            distr=distr,
-            data_variable=data_variable,
-            arg_value=arg_value,
-            bootstrap_runs=bootstrap_runs,
-            conf_int_lower_bound=conf_int_lower_bound,
-            conf_int_upper_bound=conf_int_upper_bound,
-            block_size=block_size,
-            extremes_type=extremes_type,
-        )
+        try:
+            conf_int_lower_limit, conf_int_upper_limit = _conf_int(
+                bms=bms,
+                distr=distr,
+                data_variable=data_variable,
+                arg_value=arg_value,
+                bootstrap_runs=bootstrap_runs,
+                conf_int_lower_bound=conf_int_lower_bound,
+                conf_int_upper_bound=conf_int_upper_bound,
+                block_size=block_size,
+                extremes_type=extremes_type,
+            )
+        except ValueError:
+            conf_int_lower_limit = np.nan
+            conf_int_upper_limit = np.nan
+
         return (
             np.array([return_variable]),
             np.array([conf_int_lower_limit]),


### PR DESCRIPTION
## Summary of changes and related issue
Return an NaN if errors occur when calculating the confidence interval.

## Relevant motivation and context
Occasionally I'll see the return value code fail with an error like the one copied below. The bootstrap values array will be empty. Instead of failing the whole run, I'd like to return NaNs for the confidence interval results when this happens.
```
ValueError                                Traceback (most recent call last)
Cell In[43], line 1
----> 1 get_ipython().run_cell_magic('time', '', 'return_period = 10  # years\nfor duration in [1, 2, 10]:  # 1, 2, and 10-day rain totals\n    sim_list = []\n    for sim in loaded_data.simulation:\n        rv_list = []\n        for wl in loaded_data.warming_level:\n            # afaik only takes one warming level and simulation at a time\n            # so we concatenate all the warming levels and simulations per gcm\n            data = loaded_data.sel({"warming_level": wl}).sel({"simulation": sim})\n            if duration > 1:\n                data = data.rolling(time=duration, center=False).sum("time")\n            ams = get_block_maxima(\n                data,\n                check_ess=False,\n            )\n            rv = get_return_value(\n                ams, return_period=return_period, multiple_points=False\n            )\n            rv_list.append(rv)\n        rv = xr.concat(rv_list, loaded_data.warming_level)\n        sim_list.append(rv)\n    rv = xr.concat(sim_list, loaded_data.simulation)\n\n    # Objects get saved under these attributes and\n    # can\'t be written to netcdf, so they get dropped\n    rv.attrs.pop("groupby")\n    rv.attrs.pop("grouped_duration")\n    rv.return_value.attrs.pop("groupby")\n    rv.return_value.attrs.pop("grouped_duration")\n    rv.conf_int_lower_limit.attrs.pop("groupby")\n    rv.conf_int_lower_limit.attrs.pop("grouped_duration")\n    rv.conf_int_upper_limit.attrs.pop("groupby")\n    rv.conf_int_upper_limit.attrs.pop("grouped_duration")\n    rv.attrs.pop("duration")\n    rv.return_value.attrs.pop("duration")\n    rv.conf_int_lower_limit.attrs.pop("duration")\n    rv.conf_int_upper_limit.attrs.pop("duration")\n\n    # Write to s3\n    if save_zarr:\n        s3_filepath = f"11_pr_1_in_10_{duration}_day_{gcm}.zarr"\n        s3_filepath = os.path.join(zarr_store, s3_filepath)\n        store = s3fs.S3Map(root=s3_filepath, s3=s3, check=False)\n        rv.to_zarr(store=store, mode="w")\n    if debug:\n        s3_filepath = f"11_pr_1_in_10_{duration}_day_{gcm}.nc"\n        nc_filepath = os.path.join(debug_fdir, s3_filepath)\n        rv.to_netcdf(nc_filepath, mode="w")\n\n    del rv\n')

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/IPython/core/interactiveshell.py:2565, in InteractiveShell.run_cell_magic(self, magic_name, line, cell)
   2563 with self.builtin_trap:
   2564     args = (magic_arg_s, cell)
-> 2565     result = fn(*args, **kwargs)
   2567 # The code below prevents the output from being displayed
   2568 # when using magics with decorator @output_can_be_silenced
   2569 # when the last Python token in the expression is a ';'.
   2570 if getattr(fn, magic.MAGIC_OUTPUT_CAN_BE_SILENCED, False):

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/IPython/core/magics/execution.py:1470, in ExecutionMagics.time(self, line, cell, local_ns)
   1468 if interrupt_occured:
   1469     if exit_on_interrupt and captured_exception:
-> 1470         raise captured_exception
   1471     return
   1472 return out

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/IPython/core/magics/execution.py:1434, in ExecutionMagics.time(self, line, cell, local_ns)
   1432 st = clock2()
   1433 try:
-> 1434     exec(code, glob, local_ns)
   1435     out = None
   1436     # multi-line %%time case

File <timed exec>:16

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/climakitae/explore/threshold_tools.py:862, in get_return_value(bms, return_period, distr, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound, multiple_points, extremes_type)
    827 def get_return_value(
    828     bms: xr.DataArray,
    829     return_period: float = 10,
   (...)    835     extremes_type: str = "max",
    836 ) -> xr.Dataset:
    837     """Creates xarray Dataset with return values and confidence intervals from maximum series.
    838 
    839     Parameters
   (...)    859         Dataset with return values and confidence intervals
    860     """
--> 862     return _get_return_variable(
    863         bms,
    864         "return_value",
    865         return_period,
    866         distr,
    867         bootstrap_runs,
    868         conf_int_lower_bound,
    869         conf_int_upper_bound,
    870         multiple_points,
    871         extremes_type,
    872     )

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/climakitae/explore/threshold_tools.py:774, in _get_return_variable(bms, data_variable, arg_value, distr, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound, multiple_points, extremes_type)
    757     conf_int_lower_limit, conf_int_upper_limit = _conf_int(
    758         bms=bms,
    759         distr=distr,
   (...)    766         extremes_type=extremes_type,
    767     )
    768     return (
    769         np.array([return_variable]),
    770         np.array([conf_int_lower_limit]),
    771         np.array([conf_int_upper_limit]),
    772     )
--> 774 return_variable, conf_int_lower_limit, conf_int_upper_limit = xr.apply_ufunc(
    775     _return_variable,
    776     bms,
    777     input_core_dims=[["time"]],
    778     exclude_dims=set(("time",)),
    779     vectorize=True,
    780     output_core_dims=[["one_in_x"], ["one_in_x"], ["one_in_x"]],
    781 )
    782 return_variable = return_variable.rename(data_variable)
    783 new_ds = return_variable.to_dataset()

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/xarray/computation/apply_ufunc.py:1267, in apply_ufunc(func, input_core_dims, output_core_dims, exclude_dims, vectorize, join, dataset_join, dataset_fill_value, keep_attrs, kwargs, dask, output_dtypes, output_sizes, meta, dask_gufunc_kwargs, on_missing_core_dim, *args)
   1265 # feed DataArray apply_variable_ufunc through apply_dataarray_vfunc
   1266 elif any(isinstance(a, DataArray) for a in args):
-> 1267     return apply_dataarray_vfunc(
   1268         variables_vfunc,
   1269         *args,
   1270         signature=signature,
   1271         join=join,
   1272         exclude_dims=exclude_dims,
   1273         keep_attrs=keep_attrs,
   1274     )
   1275 # feed Variables directly through apply_variable_ufunc
   1276 elif any(isinstance(a, Variable) for a in args):

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/xarray/computation/apply_ufunc.py:310, in apply_dataarray_vfunc(func, signature, join, exclude_dims, keep_attrs, *args)
    305 result_coords, result_indexes = build_output_coords_and_indexes(
    306     args, signature, exclude_dims, combine_attrs=keep_attrs
    307 )
    309 data_vars = [getattr(a, "variable", a) for a in args]
--> 310 result_var = func(*data_vars)
    312 out: tuple[DataArray, ...] | DataArray
    313 if signature.num_outputs > 1:

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/xarray/computation/apply_ufunc.py:818, in apply_variable_ufunc(func, signature, exclude_dims, dask, output_dtypes, vectorize, keep_attrs, dask_gufunc_kwargs, *args)
    813 elif vectorize:
    814     func = _vectorize(
    815         func, signature, output_dtypes=output_dtypes, exclude_dims=exclude_dims
    816     )
--> 818 result_data = func(*input_data)
    820 if signature.num_outputs == 1:
    821     result_data = (result_data,)

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/numpy/lib/_function_base_impl.py:2522, in vectorize.__call__(self, *args, **kwargs)
   2519     self._init_stage_2(*args, **kwargs)
   2520     return self
-> 2522 return self._call_as_normal(*args, **kwargs)

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/numpy/lib/_function_base_impl.py:2515, in vectorize._call_as_normal(self, *args, **kwargs)
   2512     vargs = [args[_i] for _i in inds]
   2513     vargs.extend([kwargs[_n] for _n in names])
-> 2515 return self._vectorize_call(func=func, args=vargs)

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/numpy/lib/_function_base_impl.py:2596, in vectorize._vectorize_call(self, func, args)
   2594 """Vectorized call to `func` over positional `args`."""
   2595 if self.signature is not None:
-> 2596     res = self._vectorize_call_with_signature(func, args)
   2597 elif not args:
   2598     res = func()

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/numpy/lib/_function_base_impl.py:2636, in vectorize._vectorize_call_with_signature(self, func, args)
   2633 nout = len(output_core_dims)
   2635 for index in np.ndindex(*broadcast_shape):
-> 2636     results = func(*(arg[index] for arg in args))
   2638     n_results = len(results) if isinstance(results, tuple) else 1
   2640     if nout != n_results:

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/climakitae/explore/threshold_tools.py:757, in _get_return_variable.<locals>._return_variable(bms)
    754 except (ValueError, ZeroDivisionError):
    755     return_variable = np.nan
--> 757 conf_int_lower_limit, conf_int_upper_limit = _conf_int(
    758     bms=bms,
    759     distr=distr,
    760     data_variable=data_variable,
    761     arg_value=arg_value,
    762     bootstrap_runs=bootstrap_runs,
    763     conf_int_lower_bound=conf_int_lower_bound,
    764     conf_int_upper_bound=conf_int_upper_bound,
    765     block_size=block_size,
    766     extremes_type=extremes_type,
    767 )
    768 return (
    769     np.array([return_variable]),
    770     np.array([conf_int_lower_limit]),
    771     np.array([conf_int_upper_limit]),
    772 )

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/climakitae/explore/threshold_tools.py:668, in _conf_int(bms, distr, data_variable, arg_value, bootstrap_runs, conf_int_lower_bound, conf_int_upper_bound, block_size, extremes_type)
    663     result = _bootstrap(
    664         bms, distr, data_variable, arg_value, block_size, extremes_type
    665     )
    666     bootstrap_values.append(result)
--> 668 bootstrap_values = np.stack(bootstrap_values, axis=0)
    670 conf_int_array = np.percentile(
    671     bootstrap_values, [conf_int_lower_bound, conf_int_upper_bound], axis=0
    672 )
    674 conf_int_lower_limit = conf_int_array[0]

File ~/miniforge3/envs/zarr-v2a/lib/python3.11/site-packages/numpy/_core/shape_base.py:460, in stack(arrays, axis, out, dtype, casting)
    458 shapes = {arr.shape for arr in arrays}
    459 if len(shapes) != 1:
--> 460     raise ValueError('all input arrays must have the same shape')
    462 result_ndim = arrays[0].ndim + 1
    463 axis = normalize_axis_index(axis, result_ndim)

ValueError: all input arrays must have the same shape
```

## How to test 
This code will throw the error mentioned above without this change. See if the return value is successfully returned. 
I've encountered this issue in IPSL-CM6A-LR, CESM2-LENS, and EC-Earth3-Veg. 
```
from climakitae.core.data_load import load
from climakitae.core.data_interface import get_data
from climakitae.util.utils import add_dummy_time_to_wl
from climakitae.explore.threshold_tools import (
    get_block_maxima,
    get_return_value,
)

gcm="IPSL-CM6A-LR"

# Resolution of data (needed to add buffer for data retrieval)
resolution = "3 km"

# Downscaling method
downscaling_method = "Statistical"

# Warming levels
warming_levels = [0.8]

latitude = (34.043810283875885, 34.868675663379655)
longitude = (-119.51593528897254, -118.01226034039915)

## Retrieving data and sanity check plotting
da1 = get_data(
    "Precipitation (total)",
    downscaling_method=downscaling_method,
    resolution=resolution,
    timescale="daily",
    units="inches",
    approach="Warming Level",
    warming_level=warming_levels,
    latitude=latitude,
    longitude=longitude,
)

da_filtered = da1.isel(simulation=da1.simulation.str.contains(gcm))
da_filtered = da_filtered.isel(simulation=0)
loaded_data = load(add_dummy_time_to_wl(da_filtered), progress_bar=False)

duration = 1
ams = get_block_maxima(
    loaded_data,
    check_ess=False,
)
rv = get_return_value(
    ams, return_period=10, multiple_points=False
)
```

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
