### PR TITLE
Bugfix for cava_data one_in_x

### DIFF
--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -255,6 +255,12 @@ def _metric_agg(
         "max": np.max,
     }
 
+    # _apply_metric expects one_in_x to be an iterable
+    try:
+        _ = (x for x in one_in_x)
+    except TypeError:
+        one_in_x = [one_in_x]
+
     def _apply_metric(da):
         """
         Apply a statistical metric to climate data based on specified parameters.
@@ -977,8 +983,8 @@ def cava_data(
     if ssp_data is UNSET:
         ssp_data = ["SSP 3-7.0"]
 
-        # with param.exceptions_summarized():
-        # Convert `one_in_x` param to list if needed
+    # with param.exceptions_summarized():
+    # Convert `one_in_x` param to list if needed
     if one_in_x is not None:
         if not isinstance(one_in_x, list):
             one_in_x = [one_in_x]

--- a/tests/vulnerability/test_vulnerability.py
+++ b/tests/vulnerability/test_vulnerability.py
@@ -249,6 +249,47 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
         "simulation" in calc_val.dims
     ), "The expected output dimension of `metric_agg` 1-in-X has `simulation`."
 
+    # Percentile test where one-in-x variable not iterable
+    one_in_x_vals = np.array([10, 100])
+    calc_val = _metric_agg(
+        ds,
+        "Air Temperature at 2m",
+        np.arange(1, 13),
+        "time",
+        "max",
+        new_name,
+        None,
+        95,
+        None,
+        (1, "day"),
+        "gev",
+    )
+
+    assert (
+        type(calc_val) == xr.core.dataarray.DataArray
+    ), "The output type of `metric_agg` should be an xarray DataArray."
+    assert calc_val.shape == (
+        1,  # scenario
+        num_sims,  # simulation
+        1,  # y
+        1,  # x
+    ), "This is not an expected output shape of `metric_agg`."
+    assert (
+        "simulation" in calc_val.dims
+    ), "Simulation should remain in the expected output of `metric_agg`."
+    assert (
+        "time" not in calc_val.dims
+    ), "Time should not be in the dimensions after `metric_agg` is calculated."
+    assert (
+        "lat" in calc_val.coords and "lon" in calc_val.coords
+    ), "Lat and lon dimensions should exist after percentile `metric_calc`."
+    assert np.all(
+        calc_val < ds.max()
+    ), "95th yearly percentiles should all be below the max of the entire DataArray."
+    assert (
+        calc_val.name == new_name
+    ), "New name of DataArray should be carried on from argument."
+
 
 ### Listing out different parameters to test `cava_data` on
 inputs = [

--- a/tests/vulnerability/test_vulnerability.py
+++ b/tests/vulnerability/test_vulnerability.py
@@ -250,7 +250,6 @@ def test_metric_agg(test_dataarray_time_2030_2035_wrf_3km_hourly_temp):
     ), "The expected output dimension of `metric_agg` 1-in-X has `simulation`."
 
     # Percentile test where one-in-x variable not iterable
-    one_in_x_vals = np.array([10, 100])
     calc_val = _metric_agg(
         ds,
         "Air Temperature at 2m",


### PR DESCRIPTION
## Summary of changes and related issue
One_in_x is checked and converted to a list as needed in _metric_agg. None is not converted to a list in cava_data because that affects how validate_params() works.

We're now down to 77% for test coverage but I have added a test for this particular change.

## Relevant motivation and context
Gets unit tests passing for vulnerability

## How to test 
Check that test run in CI. Check that tests pass locally using:
`python -m pytest tests/vulnerability/test_vulnerability.py --cov=climakitae/explore/ --cov-report=term-missing`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [ ] Existing unit tests are passing
  - [x] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
