### PR TITLE
Update type hint in get_data

### DIFF
--- a/climakitae/core/data_interface.py
+++ b/climakitae/core/data_interface.py
@@ -1920,7 +1920,7 @@ def get_data(
     downscaling_method: str = "Dynamical",
     data_type: str = "Gridded",
     approach: str = "Time",
-    scenario: str = None,
+    scenario: Union[str, list[str]] = None,
     units: str = None,
     warming_level: list[float] = None,
     area_subset: str = "none",


### PR DESCRIPTION
## Summary of changes and related issue
Update the scenario type hint in get_data.

## Relevant motivation and context
get_data can take either a string or list of strings for scenario (e.g. ["Historical Climate", "SSP 3-7.0"] or "Historical Climate" are both valid options).

## How to test 
Check that unit tests pass
Test a get_data call, e.g.
```
from climakitae.core.data_interface import get_data
data = get_data(
    variable="Air Temperature at 2m",
    resolution="9 km",
    timescale="hourly",
    data_type="Gridded",
    units="degC",
    scenario= ["Historical Climate", "SSP 3-7.0"],
    time_slice=(1990, 1999),
)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
