### PR TITLE
Tests for `new_core/processors/filter_unadjusted_models.py`

### DIFF
--- a/tests/new_core/processors/test_filter_unadjusted_models.py
+++ b/tests/new_core/processors/test_filter_unadjusted_models.py
@@ -13,7 +13,12 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from climakitae.core.constants import NON_WRF_BA_MODELS, UNSET, WRF_BA_MODELS
+from climakitae.core.constants import (
+    _NEW_ATTRS_KEY,
+    NON_WRF_BA_MODELS,
+    UNSET,
+    WRF_BA_MODELS,
+)
 from climakitae.new_core.processors.filter_unadjusted_models import (
     FilterUnAdjustedModels,
 )
@@ -41,14 +46,17 @@ class TestFilterUnAdjustedModelsInitialization:
 
     @pytest.mark.parametrize("invalid_value", ["y", "n", "maybe", "", "123"])
     def test_init_invalid_value(self, invalid_value):
-        """Test initialization with invalid values."""
+        """Test initialization and dummy execution with invalid values."""
         with pytest.raises(ValueError) as excinfo:
-            FilterUnAdjustedModels(value=invalid_value)
+            obj = FilterUnAdjustedModels(value=invalid_value)
+            result = xr.Dataset()
+            obj.execute(result, context={})
         assert "Invalid value" in str(excinfo.value)
+        assert "Valid values are:" in str(excinfo.value)
         assert any(valid in str(excinfo.value) for valid in ["yes", "no"])
 
 
-class TestFilterUnAdjustedModelsContainsUnadjustedModels:
+class TestFilterUnAdjustedModelsContainsUnAdjustedModels:
     """Test class for _contains_unadjusted_models method."""
 
     def setup_method(self):
@@ -230,7 +238,7 @@ class TestFilterUnAdjustedModelsContainsUnadjustedModels:
         assert "Unsupported type for result" in str(excinfo.value)
 
 
-class TestFilterUnAdjustedModelsRemoveUnadjustedModels:
+class TestFilterUnAdjustedModelsRemoveUnAdjustedModels:
     """Test class for _remove_unadjusted_models method."""
 
     def setup_method(self):
@@ -268,195 +276,45 @@ class TestFilterUnAdjustedModelsRemoveUnadjustedModels:
     def test_remove_unadjusted_models_single_dataset_adjusted(self):
         """Test _remove_unadjusted_models with a single adjusted Dataset."""
         result_yes = self.processor_yes._remove_unadjusted_models(self.ds_adjusted)
-        result_no = self.processor_no._remove_unadjusted_models(self.ds_adjusted)
         assert result_yes is self.ds_adjusted
-        assert result_no is self.ds_adjusted
 
     def test_remove_unadjusted_models_single_dataset_not_adjusted(self):
         """Test _remove_unadjusted_models with a single unadjusted Dataset."""
         result_yes = self.processor_yes._remove_unadjusted_models(self.ds_not_adjusted)
-        result_no = self.processor_no._remove_unadjusted_models(self.ds_not_adjusted)
         assert result_yes is None
-        assert result_no is self.ds_not_adjusted
 
     def test_remove_unadjusted_models_empty_dataset(self):
         """Test _remove_unadjusted_models with an empty Dataset."""
-        result_yes = self.processor_yes._remove_unadjusted_models(self.ds_empty)
-        result_no = self.processor_no._remove_unadjusted_models(self.ds_empty)
-        assert result_yes is self.ds_empty
-        assert result_no is self.ds_empty
+        result = self.processor_yes._remove_unadjusted_models(self.ds_empty)
+        assert result is self.ds_empty
 
     def test_remove_unadjusted_models_list_mixed(self):
         """Test _remove_unadjusted_models with a list of mixed Datasets."""
         result_yes = self.processor_yes._remove_unadjusted_models(
             [self.ds_adjusted, self.ds_not_adjusted]
         )
-        result_no = self.processor_no._remove_unadjusted_models(
-            [self.ds_adjusted, self.ds_not_adjusted]
-        )
         assert result_yes == [self.ds_adjusted]
-        assert result_no == [self.ds_adjusted, self.ds_not_adjusted]
 
     def test_remove_unadjusted_models_tuple_mixed(self):
         """Test _remove_unadjusted_models with a tuple of mixed Datasets."""
         result_yes = self.processor_yes._remove_unadjusted_models(
             (self.ds_not_adjusted, self.ds_adjusted)
         )
-        result_no = self.processor_no._remove_unadjusted_models(
-            (self.ds_not_adjusted, self.ds_adjusted)
-        )
-        assert result_yes == (self.ds_adjusted,)
-        assert result_no == (self.ds_not_adjusted, self.ds_adjusted)
+        assert result_yes == (self.ds_adjusted)
 
     def test_remove_unadjusted_models_list_all_not_adjusted(self):
         """Test _remove_unadjusted_models with a list of unadjusted Datasets."""
         result_yes = self.processor_yes._remove_unadjusted_models(
             [self.ds_not_adjusted, self.ds_not_adjusted]
         )
-        result_no = self.processor_no._remove_unadjusted_models(
-            [self.ds_not_adjusted, self.ds_not_adjusted]
-        )
-        assert result_yes is None
-        assert result_no == [self.ds_not_adjusted, self.ds_not_adjusted]
+        assert result_yes == []
 
     def test_remove_unadjusted_models_tuple_all_not_adjusted(self):
         """Test _remove_unadjusted_models with a tuple of unadjusted Datasets."""
         result_yes = self.processor_yes._remove_unadjusted_models(
             (self.ds_not_adjusted, self.ds_not_adjusted)
         )
-        result_no = self.processor_no._remove_unadjusted_models(
-            (self.ds_not_adjusted, self.ds_not_adjusted)
-        )
         assert result_yes is None
-        assert result_no == (self.ds_not_adjusted, self.ds_not_adjusted)
-
-    def test_remove_unadjusted_models_empty_list(self):
-        """Test _remove_unadjusted_models with an empty list."""
-        result_yes = self.processor_yes._remove_unadjusted_models([])
-        result_no = self.processor_no._remove_unadjusted_models([])
-        assert result_yes == []
-        assert result_no == []
-
-    def test_remove_unadjusted_models_empty_tuple(self):
-        """Test _remove_unadjusted_models with an empty tuple."""
-        result_yes = self.processor_yes._remove_unadjusted_models(())
-        result_no = self.processor_no._remove_unadjusted_models(())
-        assert result_yes == ()
-        assert result_no == ()
-
-    def test_remove_unadjusted_models_list_all_adjusted(self):
-        """Test _remove_unadjusted_models with a list of adjusted Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            [self.ds_adjusted, self.ds_adjusted]
-        )
-        result_no = self.processor_no._remove_unadjusted_models(
-            [self.ds_adjusted, self.ds_adjusted]
-        )
-        assert result_yes == [self.ds_adjusted, self.ds_adjusted]
-        assert result_no == [self.ds_adjusted, self.ds_adjusted]
-
-    def test_remove_unadjusted_models_tuple_all_adjusted(self):
-        """Test _remove_unadjusted_models with a tuple of adjusted Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            (self.ds_adjusted, self.ds_adjusted)
-        )
-        result_no = self.processor_no._remove_unadjusted_models(
-            (self.ds_adjusted, self.ds_adjusted)
-        )
-        assert result_yes == (self.ds_adjusted, self.ds_adjusted)
-        assert result_no == (self.ds_adjusted, self.ds_adjusted)
-
-    def test_remove_unadjusted_models_dict_mixed(self):
-        """Test _remove_unadjusted_models with a dictionary of mixed Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
-        )
-        result_no = self.processor_no._remove_unadjusted_models(
-            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
-        )
-        assert result_yes == {"data1": self.ds_adjusted}
-        assert result_no == {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
-
-    def test_remove_unadjusted_models_dict_all_not_adjusted(self):
-        """Test _remove_unadjusted_models with a dictionary of unadjusted Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            {"data1": self.ds_not_adjusted, "data2": self.ds_not_adjusted}
-        )
-        result_no = self.processor_no._remove_unadjusted_models(
-            {"data1": self.ds_not_adjusted, "data2": self.ds_not_adjusted}
-        )
-        assert result_yes == {}
-        assert result_no == {
-            "data1": self.ds_not_adjusted,
-            "data2": self.ds_not_adjusted,
-        }
-
-    def test_remove_unadjusted_models_empty_dict(self):
-        """Test _remove_unadjusted_models with an empty dictionary."""
-        result_yes = self.processor_yes._remove_unadjusted_models({})
-        result_no = self.processor_no._remove_unadjusted_models({})
-        assert result_yes == {}
-        assert result_no == {}
-
-    def test_remove_unadjusted_models_dict_mixed_multiple(self):
-        """Test _remove_unadjusted_models with a dictionary with mixed Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            {
-                "data1": self.ds_adjusted,
-                "data2": self.ds_adjusted,
-                "data3": self.ds_not_adjusted,
-            }
-        )
-        result_no = self.processor_no._remove_unadjusted_models(
-            {
-                "data1": self.ds_adjusted,
-                "data2": self.ds_adjusted,
-                "data3": self.ds_not_adjusted,
-            }
-        )
-        assert result_yes == {"data1": self.ds_adjusted, "data2": self.ds_adjusted}
-        assert result_no == {
-            "data1": self.ds_adjusted,
-            "data2": self.ds_adjusted,
-            "data3": self.ds_not_adjusted,
-        }
-
-    def test_remove_unadjusted_models_dict_all_adjusted(self):
-        """Test _remove_unadjusted_models with a dictionary of adjusted Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            {
-                "data1": self.ds_adjusted,
-                "data2": self.ds_adjusted,
-                "data3": self.ds_adjusted,
-            }
-        )
-        result_no = self.processor_no._remove_unadjusted_models(
-            {
-                "data1": self.ds_adjusted,
-                "data2": self.ds_adjusted,
-                "data3": self.ds_adjusted,
-            }
-        )
-        assert result_yes == {
-            "data1": self.ds_adjusted,
-            "data2": self.ds_adjusted,
-            "data3": self.ds_adjusted,
-        }
-        assert result_no == {
-            "data1": self.ds_adjusted,
-            "data2": self.ds_adjusted,
-            "data3": self.ds_adjusted,
-        }
-
-    def test_remove_unadjusted_models_invalid_type(self):
-        """Test _remove_unadjusted_models with an invalid type."""
-        with pytest.raises(TypeError) as excinfo:
-            self.processor_yes._remove_unadjusted_models(123)
-        assert "Unsupported type for result" in str(excinfo.value)
-
-        with pytest.raises(TypeError) as excinfo:
-            self.processor_no._remove_unadjusted_models(123)
-        assert "Unsupported type for result" in str(excinfo.value)
 
 
 class TestFilterUnAdjustedModelsUpdateContext:
@@ -464,17 +322,128 @@ class TestFilterUnAdjustedModelsUpdateContext:
 
     def setup_method(self):
         """Setup method to initialize common variables."""
-        self.processor_yes = FilterUnAdjustedModels(value="yes")
-        self.processor_no = FilterUnAdjustedModels(value="no")
+        self.processor = FilterUnAdjustedModels()
 
     def test_update_context_yes(self):
         """Test update_context when value is 'yes'."""
         context = {}
-        self.processor_yes.update_context(context)
-        assert context.get("filter_unadjusted_models") is True
+        self.processor.update_context(context)
+        assert f"Process '{self.processor.name}' applied to the data" in context[
+            _NEW_ATTRS_KEY
+        ].get("filter_unadjusted_models")
 
-    def test_update_context_no(self):
-        """Test update_context when value is 'no'."""
-        context = {}
-        self.processor_no.update_context(context)
-        assert context.get("filter_unadjusted_models") is False
+    def test_update_context_with_attrs_key_existing(self):
+        """Test update_context when _NEW_ATTRS_KEY already exists in context."""
+        context = {_NEW_ATTRS_KEY: {"existing_key": "existing_value"}}
+        self.processor.update_context(context)
+        assert "existing_key" in context[_NEW_ATTRS_KEY]
+        assert f"Process '{self.processor.name}' applied to the data" in context[
+            _NEW_ATTRS_KEY
+        ].get("filter_unadjusted_models")
+
+
+class TestFilterUnAdjustedModelsExecute:
+    """Test class for execute method."""
+
+    def setup_method(self):
+        """Setup method to initialize common variables."""
+        self.processor_yes = FilterUnAdjustedModels(value="yes")
+        self.processor_no = FilterUnAdjustedModels(value="no")
+
+        # Create sample xarray Datasets and DataArrays for testing
+        self.ds_empty = xr.Dataset()
+        self.ds_adjusted = xr.Dataset(
+            {"temp": (["time"], [1, 2, 3])},
+            coords={
+                "time": pd.date_range("2000-01-01", periods=3),
+                "simulation": ["model_a"],
+            },
+            attrs={
+                "intake_esm_attrs:activity_id": "WRF",
+                "intake_esm_attrs:source_id": "EC-Earth3",
+                "intake_esm_attrs:member_id": "r1i1p1f1",
+            },
+        )
+        self.ds_not_adjusted = xr.Dataset(
+            {"temp": (["time"], [4, 5, 6])},
+            coords={
+                "time": pd.date_range("2000-01-01", periods=3),
+                "simulation": ["model_b"],
+            },
+            attrs={
+                "intake_esm_attrs:activity_id": "WRF",
+                "intake_esm_attrs:source_id": "FGOALS-g3",
+                "intake_esm_attrs:member_id": "r1i1p1f1",
+            },
+        )
+
+    def test_execute_single_dataset_adjusted_yes(self):
+        """Test execute with a single adjusted Dataset and value 'yes'."""
+        result = self.processor_yes.execute(self.ds_adjusted, context={})
+        assert result is self.ds_adjusted
+
+    def test_execute_single_dataset_not_adjusted_yes(self):
+        """Test execute with a single unadjusted Dataset and value 'yes'."""
+        result = self.processor_yes.execute(self.ds_not_adjusted, context={})
+        assert result is None
+
+    def test_execute_single_dataset_adjusted_no(self):
+        """Test execute with a single adjusted Dataset and value 'no'."""
+        result = self.processor_no.execute(self.ds_adjusted, context={})
+        assert result is self.ds_adjusted
+
+    def test_execute_single_dataset_not_adjusted_no(self):
+        """Test execute with a single unadjusted Dataset and value 'no'."""
+        result = self.processor_no.execute(self.ds_not_adjusted, context={})
+        assert result is self.ds_not_adjusted
+
+    def test_execute_list_mixed_yes(self):
+        """Test execute with a list of mixed Datasets and value 'yes'."""
+        result = self.processor_yes.execute(
+            [self.ds_adjusted, self.ds_not_adjusted], context={}
+        )
+        assert result == [self.ds_adjusted]
+
+    def test_execute_list_mixed_no(self):
+        """Test execute with a list of mixed Datasets and value 'no'."""
+        result = self.processor_no.execute(
+            [self.ds_adjusted, self.ds_not_adjusted], context={}
+        )
+        assert result == [self.ds_adjusted, self.ds_not_adjusted]
+
+    def test_execute_tuple_mixed_yes(self):
+        """Test execute with a tuple of mixed Datasets and value 'yes'."""
+        result = self.processor_yes.execute(
+            (self.ds_not_adjusted, self.ds_adjusted), context={}
+        )
+        assert result == (self.ds_adjusted,)
+
+    def test_execute_tuple_mixed_no(self):
+        """Test execute with a tuple of mixed Datasets and value 'no'."""
+        result = self.processor_no.execute(
+            (self.ds_not_adjusted, self.ds_adjusted), context={}
+        )
+        assert result == (self.ds_not_adjusted, self.ds_adjusted)
+
+    def test_execute_empty_list_yes(self):
+        """Test execute with an empty list and value 'yes'."""
+        result = self.processor_yes.execute([], context={})
+        assert result == []
+
+    def test_execute_empty_list_no(self):
+        """Test execute with an empty list and value 'no'."""
+        result = self.processor_no.execute([], context={})
+        assert result == []
+
+    def test_execute_throws_warning_case_yes(self):
+        """Test execute raises warning when all models are unadjusted and value 'yes'."""
+        with pytest.warns(UserWarning) as record:
+            result = self.processor_yes.execute(
+                [self.ds_not_adjusted, self.ds_not_adjusted], context={}
+            )
+            assert result == []
+        assert any(
+            "Your query selected models that do not have a-priori bias adjustment."
+            in str(warning.message)
+            for warning in record
+        )

