### PR TITLE
Fix/failing registry tests

### DIFF
--- a/tests/new_core/param_validation/test_abc_param_validation.py
+++ b/tests/new_core/param_validation/test_abc_param_validation.py
@@ -36,8 +36,14 @@ class TestRegisterCatalogValidator:
     """Test class for the register_catalog_validator decorator."""
 
     def setup_method(self):
-        """Clear the registry before each test."""
+        """Save original registry state and clear for testing."""
+        self._original_catalog_registry = _CATALOG_VALIDATOR_REGISTRY.copy()
         _CATALOG_VALIDATOR_REGISTRY.clear()
+    
+    def teardown_method(self):
+        """Restore original registry state."""
+        _CATALOG_VALIDATOR_REGISTRY.clear()
+        _CATALOG_VALIDATOR_REGISTRY.update(self._original_catalog_registry)
 
     def test_register_catalog_validator_successful(self):
         """Test successful registration of a catalog validator."""
@@ -95,8 +101,14 @@ class TestRegisterProcessorValidator:
     """Test class for the register_processor_validator decorator."""
 
     def setup_method(self):
-        """Clear the registry before each test."""
+        """Save original registry state and clear for testing."""
+        self._original_processor_registry = _PROCESSOR_VALIDATOR_REGISTRY.copy()
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
+    
+    def teardown_method(self):
+        """Restore original registry state."""
+        _PROCESSOR_VALIDATOR_REGISTRY.clear()
+        _PROCESSOR_VALIDATOR_REGISTRY.update(self._original_processor_registry)
 
     def test_register_processor_validator_successful(self):
         """Test successful registration of a processor validator."""
@@ -234,11 +246,17 @@ class TestHasValidProcesses:
 
     def setup_method(self):
         """Set up test fixtures."""
+        self._original_processor_registry = _PROCESSOR_VALIDATOR_REGISTRY.copy()
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
         with patch(
             "climakitae.new_core.param_validation.abc_param_validation.DataCatalog"
         ):
             self.validator = ConcreteValidator()
+    
+    def teardown_method(self):
+        """Restore original registry state."""
+        _PROCESSOR_VALIDATOR_REGISTRY.clear()
+        _PROCESSOR_VALIDATOR_REGISTRY.update(self._original_processor_registry)
 
     def test_has_valid_processes_no_processes(self):
         """Test _has_valid_processes with no processes in query."""
@@ -309,6 +327,7 @@ class TestIsValidQuery:
 
     def setup_method(self):
         """Set up test fixtures."""
+        self._original_processor_registry = _PROCESSOR_VALIDATOR_REGISTRY.copy()
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
         with patch(
             "climakitae.new_core.param_validation.abc_param_validation.DataCatalog"
@@ -334,6 +353,11 @@ class TestIsValidQuery:
                 "source_id": UNSET,
                 "grid_label": UNSET,
             }
+    
+    def teardown_method(self):
+        """Restore original registry state."""
+        _PROCESSOR_VALIDATOR_REGISTRY.clear()
+        _PROCESSOR_VALIDATOR_REGISTRY.update(self._original_processor_registry)
 
     def test_is_valid_query_successful_match(self):
         """Test _is_valid_query with successful dataset match."""
@@ -481,8 +505,17 @@ class TestParameterValidatorIntegration:
 
     def setup_method(self):
         """Set up test fixtures."""
+        self._original_catalog_registry = _CATALOG_VALIDATOR_REGISTRY.copy()
+        self._original_processor_registry = _PROCESSOR_VALIDATOR_REGISTRY.copy()
         _CATALOG_VALIDATOR_REGISTRY.clear()
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
+    
+    def teardown_method(self):
+        """Restore original registry states."""
+        _CATALOG_VALIDATOR_REGISTRY.clear()
+        _CATALOG_VALIDATOR_REGISTRY.update(self._original_catalog_registry)
+        _PROCESSOR_VALIDATOR_REGISTRY.clear()
+        _PROCESSOR_VALIDATOR_REGISTRY.update(self._original_processor_registry)
 
     def test_complete_validation_workflow(self):
         """Test complete validation workflow with catalog and processor validators."""

--- a/tests/new_core/param_validation/test_abc_param_validation.py
+++ b/tests/new_core/param_validation/test_abc_param_validation.py
@@ -39,7 +39,7 @@ class TestRegisterCatalogValidator:
         """Save original registry state and clear for testing."""
         self._original_catalog_registry = _CATALOG_VALIDATOR_REGISTRY.copy()
         _CATALOG_VALIDATOR_REGISTRY.clear()
-    
+
     def teardown_method(self):
         """Restore original registry state."""
         _CATALOG_VALIDATOR_REGISTRY.clear()
@@ -104,7 +104,7 @@ class TestRegisterProcessorValidator:
         """Save original registry state and clear for testing."""
         self._original_processor_registry = _PROCESSOR_VALIDATOR_REGISTRY.copy()
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
-    
+
     def teardown_method(self):
         """Restore original registry state."""
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
@@ -252,7 +252,7 @@ class TestHasValidProcesses:
             "climakitae.new_core.param_validation.abc_param_validation.DataCatalog"
         ):
             self.validator = ConcreteValidator()
-    
+
     def teardown_method(self):
         """Restore original registry state."""
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
@@ -353,7 +353,7 @@ class TestIsValidQuery:
                 "source_id": UNSET,
                 "grid_label": UNSET,
             }
-    
+
     def teardown_method(self):
         """Restore original registry state."""
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
@@ -509,7 +509,7 @@ class TestParameterValidatorIntegration:
         self._original_processor_registry = _PROCESSOR_VALIDATOR_REGISTRY.copy()
         _CATALOG_VALIDATOR_REGISTRY.clear()
         _PROCESSOR_VALIDATOR_REGISTRY.clear()
-    
+
     def teardown_method(self):
         """Restore original registry states."""
         _CATALOG_VALIDATOR_REGISTRY.clear()


### PR DESCRIPTION
## Summary of changes and related issue
Fixed registries to reset initial values after clearing so that this test stops failing.

## Relevant motivation and context
tests were failing

## How to test 
verify that the tests on the github ci no longer fail. Go to github actions, click re-run tests and confirm that the tests do not fail. This is almost entirely a product of running a bunch of tests back-to-back and in parallel. If you want to test this on your local machine you can run `python -m pytest tests/new_core/param_validation/test_abc_param_validation.py tests/new_core/param_validation/test_update_attributes_param_validator.py` and confirm that things run successfully when run back to back like this.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
