### PR TITLE
Tests/new core param val update attrs

### DIFF
--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -35,7 +35,6 @@ class TestValidateUpdateAttributesParam:
             ("test_string", "regular string"),
             ("", "empty string"),
             ("complex string with spaces and 123", "complex string"),
-            
             # Numeric values
             (42, "positive integer"),
             (0, "zero integer"),
@@ -43,15 +42,12 @@ class TestValidateUpdateAttributesParam:
             (3.14159, "positive float"),
             (0.0, "zero float"),
             (-2.5, "negative float"),
-            
             # Boolean values
             (True, "boolean True"),
             (False, "boolean False"),
-            
             # Special values
             (None, "None value"),
             (UNSET, "UNSET constant"),
-            
             # Complex data structures
             ({"key": "value", "number": 42}, "dictionary with mixed types"),
             ({}, "empty dictionary"),
@@ -59,17 +55,17 @@ class TestValidateUpdateAttributesParam:
             ([], "empty list"),
             (
                 {"nested": {"data": [1, 2, 3]}, "list": ["a", "b", {"inner": "value"}]},
-                "nested data structure"
+                "nested data structure",
             ),
         ],
-        ids=lambda x: x[1] if isinstance(x, tuple) else str(x)
+        ids=lambda x: x[1] if isinstance(x, tuple) else str(x),
     )
     def test_validate_accepts_all_input_types(self, test_value, description):
         """Test that validate_update_attributes_param accepts all input types.
-        
+
         Tests the permissive nature of the UpdateAttributes processor validator
         by verifying it returns True for any input type.
-        
+
         Parameters
         ----------
         test_value : Any
@@ -106,33 +102,36 @@ class TestUpdateAttributesValidatorRegistration:
         [
             (
                 "test_value",
-                {"extra_param": "ignored", "another_kwarg": 42, "complex_kwarg": {"nested": "data"}},
-                "string value with multiple kwargs"
+                {
+                    "extra_param": "ignored",
+                    "another_kwarg": 42,
+                    "complex_kwarg": {"nested": "data"},
+                },
+                "string value with multiple kwargs",
             ),
             (
                 None,
-                {"processor_name": "update_attributes", "dataset_info": {"source": "test"}},
-                "None value with processor-specific kwargs"
+                {
+                    "processor_name": "update_attributes",
+                    "dataset_info": {"source": "test"},
+                },
+                "None value with processor-specific kwargs",
             ),
             (
                 42,
                 {"param1": "value1", "param2": [1, 2, 3]},
-                "numeric value with mixed kwargs"
+                "numeric value with mixed kwargs",
             ),
-            (
-                {"data": "test"},
-                {},
-                "dictionary value with no kwargs"
-            ),
+            ({"data": "test"}, {}, "dictionary value with no kwargs"),
         ],
-        ids=lambda x: x[2] if isinstance(x, tuple) else str(x)
+        ids=lambda x: x[2] if isinstance(x, tuple) else str(x),
     )
     def test_validate_with_kwargs(self, value, kwargs, description):
         """Test validate_update_attributes_param with keyword arguments.
 
         Tests that the validator properly handles keyword arguments
         (which are ignored per the function signature) and still returns True.
-        
+
         Parameters
         ----------
         value : Any

--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -76,7 +76,7 @@ class TestValidateUpdateAttributesParam:
         # Resolve the UNSET placeholder to the actual constant
         if test_value == "__UNSET__":
             test_value = UNSET
-            
+
         result = validate_update_attributes_param(test_value)
         assert result is True, f"Validator should accept {description}: {test_value}"
 

--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -135,3 +135,26 @@ class TestUpdateAttributesValidatorRegistration:
         # Verify that the update_attributes validator is registered
         assert "update_attributes" in _PROCESSOR_VALIDATOR_REGISTRY
         assert _PROCESSOR_VALIDATOR_REGISTRY["update_attributes"] is validate_update_attributes_param
+
+    def test_validate_with_kwargs(self):
+        """Test validate_update_attributes_param with keyword arguments.
+        
+        Tests that the validator properly handles keyword arguments
+        (which are ignored per the function signature) and still returns True.
+        """
+        # Test with various kwargs - they should all be ignored
+        result = validate_update_attributes_param(
+            "test_value", 
+            extra_param="ignored",
+            another_kwarg=42,
+            complex_kwarg={"nested": "data"}
+        )
+        assert result is True
+        
+        # Test with only kwargs, no positional value
+        result = validate_update_attributes_param(
+            None,
+            processor_name="update_attributes",
+            dataset_info={"source": "test"}
+        )
+        assert result is True

--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -47,7 +47,7 @@ class TestValidateUpdateAttributesParam:
             (False, "boolean False"),
             # Special values
             (None, "None value"),
-            (UNSET, "UNSET constant"),
+            ("__UNSET__", "UNSET constant"),  # Use string placeholder
             # Complex data structures
             ({"key": "value", "number": 42}, "dictionary with mixed types"),
             ({}, "empty dictionary"),