--- a/tests/new_core/processors/test_filter_unadjusted_models.py
+++ b/tests/new_core/processors/test_filter_unadjusted_models.py
@@ -1,0 +1,480 @@
+"""
+Units tests for `filter_unadjusted_models` processor.
+
+This module contains comprehensive unit tests for the `FilterUnadjustedModels` processor class
+that filters out unadjusted climate models from datasets. The tests cover various scenarios,
+including different input types (xarray Dataset, DataArray, lists, tuples, dictionaries),
+and edge cases such as all models being unadjusted or none being unadjusted.
+"""
+
+from typing import Iterable, Union
+
+import pandas as pd
+import pytest
+import xarray as xr
+
+from climakitae.core.constants import NON_WRF_BA_MODELS, UNSET, WRF_BA_MODELS
+from climakitae.new_core.processors.filter_unadjusted_models import (
+    FilterUnAdjustedModels,
+)
+
+
+class TestFilterUnAdjustedModelsInitialization:
+    """Test class for FilterUnAdjustedModels processor."""
+
+    def setup_method(self):
+        """Set up text fixtures."""
+        pass
+
+    def test_init_default_params(self):
+        """Setup method to initialize common variables."""
+        processor = FilterUnAdjustedModels()
+        assert processor.value == "yes"
+        assert processor.name == "filter_unadjusted_models"
+        assert processor.valid_values == ["yes", "no"]
+
+    @pytest.mark.parametrize("value", ["yes", "no", "YES", "No", "YeS"])
+    def test_init_custom_value(self, value):
+        """Test initialization with custom valid values to test capitalization validation."""
+        processor = FilterUnAdjustedModels(value=value)
+        assert processor.value == value.lower()
+
+    @pytest.mark.parametrize("invalid_value", ["y", "n", "maybe", "", "123"])
+    def test_init_invalid_value(self, invalid_value):
+        """Test initialization with invalid values."""
+        with pytest.raises(ValueError) as excinfo:
+            FilterUnAdjustedModels(value=invalid_value)
+        assert "Invalid value" in str(excinfo.value)
+        assert any(valid in str(excinfo.value) for valid in ["yes", "no"])
+
+
+class TestFilterUnAdjustedModelsContainsUnadjustedModels:
+    """Test class for _contains_unadjusted_models method."""
+
+    def setup_method(self):
+        """Setup method to initialize common variables."""
+        self.processor_yes = FilterUnAdjustedModels(value="yes")
+        self.processor_no = FilterUnAdjustedModels(value="no")
+
+        # Create sample xarray Datasets and DataArrays for testing
+        self.ds_empty = xr.Dataset()
+        self.ds_adjusted = xr.Dataset(
+            {"temp": (["time"], [1, 2, 3])},
+            coords={
+                "time": pd.date_range("2000-01-01", periods=3),
+                "simulation": ["model_a"],
+            },
+            attrs={
+                "intake_esm_attrs:activity_id": "WRF",
+                "intake_esm_attrs:source_id": "EC-Earth3",
+                "intake_esm_attrs:member_id": "r1i1p1f1",
+            },
+        )
+        self.ds_not_adjusted = xr.Dataset(
+            {"temp": (["time"], [4, 5, 6])},
+            coords={
+                "time": pd.date_range("2000-01-01", periods=3),
+                "simulation": ["model_b"],
+            },
+            attrs={
+                "intake_esm_attrs:activity_id": "WRF",
+                "intake_esm_attrs:source_id": "FGOALS-g3",
+                "intake_esm_attrs:member_id": "r1i1p1f1",
+            },
+        )
+
+    def test_contains_unadjusted_models_single_dataset_adjusted(self):
+        """Test _contains_unadjusted_models with a single adjusted Dataset."""
+        assert not self.processor_yes._contains_unadjusted_models(self.ds_adjusted)
+        assert not self.processor_no._contains_unadjusted_models(self.ds_adjusted)
+
+    def test_contains_unadjusted_models_single_dataset_not_adjusted(self):
+        """Test _contains_unadjusted_models with a single unadjusted Dataset."""
+        assert self.processor_yes._contains_unadjusted_models(self.ds_not_adjusted)
+        assert self.processor_no._contains_unadjusted_models(self.ds_not_adjusted)
+
+    def test_contains_unadjusted_models_empty_dataset(self):
+        """Test _contains_unadjusted_models with an empty Dataset."""
+        assert not self.processor_yes._contains_unadjusted_models(self.ds_empty)
+        assert not self.processor_no._contains_unadjusted_models(self.ds_empty)
+
+    def test_contains_unadjusted_models_list_mixed(self):
+        """Test _contains_unadjusted_models with a list of mixed Datasets."""
+        assert self.processor_yes._contains_unadjusted_models(
+            [self.ds_adjusted, self.ds_not_adjusted]
+        )
+        assert self.processor_no._contains_unadjusted_models(
+            [self.ds_adjusted, self.ds_not_adjusted]
+        )
+
+    def test_contains_unadjusted_models_tuple_mixed(self):
+        """Test _contains_unadjusted_models with a tuple of mixed Datasets."""
+        assert self.processor_yes._contains_unadjusted_models(
+            (self.ds_not_adjusted, self.ds_adjusted)
+        )
+        assert self.processor_no._contains_unadjusted_models(
+            (self.ds_not_adjusted, self.ds_adjusted)
+        )
+
+    def test_contains_unadjusted_models_list_all_not_adjusted(self):
+        """Test _contains_unadjusted_models with a list of unadjusted Datasets."""
+        assert self.processor_yes._contains_unadjusted_models(
+            [self.ds_not_adjusted, self.ds_not_adjusted]
+        )
+        assert self.processor_no._contains_unadjusted_models(
+            [self.ds_not_adjusted, self.ds_not_adjusted]
+        )
+
+    def test_contains_unadjusted_models_tuple_all_not_adjusted(self):
+        """Test _contains_unadjusted_models with a tuple of unadjusted Datasets."""
+        assert self.processor_yes._contains_unadjusted_models(
+            (self.ds_not_adjusted, self.ds_not_adjusted)
+        )
+        assert self.processor_no._contains_unadjusted_models(
+            (self.ds_not_adjusted, self.ds_not_adjusted)
+        )
+
+    def test_contains_unadjusted_models_empty_list(self):
+        """Test _contains_unadjusted_models with an empty list."""
+        assert not self.processor_yes._contains_unadjusted_models([])
+        assert not self.processor_no._contains_unadjusted_models([])
+
+    def test_contains_unadjusted_models_empty_tuple(self):
+        """Test _contains_unadjusted_models with an empty tuple."""
+        assert not self.processor_yes._contains_unadjusted_models(())
+        assert not self.processor_no._contains_unadjusted_models(())
+
+    def test_contains_unadjusted_models_list_all_adjusted(self):
+        """Test _contains_unadjusted_models with a list of adjusted Datasets."""
+        assert not self.processor_yes._contains_unadjusted_models(
+            [self.ds_adjusted, self.ds_adjusted]
+        )
+        assert not self.processor_no._contains_unadjusted_models(
+            [self.ds_adjusted, self.ds_adjusted]
+        )
+
+    def test_contains_unadjusted_models_tuple_all_adjusted(self):
+        """Test _contains_unadjusted_models with a tuple of adjusted Datasets."""
+        assert not self.processor_yes._contains_unadjusted_models(
+            (self.ds_adjusted, self.ds_adjusted)
+        )
+        assert not self.processor_no._contains_unadjusted_models(
+            (self.ds_adjusted, self.ds_adjusted)
+        )
+
+    def test_contains_unadjusted_models_dict_mixed(self):
+        """Test _contains_unadjusted_models with a dictionary of mixed Datasets."""
+        assert self.processor_yes._contains_unadjusted_models(
+            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
+        )
+        assert self.processor_no._contains_unadjusted_models(
+            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
+        )
+
+    def test_contains_unadjusted_models_dict_all_not_adjusted(self):
+        """Test _contains_unadjusted_models with a dictionary of unadjusted Datasets."""
+        assert self.processor_yes._contains_unadjusted_models(
+            {"data1": self.ds_not_adjusted, "data2": self.ds_not_adjusted}
+        )
+        assert self.processor_no._contains_unadjusted_models(
+            {"data1": self.ds_not_adjusted, "data2": self.ds_not_adjusted}
+        )
+
+    def test_contains_unadjusted_models_empty_dict(self):
+        """Test _contains_unadjusted_models with an empty dictionary."""
+        assert not self.processor_yes._contains_unadjusted_models({})
+        assert not self.processor_no._contains_unadjusted_models({})
+
+    def test_contains_unadjusted_models_dict_mixed_multiple(self):
+        """Test _contains_unadjusted_models with a dictionary with mixed Datasets."""
+        assert self.processor_yes._contains_unadjusted_models(
+            {
+                "data1": self.ds_adjusted,
+                "data2": self.ds_adjusted,
+                "data3": self.ds_not_adjusted,
+            }
+        )
+        assert self.processor_no._contains_unadjusted_models(
+            {
+                "data1": self.ds_adjusted,
+                "data2": self.ds_adjusted,
+                "data3": self.ds_not_adjusted,
+            }
+        )
+
+    def test_contains_unadjusted_models_dict_all_adjusted(self):
+        """Test _contains_unadjusted_models with a dictionary of adjusted Datasets."""
+        assert not self.processor_yes._contains_unadjusted_models(
+            {
+                "data1": self.ds_adjusted,
+                "data2": self.ds_adjusted,
+                "data3": self.ds_adjusted,
+            }
+        )
+        assert not self.processor_no._contains_unadjusted_models(
+            {
+                "data1": self.ds_adjusted,
+                "data2": self.ds_adjusted,
+                "data3": self.ds_adjusted,
+            }
+        )
+
+    def test_contains_unadjusted_models_invalid_type(self):
+        """Test _contains_unadjusted_models with an invalid type."""
+        with pytest.raises(TypeError) as excinfo:
+            self.processor_yes._contains_unadjusted_models(123)
+        assert "Unsupported type for result" in str(excinfo.value)
+
+        with pytest.raises(TypeError) as excinfo:
+            self.processor_no._contains_unadjusted_models(123)
+        assert "Unsupported type for result" in str(excinfo.value)
+
+
+class TestFilterUnAdjustedModelsRemoveUnadjustedModels:
+    """Test class for _remove_unadjusted_models method."""
+
+    def setup_method(self):
+        """Setup method to initialize common variables."""
+        self.processor_yes = FilterUnAdjustedModels(value="yes")
+        self.processor_no = FilterUnAdjustedModels(value="no")
+
+        # Create sample xarray Datasets and DataArrays for testing
+        self.ds_empty = xr.Dataset()
+        self.ds_adjusted = xr.Dataset(
+            {"temp": (["time"], [1, 2, 3])},
+            coords={
+                "time": pd.date_range("2000-01-01", periods=3),
+                "simulation": ["model_a"],
+            },
+            attrs={
+                "intake_esm_attrs:activity_id": "WRF",
+                "intake_esm_attrs:source_id": "EC-Earth3",
+                "intake_esm_attrs:member_id": "r1i1p1f1",
+            },
+        )
+        self.ds_not_adjusted = xr.Dataset(
+            {"temp": (["time"], [4, 5, 6])},
+            coords={
+                "time": pd.date_range("2000-01-01", periods=3),
+                "simulation": ["model_b"],
+            },
+            attrs={
+                "intake_esm_attrs:activity_id": "WRF",
+                "intake_esm_attrs:source_id": "FGOALS-g3",
+                "intake_esm_attrs:member_id": "r1i1p1f1",
+            },
+        )
+
+    def test_remove_unadjusted_models_single_dataset_adjusted(self):
+        """Test _remove_unadjusted_models with a single adjusted Dataset."""
+        result_yes = self.processor_yes._remove_unadjusted_models(self.ds_adjusted)
+        result_no = self.processor_no._remove_unadjusted_models(self.ds_adjusted)
+        assert result_yes is self.ds_adjusted
+        assert result_no is self.ds_adjusted
+
+    def test_remove_unadjusted_models_single_dataset_not_adjusted(self):
+        """Test _remove_unadjusted_models with a single unadjusted Dataset."""
+        result_yes = self.processor_yes._remove_unadjusted_models(self.ds_not_adjusted)
+        result_no = self.processor_no._remove_unadjusted_models(self.ds_not_adjusted)
+        assert result_yes is None
+        assert result_no is self.ds_not_adjusted
+
+    def test_remove_unadjusted_models_empty_dataset(self):
+        """Test _remove_unadjusted_models with an empty Dataset."""
+        result_yes = self.processor_yes._remove_unadjusted_models(self.ds_empty)
+        result_no = self.processor_no._remove_unadjusted_models(self.ds_empty)
+        assert result_yes is self.ds_empty
+        assert result_no is self.ds_empty
+
+    def test_remove_unadjusted_models_list_mixed(self):
+        """Test _remove_unadjusted_models with a list of mixed Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            [self.ds_adjusted, self.ds_not_adjusted]
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            [self.ds_adjusted, self.ds_not_adjusted]
+        )
+        assert result_yes == [self.ds_adjusted]
+        assert result_no == [self.ds_adjusted, self.ds_not_adjusted]
+
+    def test_remove_unadjusted_models_tuple_mixed(self):
+        """Test _remove_unadjusted_models with a tuple of mixed Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            (self.ds_not_adjusted, self.ds_adjusted)
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            (self.ds_not_adjusted, self.ds_adjusted)
+        )
+        assert result_yes == (self.ds_adjusted,)
+        assert result_no == (self.ds_not_adjusted, self.ds_adjusted)
+
+    def test_remove_unadjusted_models_list_all_not_adjusted(self):
+        """Test _remove_unadjusted_models with a list of unadjusted Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            [self.ds_not_adjusted, self.ds_not_adjusted]
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            [self.ds_not_adjusted, self.ds_not_adjusted]
+        )
+        assert result_yes is None
+        assert result_no == [self.ds_not_adjusted, self.ds_not_adjusted]
+
+    def test_remove_unadjusted_models_tuple_all_not_adjusted(self):
+        """Test _remove_unadjusted_models with a tuple of unadjusted Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            (self.ds_not_adjusted, self.ds_not_adjusted)
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            (self.ds_not_adjusted, self.ds_not_adjusted)
+        )
+        assert result_yes is None
+        assert result_no == (self.ds_not_adjusted, self.ds_not_adjusted)
+
+    def test_remove_unadjusted_models_empty_list(self):
+        """Test _remove_unadjusted_models with an empty list."""
+        result_yes = self.processor_yes._remove_unadjusted_models([])
+        result_no = self.processor_no._remove_unadjusted_models([])
+        assert result_yes == []
+        assert result_no == []
+
+    def test_remove_unadjusted_models_empty_tuple(self):
+        """Test _remove_unadjusted_models with an empty tuple."""
+        result_yes = self.processor_yes._remove_unadjusted_models(())
+        result_no = self.processor_no._remove_unadjusted_models(())
+        assert result_yes == ()
+        assert result_no == ()
+
+    def test_remove_unadjusted_models_list_all_adjusted(self):
+        """Test _remove_unadjusted_models with a list of adjusted Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            [self.ds_adjusted, self.ds_adjusted]
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            [self.ds_adjusted, self.ds_adjusted]
+        )
+        assert result_yes == [self.ds_adjusted, self.ds_adjusted]
+        assert result_no == [self.ds_adjusted, self.ds_adjusted]
+
+    def test_remove_unadjusted_models_tuple_all_adjusted(self):
+        """Test _remove_unadjusted_models with a tuple of adjusted Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            (self.ds_adjusted, self.ds_adjusted)
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            (self.ds_adjusted, self.ds_adjusted)
+        )
+        assert result_yes == (self.ds_adjusted, self.ds_adjusted)
+        assert result_no == (self.ds_adjusted, self.ds_adjusted)
+
+    def test_remove_unadjusted_models_dict_mixed(self):
+        """Test _remove_unadjusted_models with a dictionary of mixed Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
+        )
+        assert result_yes == {"data1": self.ds_adjusted}
+        assert result_no == {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
+
+    def test_remove_unadjusted_models_dict_all_not_adjusted(self):
+        """Test _remove_unadjusted_models with a dictionary of unadjusted Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            {"data1": self.ds_not_adjusted, "data2": self.ds_not_adjusted}
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            {"data1": self.ds_not_adjusted, "data2": self.ds_not_adjusted}
+        )
+        assert result_yes == {}
+        assert result_no == {
+            "data1": self.ds_not_adjusted,
+            "data2": self.ds_not_adjusted,
+        }
+
+    def test_remove_unadjusted_models_empty_dict(self):
+        """Test _remove_unadjusted_models with an empty dictionary."""
+        result_yes = self.processor_yes._remove_unadjusted_models({})
+        result_no = self.processor_no._remove_unadjusted_models({})
+        assert result_yes == {}
+        assert result_no == {}
+
+    def test_remove_unadjusted_models_dict_mixed_multiple(self):
+        """Test _remove_unadjusted_models with a dictionary with mixed Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            {
+                "data1": self.ds_adjusted,
+                "data2": self.ds_adjusted,
+                "data3": self.ds_not_adjusted,
+            }
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            {
+                "data1": self.ds_adjusted,
+                "data2": self.ds_adjusted,
+                "data3": self.ds_not_adjusted,
+            }
+        )
+        assert result_yes == {"data1": self.ds_adjusted, "data2": self.ds_adjusted}
+        assert result_no == {
+            "data1": self.ds_adjusted,
+            "data2": self.ds_adjusted,
+            "data3": self.ds_not_adjusted,
+        }
+
+    def test_remove_unadjusted_models_dict_all_adjusted(self):
+        """Test _remove_unadjusted_models with a dictionary of adjusted Datasets."""
+        result_yes = self.processor_yes._remove_unadjusted_models(
+            {
+                "data1": self.ds_adjusted,
+                "data2": self.ds_adjusted,
+                "data3": self.ds_adjusted,
+            }
+        )
+        result_no = self.processor_no._remove_unadjusted_models(
+            {
+                "data1": self.ds_adjusted,
+                "data2": self.ds_adjusted,
+                "data3": self.ds_adjusted,
+            }
+        )
+        assert result_yes == {
+            "data1": self.ds_adjusted,
+            "data2": self.ds_adjusted,
+            "data3": self.ds_adjusted,
+        }
+        assert result_no == {
+            "data1": self.ds_adjusted,
+            "data2": self.ds_adjusted,
+            "data3": self.ds_adjusted,
+        }
+
+    def test_remove_unadjusted_models_invalid_type(self):
+        """Test _remove_unadjusted_models with an invalid type."""
+        with pytest.raises(TypeError) as excinfo:
+            self.processor_yes._remove_unadjusted_models(123)
+        assert "Unsupported type for result" in str(excinfo.value)
+
+        with pytest.raises(TypeError) as excinfo:
+            self.processor_no._remove_unadjusted_models(123)
+        assert "Unsupported type for result" in str(excinfo.value)
+
+
+class TestFilterUnAdjustedModelsUpdateContext:
+    """Test class for update_context method."""
+
+    def setup_method(self):
+        """Setup method to initialize common variables."""
+        self.processor_yes = FilterUnAdjustedModels(value="yes")
+        self.processor_no = FilterUnAdjustedModels(value="no")
+
+    def test_update_context_yes(self):
+        """Test update_context when value is 'yes'."""
+        context = {}
+        self.processor_yes.update_context(context)
+        assert context.get("filter_unadjusted_models") is True
+
+    def test_update_context_no(self):
+        """Test update_context when value is 'no'."""
+        context = {}
+        self.processor_no.update_context(context)
+        assert context.get("filter_unadjusted_models") is False

--- a/tests/new_core/processors/test_filter_unadjusted_models.py
+++ b/tests/new_core/processors/test_filter_unadjusted_models.py
@@ -1,52 +1,142 @@
 """
