### PR TITLE
Fix/cava data file naming

### DIFF
--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -1129,16 +1129,28 @@ def cava_data(
             for _, data_point in enumerate(loaded_data):
                 lat_str = str(round(data_point.lat.item(), 6)).replace(".", "-")
                 lon_str = str(abs(round(data_point.lon.item(), 6))).replace(".", "-")
-                filename_str = f"{clean_params['raw_name']}_" f"{lat_str}N_{lon_str}W"
+                loc_suffix = f"{lat_str}N_{lon_str}W"
+                if file_name is None:
+                    filename_str = f"{clean_params['raw_name']}_{loc_suffix}"
+                else:
+                    # Append location info and _raw suffix to custom filename
+                    filename_str = f"{file_name}_raw_{loc_suffix}"
                 _export_no_e(
                     data_point,
-                    filename=filename_str if file_name is None else file_name,
+                    filename=filename_str,
                     file_format=file_format,
                 )
         else:
+            if file_name is None:
+                raw_filename = "combined_raw_data"
+            else:
+                # Add _raw suffix when export_method="both" to avoid name collision
+                raw_filename = (
+                    f"{file_name}_raw" if export_method == "both" else file_name
+                )
             _export_no_e(
                 loaded_data,
-                filename="combined_raw_data" if file_name is None else file_name,
+                filename=raw_filename,
                 file_format=file_format,
             )
 
@@ -1196,19 +1208,30 @@ def cava_data(
                     lon_str = str(abs(round(data_point.lon.item(), 6))).replace(
                         ".", "-"
                     )
+                    loc_suffix = f"{lat_str}N_{lon_str}W"
+                    if file_name is None:
+                        calc_filename = f"{clean_params['calc_name']}_{loc_suffix}"
+                    else:
+                        # Append location info and _calculated suffix to custom filename
+                        calc_filename = f"{file_name}_calculated_{loc_suffix}"
                     _export_no_e(
                         data_point,
-                        filename=(
-                            f"{clean_params['calc_name']}_{lat_str}N_{lon_str}W"
-                            if file_name is None
-                            else file_name
-                        ),
+                        filename=calc_filename,
                         file_format=file_format,
-                    )  # Will need to include naming convention for calculated file too.
+                    )
             else:
+                if file_name is None:
+                    calc_filename = "metric_data"
+                else:
+                    # Add _calculated suffix when export_method="both" to avoid name collision
+                    calc_filename = (
+                        f"{file_name}_calculated"
+                        if export_method == "both"
+                        else file_name
+                    )
                 _export_no_e(
                     metric_data,
-                    filename="metric_data" if file_name is None else file_name,
+                    filename=calc_filename,
                     file_format=file_format,
                 )
             # Returning values to user

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -606,7 +606,10 @@ class CavaParams(param.Parameterized):
         doc="Distribution function",
     )
     event_duration = param.Tuple(default=(1, "day"))
-    file_name = param.String(default="cava_output", doc="Base name for output files")
+    file_name = param.String(
+        default="cava_output",
+        doc="Base name for output files, no extension (e.g., 'output', not 'output.nc').",
+    )
 
     def __init__(self, **params):
         super().__init__(**params)