@@ -73,6 +73,10 @@ class TestValidateUpdateAttributesParam:
         description : str
             Human-readable description of the test case.
         """
+        # Resolve the UNSET placeholder to the actual constant
+        if test_value == "__UNSET__":
+            test_value = UNSET
+            
         result = validate_update_attributes_param(test_value)
         assert result is True, f"Validator should accept {description}: {test_value}"
 

--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -41,3 +41,29 @@ class TestValidateUpdateAttributesParam:
         
         result = validate_update_attributes_param("complex string with spaces and 123")
         assert result is True
+
+    def test_validate_with_numeric_values(self):
+        """Test validate_update_attributes_param with numeric inputs.
+        
+        Tests that the validator accepts various numeric types (int, float)
+        and returns True for all of them.
+        """
+        # Test with integer values
+        result = validate_update_attributes_param(42)
+        assert result is True
+        
+        result = validate_update_attributes_param(0)
+        assert result is True
+        
+        result = validate_update_attributes_param(-100)
+        assert result is True
+        
+        # Test with float values
+        result = validate_update_attributes_param(3.14159)
+        assert result is True
+        
+        result = validate_update_attributes_param(0.0)
+        assert result is True
+        
+        result = validate_update_attributes_param(-2.5)
+        assert result is True

--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -67,3 +67,32 @@ class TestValidateUpdateAttributesParam:
         
         result = validate_update_attributes_param(-2.5)
         assert result is True
+
+    def test_validate_with_complex_data_types(self):
+        """Test validate_update_attributes_param with complex data structures.
+        
+        Tests that the validator accepts dictionaries, lists, and other
+        complex data types, demonstrating its permissive nature.
+        """
+        # Test with dictionary
+        result = validate_update_attributes_param({"key": "value", "number": 42})
+        assert result is True
+        
+        # Test with empty dictionary
+        result = validate_update_attributes_param({})
+        assert result is True
+        
+        # Test with list
+        result = validate_update_attributes_param([1, 2, 3, "test"])
+        assert result is True
+        
+        # Test with empty list
+        result = validate_update_attributes_param([])
+        assert result is True
+        
+        # Test with nested structures
+        result = validate_update_attributes_param({
+            "nested": {"data": [1, 2, 3]},
+            "list": ["a", "b", {"inner": "value"}]
+        })
+        assert result is True

--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -1,0 +1,43 @@
+"""
+Unit tests for climakitae/new_core/param_validation/update_attributes_param_validator.py
+
+This module contains comprehensive unit tests for the validate_update_attributes_param
+function that provides parameter validation for the UpdateAttributes processor.
+"""
+
+import warnings
+
+from climakitae.core.constants import UNSET
+from climakitae.new_core.param_validation.update_attributes_param_validator import (
+    validate_update_attributes_param,
+)
+
+# Suppress known external warnings that are not relevant to our tests
+warnings.filterwarnings(
+    "ignore",
+    message="The 'shapely.geos' module is deprecated",
+    category=DeprecationWarning,
+)
+warnings.filterwarnings(
+    "ignore", message="pkg_resources is deprecated", category=DeprecationWarning
+)
+
+
+class TestValidateUpdateAttributesParam:
+    """Test class for validate_update_attributes_param function."""
+
+    def test_validate_with_string_value(self):
+        """Test validate_update_attributes_param with string input.
+        
+        Tests that the validator accepts string values and returns True,
+        demonstrating the permissive nature of the UpdateAttributes processor.
+        """
+        # Test with various string values
+        result = validate_update_attributes_param("test_string")
+        assert result is True
+        
+        result = validate_update_attributes_param("")
+        assert result is True
+        
+        result = validate_update_attributes_param("complex string with spaces and 123")
+        assert result is True

--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -96,3 +96,24 @@ class TestValidateUpdateAttributesParam:
             "list": ["a", "b", {"inner": "value"}]
         })
         assert result is True
+
+    def test_validate_with_special_values(self):
+        """Test validate_update_attributes_param with special values.
+        
+        Tests that the validator accepts None and UNSET values,
+        which are mentioned as potentially valid in the source code.
+        """
+        # Test with None (mentioned as potentially valid in source comments)
+        result = validate_update_attributes_param(None)
+        assert result is True
+        
+        # Test with UNSET (mentioned as accepted in source comments)
+        result = validate_update_attributes_param(UNSET)
+        assert result is True
+        
+        # Test with boolean values
+        result = validate_update_attributes_param(True)
+        assert result is True
+        
+        result = validate_update_attributes_param(False)
+        assert result is True

--- a/tests/new_core/param_validation/test_update_attributes_param_validator.py
+++ b/tests/new_core/param_validation/test_update_attributes_param_validator.py
@@ -117,3 +117,21 @@ class TestValidateUpdateAttributesParam:
         
         result = validate_update_attributes_param(False)
         assert result is True
+
+
+class TestUpdateAttributesValidatorRegistration:
+    """Test class for UpdateAttributes validator registration."""
+
+    def test_validator_registration(self):
+        """Test that validate_update_attributes_param is properly registered.
+        
+        Tests that the validator function is correctly registered with the
+        processor validation system under the "update_attributes" key.
+        """
+        from climakitae.new_core.param_validation.abc_param_validation import (
+            _PROCESSOR_VALIDATOR_REGISTRY,
+        )
+        
+        # Verify that the update_attributes validator is registered
+        assert "update_attributes" in _PROCESSOR_VALIDATOR_REGISTRY
+        assert _PROCESSOR_VALIDATOR_REGISTRY["update_attributes"] is validate_update_attributes_param


### PR DESCRIPTION
## Summary of changes and related issue
This pull request adds comprehensive unit tests for the `validate_update_attributes_param` function, which is responsible for parameter validation in the UpdateAttributes processor. The new tests ensure that the validator correctly accepts all input types and is properly registered in the processor validation system.

Unit test additions for parameter validation:

* Added a test class `TestValidateUpdateAttributesParam` to verify that `validate_update_attributes_param` accepts a wide range of input types, including strings, numbers, booleans, special values, and complex data structures.
* Added tests to ensure the validator function is correctly registered in the `_PROCESSOR_VALIDATOR_REGISTRY` under the "update_attributes" key.
* Added parameterized tests to confirm that the validator properly handles and ignores keyword arguments, always returning `True`.

## Relevant motivation and context
tests are good

## How to test 
ci tests and `python -m pytest tests/new_core/param_validation/test_update_attributes_param_validator.py --cov=climakitae/new_core/param_validation/`

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