-Units tests for `filter_unadjusted_models` processor.
+Unit tests for the `filter_unadjusted_models` processor.
 
 This module contains comprehensive unit tests for the `FilterUnadjustedModels` processor class
 that filters out unadjusted climate models from datasets. The tests cover various scenarios,
 including different input types (xarray Dataset, DataArray, lists, tuples, dictionaries),
-and edge cases such as all models being unadjusted or none being unadjusted.
+and edge cases such as empty datasets, datasets with only adjusted or unadjusted models, and
+datasets with a mixed set of adjusted and unadjusted models.
 """
 
-from typing import Iterable, Union
+from typing import Union
 
 import pandas as pd
 import pytest
 import xarray as xr
 
-from climakitae.core.constants import (
-    _NEW_ATTRS_KEY,
-    NON_WRF_BA_MODELS,
-    UNSET,
-    WRF_BA_MODELS,
-)
+from climakitae.core.constants import _NEW_ATTRS_KEY
 from climakitae.new_core.processors.filter_unadjusted_models import (
     FilterUnAdjustedModels,
 )
 
 
+@pytest.fixture
+def da_empty() -> xr.DataArray:
+    """Fixture for an empty xarray DataArray."""
+    return xr.DataArray([], dims=["time"], coords={"time": []})
+
+
+@pytest.fixture
+def ds_empty() -> xr.Dataset:
+    """Fixture for an empty xarray Dataset."""
+    return xr.Dataset()
+
+
+@pytest.fixture
+def da_adjusted() -> xr.DataArray:
+    """Fixture for an adjusted xarray DataArray."""
+    return xr.DataArray(
+        [1, 2, 3],
+        dims=["time"],
+        coords={
+            "time": pd.date_range("2000-01-01", periods=3),
+        },
+        attrs={
+            "intake_esm_attrs:activity_id": "WRF",
+            "intake_esm_attrs:source_id": "EC-Earth3",
+            "intake_esm_attrs:member_id": "r1i1p1f1",
+        },
+    )
+
+
+@pytest.fixture
+def ds_adjusted() -> xr.Dataset:
+    """Fixture for an adjusted xarray Dataset."""
+    return xr.Dataset(
+        {"temp": (["time"], [1, 2, 3])},
+        coords={
+            "time": pd.date_range("2000-01-01", periods=3),
+            "simulation": ["model_a"],
+        },
+        attrs={
+            "intake_esm_attrs:activity_id": "WRF",
+            "intake_esm_attrs:source_id": "EC-Earth3",
+            "intake_esm_attrs:member_id": "r1i1p1f1",
+        },
+    )
+
+
+@pytest.fixture
+def da_not_adjusted() -> xr.DataArray:
+    """Fixture for an unadjusted xarray DataArray."""
+    return xr.DataArray(
+        [4, 5, 6],
+        dims=["time"],
+        coords={
+            "time": pd.date_range("2000-01-01", periods=3),
+        },
+        attrs={
+            "intake_esm_attrs:activity_id": "WRF",
+            "intake_esm_attrs:source_id": "FGOALS-g3",
+            "intake_esm_attrs:member_id": "r1i1p1f1",
+        },
+    )
+
+
+@pytest.fixture
+def ds_not_adjusted() -> xr.Dataset:
+    """Fixture for an unadjusted xarray Dataset."""
+    return xr.Dataset(
+        {"temp": (["time"], [4, 5, 6])},
+        coords={
+            "time": pd.date_range("2000-01-01", periods=3),
+            "simulation": ["model_b"],
+        },
+        attrs={
+            "intake_esm_attrs:activity_id": "WRF",
+            "intake_esm_attrs:source_id": "FGOALS-g3",
+            "intake_esm_attrs:member_id": "r1i1p1f1",
+        },
+    )
+
+
+@pytest.fixture
+def processor_yes() -> FilterUnAdjustedModels:
+    """Fixture for FilterUnAdjustedModels processor with value 'yes'."""
+    return FilterUnAdjustedModels(value="yes")
+
+
+@pytest.fixture
+def processor_no() -> FilterUnAdjustedModels:
+    """Fixture for FilterUnAdjustedModels processor with value 'no'."""
+    return FilterUnAdjustedModels(value="no")
+
+
+@pytest.fixture
+def empty_processor() -> FilterUnAdjustedModels:
+    """Fixture for FilterUnAdjustedModels processor with default value."""
+    return FilterUnAdjustedModels()
+
+
 class TestFilterUnAdjustedModelsInitialization:
-    """Test class for FilterUnAdjustedModels processor."""
+    """Tests for FilterUnAdjustedModels initialization."""
 
-    def setup_method(self):
-        """Set up text fixtures."""
-        pass
-
-    def test_init_default_params(self):
-        """Setup method to initialize common variables."""
+    def test_init_default_params(self) -> None:
+        """Test default initialization."""
         processor = FilterUnAdjustedModels()
         assert processor.value == "yes"
         assert processor.name == "filter_unadjusted_models"
         assert processor.valid_values == ["yes", "no"]
 
     @pytest.mark.parametrize("value", ["yes", "no", "YES", "No", "YeS"])
-    def test_init_custom_value(self, value):
-        """Test initialization with custom valid values to test capitalization validation."""
+    def test_init_custom_value(self, value: str) -> None:
+        """Test initialization with custom valid values."""
         processor = FilterUnAdjustedModels(value=value)
         assert processor.value == value.lower()
 
     @pytest.mark.parametrize("invalid_value", ["y", "n", "maybe", "", "123"])
-    def test_init_invalid_value(self, invalid_value):
-        """Test initialization and dummy execution with invalid values."""
+    def test_init_invalid_value(self, invalid_value: str) -> None:
+        """Test initialization with invalid values."""
         with pytest.raises(ValueError) as excinfo:
             obj = FilterUnAdjustedModels(value=invalid_value)
             result = xr.Dataset()
@@ -55,7 +145,7 @@ class TestFilterUnAdjustedModelsInitialization:
         assert "Valid values are:" in str(excinfo.value)
         assert any(valid in str(excinfo.value) for valid in ["yes", "no"])
 
-    def test_set_data_accessor(self):
+    def test_set_data_accessor(self) -> None:
         """Test set_data_accessor method."""
         processor = FilterUnAdjustedModels()
         processor.set_data_accessor(catalog=None)
@@ -65,365 +155,301 @@ class TestFilterUnAdjustedModelsInitialization:
 class TestFilterUnAdjustedModelsContainsUnAdjustedModels:
     """Test class for _contains_unadjusted_models method."""
 
-    def setup_method(self):
-        """Setup method to initialize common variables."""
-        self.processor_yes = FilterUnAdjustedModels(value="yes")
-        self.processor_no = FilterUnAdjustedModels(value="no")
+    @pytest.mark.parametrize("empty_iterable", [[], (), {}])
+    def test_contains_unadjusted_models_empty_iterable(
+        self,
+        empty_iterable: Union[list, tuple, dict],
+        processor_yes: FilterUnAdjustedModels,
+        processor_no: FilterUnAdjustedModels,
+    ) -> None:
+        """
+        Test _contains_unadjusted_models with an empty iterable.
+        """
+        assert not processor_yes._contains_unadjusted_models(empty_iterable)
+        assert not processor_no._contains_unadjusted_models(empty_iterable)
 
-        # Create sample xarray Datasets and DataArrays for testing
-        self.ds_empty = xr.Dataset()
-        self.ds_adjusted = xr.Dataset(
-            {"temp": (["time"], [1, 2, 3])},
-            coords={
-                "time": pd.date_range("2000-01-01", periods=3),
-                "simulation": ["model_a"],
-            },
-            attrs={
-                "intake_esm_attrs:activity_id": "WRF",
-                "intake_esm_attrs:source_id": "EC-Earth3",
-                "intake_esm_attrs:member_id": "r1i1p1f1",
-            },
-        )
-        self.ds_not_adjusted = xr.Dataset(
-            {"temp": (["time"], [4, 5, 6])},
-            coords={
-                "time": pd.date_range("2000-01-01", periods=3),
-                "simulation": ["model_b"],
-            },
-            attrs={
-                "intake_esm_attrs:activity_id": "WRF",
-                "intake_esm_attrs:source_id": "FGOALS-g3",
-                "intake_esm_attrs:member_id": "r1i1p1f1",
-            },
-        )
+    @pytest.mark.parametrize("container_type", [list, tuple, dict])
+    def test_contains_unadjusted_models_all_adjusted(
+        self,
+        container_type: type,
+        processor_yes: FilterUnAdjustedModels,
+        processor_no: FilterUnAdjustedModels,
+        ds_adjusted: xr.Dataset,
+    ) -> None:
+        """
+        Test _contains_unadjusted_models with only adjusted datasets.
+        """
+        if container_type is dict:
+            input_data = {1: ds_adjusted, 2: ds_adjusted}
+        else:
+            input_data = container_type([ds_adjusted, ds_adjusted])
+        assert not processor_yes._contains_unadjusted_models(input_data)
+        assert not processor_no._contains_unadjusted_models(input_data)
 
-    def test_contains_unadjusted_models_single_dataset_adjusted(self):
-        """Test _contains_unadjusted_models with a single adjusted Dataset."""
-        assert not self.processor_yes._contains_unadjusted_models(self.ds_adjusted)
-        assert not self.processor_no._contains_unadjusted_models(self.ds_adjusted)
+    @pytest.mark.parametrize("container_type", [list, tuple, dict])
+    def test_contains_unadjusted_models_all_unadjusted(
+        self,
+        container_type: type,
+        processor_yes: FilterUnAdjustedModels,
+        processor_no: FilterUnAdjustedModels,
+        ds_not_adjusted: xr.Dataset,
+    ) -> None:
+        """
+        Test _contains_unadjusted_models with only unadjusted datasets.
+        """
+        if container_type is dict:
+            input_data = {1: ds_not_adjusted, 2: ds_not_adjusted}
+        else:
+            input_data = container_type([ds_not_adjusted, ds_not_adjusted])
+        assert processor_yes._contains_unadjusted_models(input_data)
+        assert processor_no._contains_unadjusted_models(input_data)
 
-    def test_contains_unadjusted_models_single_dataset_not_adjusted(self):
-        """Test _contains_unadjusted_models with a single unadjusted Dataset."""
-        assert self.processor_yes._contains_unadjusted_models(self.ds_not_adjusted)
-        assert self.processor_no._contains_unadjusted_models(self.ds_not_adjusted)
+    @pytest.mark.parametrize("container_type", [list, tuple, dict])
+    def test_contains_unadjusted_models_mixed(
+        self,
+        container_type: type,
+        processor_yes: FilterUnAdjustedModels,
+        processor_no: FilterUnAdjustedModels,
+        ds_adjusted: xr.Dataset,
+        ds_not_adjusted: xr.Dataset,
+    ) -> None:
+        """
+        Test _contains_unadjusted_models with a mix of adjusted and unadjusted datasets.
+        """
+        if container_type is dict:
+            input_data = {1: ds_not_adjusted, 2: ds_adjusted}
+        else:
+            input_data = container_type([ds_not_adjusted, ds_adjusted])
+        assert processor_yes._contains_unadjusted_models(input_data)
+        assert processor_no._contains_unadjusted_models(input_data)
 
-    def test_contains_unadjusted_models_empty_dataset(self):
-        """Test _contains_unadjusted_models with an empty Dataset."""
-        assert not self.processor_yes._contains_unadjusted_models(self.ds_empty)
-        assert not self.processor_no._contains_unadjusted_models(self.ds_empty)
+    @pytest.mark.parametrize("xr_obj_name", ["da_empty", "ds_empty"])
+    def test_contains_unadjusted_models_empty_xr(
+        self,
+        xr_obj_name: str,
+        request: pytest.FixtureRequest,
+        processor_yes: FilterUnAdjustedModels,
+        processor_no: FilterUnAdjustedModels,
+    ) -> None:
+        """
+        Test _contains_unadjusted_models with an empty xarray object.
+        """
+        xr_obj = request.getfixturevalue(xr_obj_name)
+        assert not processor_yes._contains_unadjusted_models(xr_obj)
+        assert not processor_no._contains_unadjusted_models(xr_obj)
 
-    def test_contains_unadjusted_models_list_mixed(self):
-        """Test _contains_unadjusted_models with a list of mixed Datasets."""
-        assert self.processor_yes._contains_unadjusted_models(
-            [self.ds_adjusted, self.ds_not_adjusted]
-        )
-        assert self.processor_no._contains_unadjusted_models(
-            [self.ds_adjusted, self.ds_not_adjusted]
-        )
+    @pytest.mark.parametrize("xr_obj_name", ["da_adjusted", "ds_adjusted"])
+    def test_contains_unadjusted_models_all_adjusted_xr(
+        self,
+        xr_obj_name: str,
+        request: pytest.FixtureRequest,
+        processor_yes: FilterUnAdjustedModels,
+        processor_no: FilterUnAdjustedModels,
+    ) -> None:
+        """
+        Test _contains_unadjusted_models with an xarray object with an adjusted model.
+        """
+        xr_obj = request.getfixturevalue(xr_obj_name)
+        assert not processor_yes._contains_unadjusted_models(xr_obj)
+        assert not processor_no._contains_unadjusted_models(xr_obj)
 
-    def test_contains_unadjusted_models_tuple_mixed(self):
-        """Test _contains_unadjusted_models with a tuple of mixed Datasets."""
-        assert self.processor_yes._contains_unadjusted_models(
-            (self.ds_not_adjusted, self.ds_adjusted)
-        )
-        assert self.processor_no._contains_unadjusted_models(
-            (self.ds_not_adjusted, self.ds_adjusted)
-        )
+    @pytest.mark.parametrize("xr_obj_name", ["da_not_adjusted", "ds_not_adjusted"])
+    def test_contains_unadjusted_models_all_unadjusted_xr(
+        self,
+        xr_obj_name: str,
+        request: pytest.FixtureRequest,
+        processor_yes: FilterUnAdjustedModels,
+        processor_no: FilterUnAdjustedModels,
+    ) -> None:
+        """
+        Test _contains_unadjusted_models with an xarray object with an unadjusted model.
+        """
+        xr_obj = request.getfixturevalue(xr_obj_name)
+        assert processor_yes._contains_unadjusted_models(xr_obj)
+        assert processor_no._contains_unadjusted_models(xr_obj)
 
-    def test_contains_unadjusted_models_list_all_not_adjusted(self):
-        """Test _contains_unadjusted_models with a list of unadjusted Datasets."""
-        assert self.processor_yes._contains_unadjusted_models(
-            [self.ds_not_adjusted, self.ds_not_adjusted]
-        )
-        assert self.processor_no._contains_unadjusted_models(
-            [self.ds_not_adjusted, self.ds_not_adjusted]
-        )
-
-    def test_contains_unadjusted_models_tuple_all_not_adjusted(self):
-        """Test _contains_unadjusted_models with a tuple of unadjusted Datasets."""
-        assert self.processor_yes._contains_unadjusted_models(
-            (self.ds_not_adjusted, self.ds_not_adjusted)
-        )
-        assert self.processor_no._contains_unadjusted_models(
-            (self.ds_not_adjusted, self.ds_not_adjusted)
-        )
-
-    def test_contains_unadjusted_models_empty_list(self):
-        """Test _contains_unadjusted_models with an empty list."""
-        assert not self.processor_yes._contains_unadjusted_models([])
-        assert not self.processor_no._contains_unadjusted_models([])
-
-    def test_contains_unadjusted_models_empty_tuple(self):
-        """Test _contains_unadjusted_models with an empty tuple."""
-        assert not self.processor_yes._contains_unadjusted_models(())
-        assert not self.processor_no._contains_unadjusted_models(())
-
-    def test_contains_unadjusted_models_list_all_adjusted(self):
-        """Test _contains_unadjusted_models with a list of adjusted Datasets."""
-        assert not self.processor_yes._contains_unadjusted_models(
-            [self.ds_adjusted, self.ds_adjusted]
-        )
-        assert not self.processor_no._contains_unadjusted_models(
-            [self.ds_adjusted, self.ds_adjusted]
-        )
-
-    def test_contains_unadjusted_models_tuple_all_adjusted(self):
-        """Test _contains_unadjusted_models with a tuple of adjusted Datasets."""
-        assert not self.processor_yes._contains_unadjusted_models(
-            (self.ds_adjusted, self.ds_adjusted)
-        )
-        assert not self.processor_no._contains_unadjusted_models(
-            (self.ds_adjusted, self.ds_adjusted)
-        )
-
-    def test_contains_unadjusted_models_dict_mixed(self):
-        """Test _contains_unadjusted_models with a dictionary of mixed Datasets."""
-        assert self.processor_yes._contains_unadjusted_models(
-            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
-        )
-        assert self.processor_no._contains_unadjusted_models(
-            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
-        )
-
-    def test_contains_unadjusted_models_dict_all_not_adjusted(self):
-        """Test _contains_unadjusted_models with a dictionary of unadjusted Datasets."""
-        assert self.processor_yes._contains_unadjusted_models(
-            {"data1": self.ds_not_adjusted, "data2": self.ds_not_adjusted}
-        )
-        assert self.processor_no._contains_unadjusted_models(
-            {"data1": self.ds_not_adjusted, "data2": self.ds_not_adjusted}
-        )
-
-    def test_contains_unadjusted_models_empty_dict(self):
-        """Test _contains_unadjusted_models with an empty dictionary."""
-        assert not self.processor_yes._contains_unadjusted_models({})
-        assert not self.processor_no._contains_unadjusted_models({})
-
-    def test_contains_unadjusted_models_dict_mixed_multiple(self):
-        """Test _contains_unadjusted_models with a dictionary with mixed Datasets."""
-        assert self.processor_yes._contains_unadjusted_models(
-            {
-                "data1": self.ds_adjusted,
-                "data2": self.ds_adjusted,
-                "data3": self.ds_not_adjusted,
-            }
-        )
-        assert self.processor_no._contains_unadjusted_models(
-            {
-                "data1": self.ds_adjusted,
-                "data2": self.ds_adjusted,
-                "data3": self.ds_not_adjusted,
-            }
-        )
-
-    def test_contains_unadjusted_models_dict_all_adjusted(self):
-        """Test _contains_unadjusted_models with a dictionary of adjusted Datasets."""
-        assert not self.processor_yes._contains_unadjusted_models(
-            {
-                "data1": self.ds_adjusted,
-                "data2": self.ds_adjusted,
-                "data3": self.ds_adjusted,
-            }
-        )
-        assert not self.processor_no._contains_unadjusted_models(
-            {
-                "data1": self.ds_adjusted,
-                "data2": self.ds_adjusted,
-                "data3": self.ds_adjusted,
-            }
-        )
-
-    def test_contains_unadjusted_models_invalid_type(self):
-        """Test _contains_unadjusted_models with an invalid type."""
+    def test_contains_unadjusted_models_invalid_type(
+        self, empty_processor: FilterUnAdjustedModels
+    ) -> None:
+        """
+        Test _contains_unadjusted_models with an invalid type.
+        """
         with pytest.raises(TypeError) as excinfo:
-            self.processor_yes._contains_unadjusted_models(123)
-        assert "Unsupported type for result" in str(excinfo.value)
-
-        with pytest.raises(TypeError) as excinfo:
-            self.processor_no._contains_unadjusted_models(123)
+            empty_processor._contains_unadjusted_models(123)
         assert "Unsupported type for result" in str(excinfo.value)
 
 
 class TestFilterUnAdjustedModelsRemoveUnAdjustedModels:
-    """Test class for _remove_unadjusted_models method."""
+    """Tests for _remove_unadjusted_models method."""
 
-    def setup_method(self):
-        """Setup method to initialize common variables."""
-        self.processor_yes = FilterUnAdjustedModels(value="yes")
-        self.processor_no = FilterUnAdjustedModels(value="no")
+    @pytest.mark.parametrize("empty_iterable", [[], (), {}])
+    def test_remove_unadjusted_models_empty_iterable(
+        self,
+        empty_iterable: Union[list, tuple, dict],
+        processor_yes: FilterUnAdjustedModels,
+    ) -> None:
+        """Test with an empty iterable."""
+        result_yes = processor_yes._remove_unadjusted_models(empty_iterable)
+        assert result_yes == empty_iterable
 
-        # Create sample xarray Datasets and DataArrays for testing
-        self.ds_empty = xr.Dataset()
-        self.ds_adjusted = xr.Dataset(
-            {"temp": (["time"], [1, 2, 3])},
-            coords={
-                "time": pd.date_range("2000-01-01", periods=3),
-                "simulation": ["model_a"],
-            },
-            attrs={
-                "intake_esm_attrs:activity_id": "WRF",
-                "intake_esm_attrs:source_id": "EC-Earth3",
-                "intake_esm_attrs:member_id": "r1i1p1f1",
-            },
-        )
-        self.ds_not_adjusted = xr.Dataset(
-            {"temp": (["time"], [4, 5, 6])},
-            coords={
-                "time": pd.date_range("2000-01-01", periods=3),
-                "simulation": ["model_b"],
-            },
-            attrs={
-                "intake_esm_attrs:activity_id": "WRF",
-                "intake_esm_attrs:source_id": "FGOALS-g3",
-                "intake_esm_attrs:member_id": "r1i1p1f1",
-            },
-        )
+    @pytest.mark.parametrize("container_type", [list, tuple, dict])
+    def test_remove_unadjusted_models_all_adjusted(
+        self,
+        container_type: type,
+        processor_yes: FilterUnAdjustedModels,
+        ds_adjusted: xr.Dataset,
+    ) -> None:
+        """Test with only adjusted models datasets."""
+        if container_type is dict:
+            input_data = {1: ds_adjusted, 2: ds_adjusted}
+        else:
+            input_data = container_type([ds_adjusted, ds_adjusted])
+        result_yes = processor_yes._remove_unadjusted_models(input_data)
+        if isinstance(input_data, dict):
+            assert result_yes == {1: ds_adjusted, 2: ds_adjusted}
+        else:
+            assert result_yes == container_type([ds_adjusted, ds_adjusted])
 
-    def test_remove_unadjusted_models_single_dataset_adjusted(self):
-        """Test _remove_unadjusted_models with a single adjusted Dataset."""
-        result_yes = self.processor_yes._remove_unadjusted_models(self.ds_adjusted)
-        assert result_yes is self.ds_adjusted
+    @pytest.mark.parametrize("container_type", [list, tuple, dict])
+    def test_remove_unadjusted_models_all_unadjusted(
+        self,
+        container_type: type,
+        processor_yes: FilterUnAdjustedModels,
+        ds_not_adjusted: xr.Dataset,
+    ) -> None:
+        """Test with only unadjusted models datasets."""
+        if container_type is dict:
+            input_data = {1: ds_not_adjusted, 2: ds_not_adjusted}
+        else:
+            input_data = container_type([ds_not_adjusted, ds_not_adjusted])
+        result_yes = processor_yes._remove_unadjusted_models(input_data)
+        if isinstance(input_data, dict):
+            assert result_yes == {}
+        else:
+            assert result_yes == container_type()
 
-    def test_remove_unadjusted_models_single_dataset_not_adjusted(self):
-        """Test _remove_unadjusted_models with a single unadjusted Dataset."""
-        result_yes = self.processor_yes._remove_unadjusted_models(self.ds_not_adjusted)
+    @pytest.mark.parametrize("container_type", [list, tuple, dict])
+    def test_remove_unadjusted_models_mixed(
+        self,
+        container_type: type,
+        processor_yes: FilterUnAdjustedModels,
+        ds_adjusted: xr.Dataset,
+        ds_not_adjusted: xr.Dataset,
+    ) -> None:
+        """Test with datasets with a mix of adjusted and unadjusted models."""
+        if container_type is dict:
+            input_data = {1: ds_not_adjusted, 2: ds_adjusted}
+        else:
+            input_data = container_type([ds_not_adjusted, ds_adjusted])
+        result_yes = processor_yes._remove_unadjusted_models(input_data)
+        if isinstance(input_data, dict):
+            assert result_yes == {2: ds_adjusted}
+        else:
+            assert result_yes == container_type([ds_adjusted])
+
+    @pytest.mark.parametrize("xr_obj_name", ["da_empty", "ds_empty"])
+    def test_remove_unadjusted_models_empty_xr(
+        self,
+        xr_obj_name: str,
+        request: pytest.FixtureRequest,
+        processor_yes: FilterUnAdjustedModels,
+    ) -> None:
+        """Test with an empty xarray object."""
+        xr_obj = request.getfixturevalue(xr_obj_name)
+        result_yes = processor_yes._remove_unadjusted_models(xr_obj)
+        assert result_yes.identical(xr_obj)
+
+    @pytest.mark.parametrize("xr_obj_name", ["da_adjusted", "ds_adjusted"])
+    def test_remove_unadjusted_models_all_adjusted_xr(
+        self,
+        xr_obj_name: str,
+        request: pytest.FixtureRequest,
+        processor_yes: FilterUnAdjustedModels,
+    ) -> None:
+        """Test with an xarray object with an adjusted model."""
+        xr_obj = request.getfixturevalue(xr_obj_name)
+        result_yes = processor_yes._remove_unadjusted_models(xr_obj)
+        assert result_yes.identical(xr_obj)
+
+    @pytest.mark.parametrize("xr_obj_name", ["da_not_adjusted", "ds_not_adjusted"])
+    def test_remove_unadjusted_models_all_unadjusted_xr(
+        self,
+        xr_obj_name: str,
+        request: pytest.FixtureRequest,
+        processor_yes: FilterUnAdjustedModels,
+    ) -> None:
+        """Test with an xarray object with an unadjusted model."""
+        xr_obj = request.getfixturevalue(xr_obj_name)
+        result_yes = processor_yes._remove_unadjusted_models(xr_obj)
         assert result_yes is None
 
-    def test_remove_unadjusted_models_empty_dataset(self):
-        """Test _remove_unadjusted_models with an empty Dataset."""
-        result = self.processor_yes._remove_unadjusted_models(self.ds_empty)
-        assert result is self.ds_empty
-
-    def test_remove_unadjusted_models_list_mixed(self):
-        """Test _remove_unadjusted_models with a list of mixed Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            [self.ds_adjusted, self.ds_not_adjusted]
-        )
-        assert result_yes == [self.ds_adjusted]
-
-    # def test_remove_unadjusted_models_tuple_mixed(self):
-    #     """Test _remove_unadjusted_models with a tuple of mixed Datasets."""
-    #     result_yes = self.processor_yes._remove_unadjusted_models(
-    #         (self.ds_not_adjusted, self.ds_adjusted)
-    #     )
-    #     assert result_yes == (self.ds_adjusted)
-
-    def test_remove_unadjusted_models_list_all_not_adjusted(self):
-        """Test _remove_unadjusted_models with a list of unadjusted Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            [self.ds_not_adjusted, self.ds_not_adjusted]
-        )
-        assert result_yes == []
-
-    def test_remove_unadjusted_models_tuple_all_not_adjusted(self):
-        """Test _remove_unadjusted_models with a tuple of unadjusted Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            (self.ds_not_adjusted, self.ds_not_adjusted)
-        )
-        assert result_yes is ()
-
-    def test_remove_unadjusted_models_dict_mixed(self):
-        """Test _remove_unadjusted_models with a dictionary of mixed Datasets."""
-        result_yes = self.processor_yes._remove_unadjusted_models(
-            {"data1": self.ds_adjusted, "data2": self.ds_not_adjusted}
-        )
-        assert result_yes == {"data1": self.ds_adjusted}
-
-    def test_remove_unadjusted_models_dict_empty(self):
-        """Test _remove_unadjusted_models with an empty dictionary."""
-        result_yes = self.processor_yes._remove_unadjusted_models({})
-        assert result_yes == {}
-
-    def test_remove_unadjusted_models_with_invalid_dtype(self):
-        """Test _remove_unadjusted_models with an invalid type."""
+    def test_remove_unadjusted_models_with_invalid_dtype(
+        self, processor_yes: FilterUnAdjustedModels
+    ) -> None:
+        """Test with an invalid type."""
         with pytest.raises(TypeError) as excinfo:
