### PR TITLE
Tests/new core param val concat

### DIFF
--- a/tests/new_core/param_validation/test_concat_param_validation.py
+++ b/tests/new_core/param_validation/test_concat_param_validation.py
@@ -1,0 +1,48 @@
+"""
+Unit tests for climakitae/new_core/param_validation/concat_param_validator.py
+
+This module contains comprehensive unit tests for the concat parameter validation
+functionality that validates dimension names for the Concat Processor.
+"""
+
+import warnings
+
+from climakitae.new_core.param_validation.concat_param_validator import (
+    validate_concat_param,
+)
+
+# Suppress known external warnings that are not relevant to our tests
+warnings.filterwarnings(
+    "ignore",
+    message="The 'shapely.geos' module is deprecated",
+    category=DeprecationWarning,
+)
+warnings.filterwarnings(
+    "ignore", message="pkg_resources is deprecated", category=DeprecationWarning
+)
+
+
+class TestValidateConcatParam:
+    """Test class for validate_concat_param function validation logic."""
+
+    def test_validate_concat_param_valid_string(self):
+        """Test validation with valid string input."""
+        result = validate_concat_param("sim")
+        assert result is True
+        
+        result = validate_concat_param("time")
+        assert result is True
+        
+        result = validate_concat_param("ensemble")
+        assert result is True
+
+    def test_validate_concat_param_valid_string_with_whitespace(self):
+        """Test validation with valid string that has leading/trailing whitespace."""
+        result = validate_concat_param("  sim  ")
+        assert result is True
+        
+        result = validate_concat_param("\ttime\n")
+        assert result is True
+        
+        result = validate_concat_param(" ensemble ")
+        assert result is True

--- a/tests/new_core/param_validation/test_concat_param_validation.py
+++ b/tests/new_core/param_validation/test_concat_param_validation.py
@@ -29,10 +29,10 @@ class TestValidateConcatParam:
         """Test validation with valid string input."""
         result = validate_concat_param("sim")
         assert result is True
-        
+
         result = validate_concat_param("time")
         assert result is True
-        
+
         result = validate_concat_param("ensemble")
         assert result is True
 
@@ -40,9 +40,9 @@ class TestValidateConcatParam:
         """Test validation with valid string that has leading/trailing whitespace."""
         result = validate_concat_param("  sim  ")
         assert result is True
-        
+
         result = validate_concat_param("\ttime\n")
         assert result is True
-        
+
         result = validate_concat_param(" ensemble ")
         assert result is True

--- a/tests/new_core/param_validation/test_concat_param_validation.py
+++ b/tests/new_core/param_validation/test_concat_param_validation.py
@@ -54,3 +54,9 @@ class TestValidateConcatParam:
         """Test validation with valid string that has leading/trailing whitespace."""
         result = validate_concat_param(input_value)
         assert result is expected
+
+    def test_validate_concat_param_empty_string(self):
+        """Test validation with empty string input."""
+        with pytest.warns(UserWarning, match="dimension name cannot be empty"):
+            result = validate_concat_param("")
+            assert result is False

--- a/tests/new_core/param_validation/test_concat_param_validation.py
+++ b/tests/new_core/param_validation/test_concat_param_validation.py
@@ -75,3 +75,21 @@ class TestValidateConcatParam:
         with pytest.warns(UserWarning, match="dimension name cannot be empty"):
             result = validate_concat_param(input_value)
             assert result is False
+
+    @pytest.mark.parametrize(
+        "input_value",
+        [
+            123,  # integer
+            12.5,  # float
+            True,  # boolean
+            None,  # None type
+            ["sim"],  # list
+            {"dim": "sim"},  # dictionary
+            ("sim",),  # tuple
+        ],
+    )
+    def test_validate_concat_param_invalid_type(self, input_value):
+        """Test validation with invalid input types."""
+        with pytest.warns(UserWarning, match="expects a string value"):
+            result = validate_concat_param(input_value)
+            assert result is False

--- a/tests/new_core/param_validation/test_concat_param_validation.py
+++ b/tests/new_core/param_validation/test_concat_param_validation.py
@@ -7,6 +7,8 @@ functionality that validates dimension names for the Concat Processor.
 
 import warnings
 
+import pytest
+
 from climakitae.new_core.param_validation.concat_param_validator import (
     validate_concat_param,
 )
@@ -25,24 +27,30 @@ warnings.filterwarnings(
 class TestValidateConcatParam:
     """Test class for validate_concat_param function validation logic."""
 
-    def test_validate_concat_param_valid_string(self):
+    @pytest.mark.parametrize(
+        "input_value,expected",
+        [
+            ("sim", True),
+            ("time", True),
+            ("ensemble", True),
+        ],
+    )
+    def test_validate_concat_param_valid_string(self, input_value, expected):
         """Test validation with valid string input."""
-        result = validate_concat_param("sim")
-        assert result is True
+        result = validate_concat_param(input_value)
+        assert result is expected
 
-        result = validate_concat_param("time")
-        assert result is True
-
-        result = validate_concat_param("ensemble")
-        assert result is True
-
-    def test_validate_concat_param_valid_string_with_whitespace(self):
+    @pytest.mark.parametrize(
+        "input_value,expected",
+        [
+            ("  sim  ", True),
+            ("\ttime\n", True),
+            (" ensemble ", True),
+        ],
+    )
+    def test_validate_concat_param_valid_string_with_whitespace(
+        self, input_value, expected
+    ):
         """Test validation with valid string that has leading/trailing whitespace."""
-        result = validate_concat_param("  sim  ")
-        assert result is True
-
-        result = validate_concat_param("\ttime\n")
-        assert result is True
-
-        result = validate_concat_param(" ensemble ")
-        assert result is True
+        result = validate_concat_param(input_value)
+        assert result is expected

--- a/tests/new_core/param_validation/test_concat_param_validation.py
+++ b/tests/new_core/param_validation/test_concat_param_validation.py
@@ -60,3 +60,18 @@ class TestValidateConcatParam:
         with pytest.warns(UserWarning, match="dimension name cannot be empty"):
             result = validate_concat_param("")
             assert result is False
+
+    @pytest.mark.parametrize(
+        "input_value",
+        [
+            "   ",  # spaces only
+            "\t\t",  # tabs only
+            "\n\n",  # newlines only
+            " \t\n ",  # mixed whitespace
+        ],
+    )
+    def test_validate_concat_param_whitespace_only_string(self, input_value):
+        """Test validation with whitespace-only string input."""
+        with pytest.warns(UserWarning, match="dimension name cannot be empty"):
+            result = validate_concat_param(input_value)
+            assert result is False


### PR DESCRIPTION
## Summary of changes and related issue

This pull request adds a comprehensive suite of unit tests for the `validate_concat_param` function, which checks the validity of dimension names for the Concat Processor. The tests cover valid input cases, handling of whitespace, empty and whitespace-only strings, and invalid input types.

Unit test additions for concat parameter validation:

* Added tests for valid dimension name strings, including cases with leading/trailing whitespace.
* Added tests to ensure empty strings and strings containing only whitespace are properly rejected, with appropriate warnings.
* Added tests to verify that non-string input types (e.g., numbers, booleans, lists, dicts, tuples) are rejected and trigger user warnings.

## Relevant motivation and context
tests are good

## How to test 
ci tests pass, local tests pass with `python -m pytest pytest tests/new_core/param_validation/test_concat_param_validation.py --cov=climakitae/new_core/param_validation/`

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
