### PR TITLE
Changing 1-in-X dropna location

### DIFF
--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -756,27 +756,30 @@ def _get_return_variable(
         )
 
     if dropna_time:
-        # PRINTING TO USER which simulations and locations will be dropped before they're being dropped, since in `_return_variable`, the objects will be numpy arrays instead of xarray objects
-        # e.g. when an SSP has missing data at a warming level, when a warming level data that does beyond 2100
-        print(
-            "Dropping NaNs along time dimension for the following dimensions combinations:\n"
-        )
 
         # Finding the dimension name combos with timesteps that will be dropped
         bms_isnull = bms.isnull()
         isnull_mask = bms_isnull.stack(all_dims=bms_isnull.dims)
         vals_to_drop = isnull_mask.where(isnull_mask, drop=True)
-        all_dims_to_drop = vals_to_drop.unstack().isel(
-            time=0
-        )  # Selecting time=0 because we DON'T want the time dimension being printed out as well
-        dim_vals = [
-            all_dims_to_drop[dim].values.tolist() for dim in all_dims_to_drop.dims
-        ]
 
-        # Combining the dimension name combos into a printed output
-        for combo in product(*dim_vals):
-            print(f"  {dict(zip(all_dims_to_drop.dims, combo))}")
-        print("\n")
+        # Determining if we need to tell the user that there will be some NaNs dropped
+        if len(vals_to_drop) > 0:
+            # PRINTING TO USER which simulations and locations will be dropped before they're being dropped, since in `_return_variable`, the objects will be numpy arrays instead of xarray objects
+            # e.g. when an SSP has missing data at a warming level, when a warming level data that does beyond 2100
+            print(
+                "Dropping NaNs along time dimension for the following dimensions combinations:\n"
+            )
+            all_dims_to_drop = vals_to_drop.unstack().isel(
+                time=0
+            )  # Selecting time=0 because we DON'T want the time dimension being printed out as well
+            dim_vals = [
+                all_dims_to_drop[dim].values.tolist() for dim in all_dims_to_drop.dims
+            ]
+
+            # Combining the dimension name combos into a printed output
+            for combo in product(*dim_vals):
+                print(f"  {dict(zip(all_dims_to_drop.dims, combo))}")
+            print("\n")
 
     # get block_size from the block maxima series attributes, if available. otherwise assume block size=1 year
     if hasattr(bms, "block size"):


### PR DESCRIPTION
## Summary of changes and related issue
Currently, chaining `get_block_maxima` with `get_return_value/period/prob` (using dropna_time=True) doesn’t drop NaNs correctly. Since we only drop NaNs if all values along the time dimension are NaN, they remain for individual simulations. As a result, _return_variable leaves NaNs in each simulation, which later causes issues in `_conf_int` and `_calculate_return`.

So, this PR addresses this concern by:
1. Dropping the NaNs on a simulation by simulation basis
2. Letting the user know which combinations of dimensions the NaNs are being dropped for.

## Relevant motivation and context
We need to fix this bug, since it is causing issues in a notebook that IOUs are using: [`phase3.ipynb`](https://github.com/cal-adapt/cae-notebooks/blob/main/collaborative/IOU/8760/phase3.ipynb)

## How to test 
Run `collaborative/IOU/8760/one_in_x_in_8760.ipynb` in the cae-notebooks PR: https://github.com/cal-adapt/cae-notebooks/pull/189 (which is what the phase3.ipynb got renamed to), and make sure that all cells run correctly.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [ ] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [ ] Black formatting has been utilized
- [ ] Tagged/notified 2 reviewers for this PR