-            self.processor_yes._remove_unadjusted_models(123)
+            processor_yes._remove_unadjusted_models(123)
         assert "Unsupported type for result" in str(excinfo.value)
 
 
 class TestFilterUnAdjustedModelsUpdateContext:
-    """Test class for update_context method."""
+    """Tests for the update_context method of FilterUnAdjustedModels."""
 
-    def setup_method(self):
-        """Setup method to initialize common variables."""
-        self.processor = FilterUnAdjustedModels()
-
-    def test_update_context_yes(self):
-        """Test update_context when value is 'yes'."""
-        context = {}
-        self.processor.update_context(context)
-        assert f"Process '{self.processor.name}' applied to the data" in context[
+    def test_update_context(self, empty_processor: FilterUnAdjustedModels) -> None:
+        """Test update_context with an empty context."""
+        context: dict = {}
+        empty_processor.update_context(context)
+        assert f"Process '{empty_processor.name}' applied to the data" in context[
             _NEW_ATTRS_KEY
         ].get("filter_unadjusted_models")
 
-    def test_update_context_with_attrs_key_existing(self):
-        """Test update_context when _NEW_ATTRS_KEY already exists in context."""
-        context = {_NEW_ATTRS_KEY: {"existing_key": "existing_value"}}
-        self.processor.update_context(context)
+    def test_update_context_with_attrs_key_existing(
+        self, empty_processor: FilterUnAdjustedModels
+    ) -> None:
+        """Test update_context when _NEW_ATTRS_KEY exists in context."""
+        context: dict = {_NEW_ATTRS_KEY: {"existing_key": "existing_value"}}
+        empty_processor.update_context(context)
         assert "existing_key" in context[_NEW_ATTRS_KEY]
-        assert f"Process '{self.processor.name}' applied to the data" in context[
+        assert f"Process '{empty_processor.name}' applied to the data" in context[
             _NEW_ATTRS_KEY
         ].get("filter_unadjusted_models")
 
 
 class TestFilterUnAdjustedModelsExecute:
-    """Test class for execute method."""
+    """Tests for the execute method."""
 
-    def setup_method(self):
-        """Setup method to initialize common variables."""
-        self.processor_yes = FilterUnAdjustedModels(value="yes")
-        self.processor_no = FilterUnAdjustedModels(value="no")
-
-        # Create sample xarray Datasets and DataArrays for testing
-        self.ds_empty = xr.Dataset()
-        self.ds_adjusted = xr.Dataset(
-            {"temp": (["time"], [1, 2, 3])},
-            coords={
-                "time": pd.date_range("2000-01-01", periods=3),
-                "simulation": ["model_a"],
-            },
-            attrs={
-                "intake_esm_attrs:activity_id": "WRF",
-                "intake_esm_attrs:source_id": "EC-Earth3",
-                "intake_esm_attrs:member_id": "r1i1p1f1",
-            },
-        )
-        self.ds_not_adjusted = xr.Dataset(
-            {"temp": (["time"], [4, 5, 6])},
-            coords={
-                "time": pd.date_range("2000-01-01", periods=3),
-                "simulation": ["model_b"],
-            },
-            attrs={
-                "intake_esm_attrs:activity_id": "WRF",
-                "intake_esm_attrs:source_id": "FGOALS-g3",
-                "intake_esm_attrs:member_id": "r1i1p1f1",
-            },
-        )
-
-    def test_execute_empty_list_yes(self):
-        """Test execute with an empty list and value 'yes'."""
-        result = self.processor_yes.execute([], context={})
+    def test_execute_empty_list_yes(
+        self, processor_yes: FilterUnAdjustedModels
+    ) -> None:
+        """Test execute with an empty list and processor value 'yes'."""
+        result: list = processor_yes.execute([], context={})
         assert result == []
 
-    def test_execute_empty_list_no(self):
-        """Test execute with an empty list and value 'no'."""
-        result = self.processor_no.execute([], context={})
+    def test_execute_empty_list_no(self, processor_no: FilterUnAdjustedModels) -> None:
+        """Test execute with an empty list and processor value 'no'."""
+        result: list = processor_no.execute([], context={})
         assert result == []
 
-    def test_execute_yes_with_only_adjusted_models(self, recwarn):
-        """Test execute does not raise warning when all models are adjusted and value 'yes'."""
-        # with pytest.warns(None) as record:
-        result = self.processor_yes.execute(
-            [self.ds_adjusted, self.ds_adjusted], context={}
-        )
-        assert result == [self.ds_adjusted, self.ds_adjusted]
+    def test_execute_yes_with_only_adjusted_models(
+        self,
+        recwarn: pytest.WarningsRecorder,
+        processor_yes: FilterUnAdjustedModels,
+        ds_adjusted: xr.Dataset,
+    ) -> None:
+        """Test execute with only adjusted models and processor value 'yes'."""
+        result: list = processor_yes.execute([ds_adjusted, ds_adjusted], context={})
+        assert result == [ds_adjusted, ds_adjusted]
         assert len(recwarn) == 0
 
-    def test_execute_yes_with_only_unadjusted_models(self, recwarn):
-        """Test execute raises warning when all models are unadjusted and value 'yes'."""
-        result = self.processor_yes.execute(
-            [self.ds_not_adjusted, self.ds_not_adjusted], context={}
+    def test_execute_yes_with_only_unadjusted_models(
+        self,
+        recwarn: pytest.WarningsRecorder,
+        processor_yes: FilterUnAdjustedModels,
+        ds_not_adjusted: xr.Dataset,
+    ) -> None:
+        """Test execute with only unadjusted models and processor value 'yes'."""
+        result: list = processor_yes.execute(
+            [ds_not_adjusted, ds_not_adjusted], context={}
         )
         assert result == []
         assert len(recwarn) > 0
@@ -432,32 +458,44 @@ class TestFilterUnAdjustedModelsExecute:
             for w in recwarn.list
         )
 
-    def test_execute_yes_with_mixed_models(self, recwarn):
-        """Test execute raises warning when mixed models and value 'yes'."""
-        result = self.processor_yes.execute(
-            [self.ds_adjusted, self.ds_not_adjusted], context={}
-        )
-        assert result == [self.ds_adjusted]
+    def test_execute_yes_with_mixed_models(
+        self,
+        recwarn: pytest.WarningsRecorder,
+        processor_yes: FilterUnAdjustedModels,
+        ds_adjusted: xr.Dataset,
+        ds_not_adjusted: xr.Dataset,
+    ) -> None:
+        """Test execute with mixed models and processor value 'yes'."""
+        result: list = processor_yes.execute([ds_adjusted, ds_not_adjusted], context={})
+        assert result == [ds_adjusted]
         assert len(recwarn) > 0
         assert any(
             "These models have been removed from the returned query." in str(w.message)
             for w in recwarn.list
         )
 
-    def test_execute_no_with_only_adjusted_models(self, recwarn):
-        """Test execute does not raise warning when all models are adjusted and value 'no'."""
-        result = self.processor_no.execute(
-            [self.ds_adjusted, self.ds_adjusted], context={}
-        )
-        assert result == [self.ds_adjusted, self.ds_adjusted]
+    def test_execute_no_with_only_adjusted_models(
+        self,
+        recwarn: pytest.WarningsRecorder,
+        processor_no: FilterUnAdjustedModels,
+        ds_adjusted: xr.Dataset,
+    ) -> None:
+        """Test execute with only adjusted models and processor value 'no'."""
+        result: list = processor_no.execute([ds_adjusted, ds_adjusted], context={})
+        assert result == [ds_adjusted, ds_adjusted]
         assert len(recwarn) == 0
 
-    def test_execute_no_with_only_unadjusted_models(self, recwarn):
-        """Test execute does not raise warning when all models are unadjusted and value 'no'."""
-        result = self.processor_no.execute(
-            [self.ds_not_adjusted, self.ds_not_adjusted], context={}
+    def test_execute_no_with_only_unadjusted_models(
+        self,
+        recwarn: pytest.WarningsRecorder,
+        processor_no: FilterUnAdjustedModels,
+        ds_not_adjusted: xr.Dataset,
+    ) -> None:
+        """Test execute with only unadjusted models and processor value 'no'."""
+        result: list = processor_no.execute(
+            [ds_not_adjusted, ds_not_adjusted], context={}
         )
-        assert result == [self.ds_not_adjusted, self.ds_not_adjusted]
+        assert result == [ds_not_adjusted, ds_not_adjusted]
         assert len(recwarn) > 0
         assert any(
             "These models HAVE NOT been removed from the returned query."
@@ -465,12 +503,16 @@ class TestFilterUnAdjustedModelsExecute:
             for w in recwarn.list
         )
 
-    def test_execute_no_with_mixed_models(self, recwarn):
-        """Test execute raises warning when mixed models and value 'no'."""
-        result = self.processor_no.execute(
-            [self.ds_adjusted, self.ds_not_adjusted], context={}
-        )
-        assert result == [self.ds_adjusted, self.ds_not_adjusted]
+    def test_execute_no_with_mixed_models(
+        self,
+        recwarn: pytest.WarningsRecorder,
+        processor_no: FilterUnAdjustedModels,
+        ds_adjusted: xr.Dataset,
+        ds_not_adjusted: xr.Dataset,
+    ) -> None:
+        """Test execute with a mixed set models and processor value 'no'."""
+        result: list = processor_no.execute([ds_adjusted, ds_not_adjusted], context={})
+        assert result == [ds_adjusted, ds_not_adjusted]
         assert len(recwarn) > 0
         assert any(
             "These models HAVE NOT been removed from the returned query."
@@ -478,10 +520,12 @@ class TestFilterUnAdjustedModelsExecute:
             for w in recwarn.list
         )
 
-    def test_execute_not_yes_or_no(self):
-        """Test execute raises ValueError when value is neither 'yes' nor 'no'."""
-        processor_invalid = FilterUnAdjustedModels(value="no idea")
+    def test_execute_not_yes_or_no(self, ds_adjusted: xr.Dataset) -> None:
+        """Test execute raises ValueError for invalid value."""
+        processor_invalid: FilterUnAdjustedModels = FilterUnAdjustedModels(
+            value="no idea"
+        )
         with pytest.raises(ValueError) as excinfo:
-            processor_invalid.execute(self.ds_adjusted, context={})
+            processor_invalid.execute(ds_adjusted, context={})
         assert "Invalid value" in str(excinfo.value)
         assert "Valid values are:" in str(excinfo.value)


### PR DESCRIPTION
## Summary of changes and related issue
Adding tests to cover `new_core/processors/filter_unadjusted_models.py`

## Relevant motivation and context
We need more tests!

## How to test 
Run `python -m pytest tests/new_core/processors/test_filter_unadjusted_models.py --cov=climakitae/new_core/processors`. Confirm that the tests run successfully and that coverage is at 100%.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