@@ -1124,8 +1127,8 @@ def cava_data(
 
         if separate_files:
             for _, data_point in enumerate(loaded_data):
-                lat_str = str(round(data_point.lat.item(), 6)).replace(".", "")
-                lon_str = str(round(data_point.lon.item(), 6)).replace(".", "")
+                lat_str = str(round(data_point.lat.item(), 6)).replace(".", "-")
+                lon_str = str(abs(round(data_point.lon.item(), 6))).replace(".", "-")
                 filename_str = f"{clean_params['raw_name']}_" f"{lat_str}N_{lon_str}W"
                 _export_no_e(
                     data_point,
@@ -1189,8 +1192,10 @@ def cava_data(
         case "calculate" | "both":
             if separate_files:
                 for _, data_point in enumerate(metric_data):
-                    lat_str = str(round(data_point.lat.item(), 6)).replace(".", "")
-                    lon_str = str(round(data_point.lon.item(), 6)).replace(".", "")
+                    lat_str = str(round(data_point.lat.item(), 6)).replace(".", "-")
+                    lon_str = str(abs(round(data_point.lon.item(), 6))).replace(
+                        ".", "-"
+                    )
                     _export_no_e(
                         data_point,
                         filename=(

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -1058,6 +1058,12 @@ def cava_data(
         )
 
     if batch_mode:
+        print(
+            "[WARNING] Batch mode is active, 'separate_files' is being set to False. "
+        )
+        print(
+            "[WARNING] This means that your output will be a single file with all locations included. \n"
+        )
         separate_files = False
         data_pts = batch_select(approach, selections, locations)
 

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -918,6 +918,7 @@ def cava_data(
     file_format="NetCDF",
     batch_mode=False,
     distr="gev",
+    file_name=None,  # override for export file name
 ):
     """Retrieve, process, and export climate data based on inputs.
 
@@ -1117,18 +1118,20 @@ def cava_data(
             )
 
         if separate_files:
-            for pt_idx, data_point in enumerate(loaded_data):
-                lat_str = str(round(data_point.lat.item(), 3)).replace(".", "")
-                lon_str = str(round(data_point.lon.item(), 3)).replace(".", "")
+            for _, data_point in enumerate(loaded_data):
+                lat_str = str(round(data_point.lat.item(), 6)).replace(".", "")
+                lon_str = str(round(data_point.lon.item(), 6)).replace(".", "")
                 filename_str = f"{clean_params['raw_name']}_" f"{lat_str}N_{lon_str}W"
                 _export_no_e(
                     data_point,
-                    filename=filename_str,
+                    filename=filename_str if file_name is None else file_name,
                     file_format=file_format,
                 )
         else:
             _export_no_e(
-                loaded_data, filename="combined_raw_data", file_format=file_format
+                loaded_data,
+                filename="combined_raw_data" if file_name is None else file_name,
+                file_format=file_format,
             )
 
         if export_method == "raw":
@@ -1181,16 +1184,22 @@ def cava_data(
         case "calculate" | "both":
             if separate_files:
                 for _, data_point in enumerate(metric_data):
-                    lat_str = str(round(data_point.lat.item(), 3)).replace(".", "")
-                    lon_str = str(round(data_point.lon.item(), 3)).replace(".", "")
+                    lat_str = str(round(data_point.lat.item(), 6)).replace(".", "")
+                    lon_str = str(round(data_point.lon.item(), 6)).replace(".", "")
                     _export_no_e(
                         data_point,
-                        filename=f"{clean_params['calc_name']}_{lat_str}N_{lon_str}W",
+                        filename=(
+                            f"{clean_params['calc_name']}_{lat_str}N_{lon_str}W"
+                            if file_name is None
+                            else file_name
+                        ),
                         file_format=file_format,
                     )  # Will need to include naming convention for calculated file too.
             else:
                 _export_no_e(
-                    metric_data, filename="metric_data", file_format=file_format
+                    metric_data,
+                    filename="metric_data" if file_name is None else file_name,
+                    file_format=file_format,
                 )
             # Returning values to user
             if len(metric_data) == 1:

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -607,8 +607,9 @@ class CavaParams(param.Parameterized):
     )
     event_duration = param.Tuple(default=(1, "day"))
     file_name = param.String(
-        default="cava_output",
-        doc="Base name for output files, no extension (e.g., 'output', not 'output.nc').",
+        default=None,
+        allow_None=True,
+        doc="Base name for output files, no extension (e.g., 'output', not 'output.nc'). If None, automatic naming will be used.",
     )
 
     def __init__(self, **params):

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -493,7 +493,7 @@ class CavaParams(param.Parameterized):
         Duration and unit for event analysis. Format: (duration, unit).
         Unit options: "hour", "day".
     file_name: str
-        Base name for output files.
+        Base name for output files, no extension (e.g., "output", not "output.nc").
 
     Methods
     -------
@@ -973,6 +973,8 @@ def cava_data(
         Whether to process data with batch mode or through iterating through the points.
     distr : str
         Name of distribution to use
+    file_name : str, optional
+        Base name for output files, no extension (e.g., "output", not "output.nc").
 
     Returns
     -------

--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -492,6 +492,8 @@ class CavaParams(param.Parameterized):
     event_duration : tuple, default=(1, "day")
         Duration and unit for event analysis. Format: (duration, unit).
         Unit options: "hour", "day".
+    file_name: str
+        Base name for output files.
 
     Methods
     -------
@@ -604,6 +606,7 @@ class CavaParams(param.Parameterized):
         doc="Distribution function",
     )
     event_duration = param.Tuple(default=(1, "day"))
+    file_name = param.String(default="cava_output", doc="Base name for output files")
 
     def __init__(self, **params):
         super().__init__(**params)


### PR DESCRIPTION
## Summary of changes and related issue
Allow file naming for cava_data, as well as improve automatic file naming.

## Relevant motivation and context
request from SCE but also just good practice

## How to test 
Check that cava_data accepts a new file name, or if you pass a single lat/lon it uses 6 significant figures, instead of 3. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [ ] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
