### PR TITLE
Tests/new core param val filter

### DIFF
--- a/tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py
+++ b/tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py
@@ -1,0 +1,47 @@
+"""
+Unit tests for climakitae/new_core/param_validation/filter_unadjusted_models_param_validator.py
+
+This module contains comprehensive unit tests for the FilterUnadjustedModels processor
+parameter validation functionality.
+"""
+
+import warnings
+
+import pytest
+
+from climakitae.new_core.param_validation.filter_unadjusted_models_param_validator import (
+    validate_filter_unadjusted_models_param,
+)
+
+# Suppress known external warnings that are not relevant to our tests
+warnings.filterwarnings(
+    "ignore",
+    message="The 'shapely.geos' module is deprecated",
+    category=DeprecationWarning,
+)
+warnings.filterwarnings(
+    "ignore", message="pkg_resources is deprecated", category=DeprecationWarning
+)
+
+
+class TestValidateFilterUnadjustedModelsParam:
+    """Test class for validate_filter_unadjusted_models_param function."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("yes", True),
+            ("no", True),
+        ],
+        ids=["yes", "no"],
+    )
+    def test_validate_filter_unadjusted_models_param_valid_values(
+        self, value, expected
+    ):
+        """Test validate_filter_unadjusted_models_param with valid values.
+        
+        Tests validation with supported string values "yes" and "no".
+        Both should return True.
+        """
+        result = validate_filter_unadjusted_models_param(value)
+        assert result == expected

--- a/tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py
+++ b/tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py
@@ -45,3 +45,48 @@ class TestValidateFilterUnadjustedModelsParam:
         """
         result = validate_filter_unadjusted_models_param(value)
         assert result == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "true",
+            "false", 
+            "YES",
+            "NO",
+            "y",
+            "n",
+            "1",
+            "0",
+            "invalid",
+            "maybe",
+            "",
+        ],
+        ids=[
+            "true",
+            "false", 
+            "YES_uppercase",
+            "NO_uppercase",
+            "y_short",
+            "n_short",
+            "numeric_1",
+            "numeric_0",
+            "invalid_word",
+            "maybe",
+            "empty_string",
+        ],
+    )
+    def test_validate_filter_unadjusted_models_param_invalid_value(self, value):
+        """Test validate_filter_unadjusted_models_param with invalid string values.
+        
+        Tests validation with various invalid string values that should
+        trigger warnings and return False.
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = validate_filter_unadjusted_models_param(value)
+            
+            assert result is False
+            assert len(w) == 1
+            assert "Invalid value" in str(w[0].message)
+            assert "FilterUnadjustedModels Processor" in str(w[0].message)
+            assert "Supported values are: ['yes', 'no']" in str(w[0].message)

--- a/tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py
+++ b/tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py
@@ -90,3 +90,41 @@ class TestValidateFilterUnadjustedModelsParam:
             assert "Invalid value" in str(w[0].message)
             assert "FilterUnadjustedModels Processor" in str(w[0].message)
             assert "Supported values are: ['yes', 'no']" in str(w[0].message)
+
+    @pytest.mark.parametrize(
+        "input_value",
+        [
+            123,
+            12.5,
+            True,
+            False,
+            None,
+            ["yes"],
+            {"value": "yes"},
+            ("yes",),
+        ],
+        ids=[
+            "integer",
+            "float",
+            "boolean_true",
+            "boolean_false",
+            "none",
+            "list",
+            "dict",
+            "tuple",
+        ],
+    )
+    def test_validate_filter_unadjusted_models_param_invalid_type(self, input_value):
+        """Test validate_filter_unadjusted_models_param with non-string types.
+        
+        Tests validation with various non-string types that should
+        trigger type warnings and return False.
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = validate_filter_unadjusted_models_param(input_value)
+            
+            assert result is False
+            assert len(w) == 1
+            assert "FilterunadjustedModels Processor expects a string value" in str(w[0].message)
+            assert "Please check the configuration" in str(w[0].message)

--- a/tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py
+++ b/tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py
@@ -39,7 +39,7 @@ class TestValidateFilterUnadjustedModelsParam:
         self, value, expected
     ):
         """Test validate_filter_unadjusted_models_param with valid values.
-        
+
         Tests validation with supported string values "yes" and "no".
         Both should return True.
         """
@@ -50,7 +50,7 @@ class TestValidateFilterUnadjustedModelsParam:
         "value",
         [
             "true",
-            "false", 
+            "false",
             "YES",
             "NO",
             "y",
@@ -63,7 +63,7 @@ class TestValidateFilterUnadjustedModelsParam:
         ],
         ids=[
             "true",
-            "false", 
+            "false",
             "YES_uppercase",
             "NO_uppercase",
             "y_short",
@@ -77,14 +77,14 @@ class TestValidateFilterUnadjustedModelsParam:
     )
     def test_validate_filter_unadjusted_models_param_invalid_value(self, value):
         """Test validate_filter_unadjusted_models_param with invalid string values.
-        
+
         Tests validation with various invalid string values that should
         trigger warnings and return False.
         """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = validate_filter_unadjusted_models_param(value)
-            
+
             assert result is False
             assert len(w) == 1
             assert "Invalid value" in str(w[0].message)
@@ -116,15 +116,17 @@ class TestValidateFilterUnadjustedModelsParam:
     )
     def test_validate_filter_unadjusted_models_param_invalid_type(self, input_value):
         """Test validate_filter_unadjusted_models_param with non-string types.
-        
+
         Tests validation with various non-string types that should
         trigger type warnings and return False.
         """
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = validate_filter_unadjusted_models_param(input_value)
-            
+
             assert result is False
             assert len(w) == 1
-            assert "FilterunadjustedModels Processor expects a string value" in str(w[0].message)
+            assert "FilterunadjustedModels Processor expects a string value" in str(
+                w[0].message
+            )
             assert "Please check the configuration" in str(w[0].message)


### PR DESCRIPTION
## Summary of changes and related issue

This pull request adds comprehensive unit tests for the `validate_filter_unadjusted_models_param` function, ensuring that both valid and invalid parameter values are properly handled. The new test suite covers supported string values, various invalid strings, and non-string types, verifying that appropriate warnings are triggered and correct boolean responses are returned.

Unit test additions for parameter validation:

* Added tests to verify correct handling of valid string values ("yes", "no") for the `validate_filter_unadjusted_models_param` function, ensuring both return `True`.
* Added tests for invalid string inputs (e.g., "true", "false", "YES", "NO", "y", "n", "1", "0", "invalid", "maybe", and empty string), checking that the function returns `False` and emits a warning with a detailed message.
* Added tests for invalid non-string types (e.g., integer, float, boolean, None, list, dict, tuple), confirming the function returns `False` and emits a type warning with guidance for configuration.

## Relevant motivation and context
tests are good

## How to test 
confirm the ci tests are running, then confirm the added tests run with `python -m pytest tests/new_core/param_validation/test_filter_unadjusted_models_param_validator.py` 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
