### PR TITLE
Update types in internal return value code

### DIFF
--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -656,7 +656,7 @@ def _conf_int(
     data_variable : str
         can be return_value, return_prob, return_period
     arg_value : np.ndarray
-        value to do the calucation to
+        value to do the calculation to
     bootstrap_runs : int
         Number of bootstrap samples
     conf_int_lower_bound : float
@@ -720,7 +720,7 @@ def _get_return_variable(
     data_variable : str
         can be return_value, return_prob, return_period
     arg_value : float
-        value to do the calucation to
+        value to do the calculation to
     distr : str
         name of distribution to use
     bootstrap_runs : int


### PR DESCRIPTION
## Summary of changes and related issue
I force the return type of _calculate_return to be an np.array and update type hints accordingly.

## Relevant motivation and context
In its current state, the code will fail in line 679 with "ValueError: all input arrays must have the same shape". This is because `_calculate_return` will not always return a numpy array, making it impossible to stack a mix of arrays and floats. This usually happens when the result is an NaN rather than a quantity calculated from `arg_value`. If it's supposed to fail on NaNs then we need a better way of doing that.

Because we set `arg_value` to be an array in `_get_return_value` (shown below), this type will get propagated to `_calculate_return` and is also expected in `_conf_int`, where the error gets thrown.
https://github.com/cal-adapt/climakitae/blob/a4bdd21bd81aaf64276f44de21aff45909f85c19/climakitae/explore/threshold_tools.py#L740-L741

## How to test 
Run the threshold_tools tests with pytest.
```
python -m pytest tests/threshold_tools --cov=climakitae/explore/
```
Test Code: If you want to check out the error in question, this code will raise it in `main` but succeed in this branch.
```
from climakitae.explore.threshold_tools import (
    get_block_maxima,
    get_return_period,
)
import numpy as np
import xarray as xr

data = np.array([ 5.0357594, 14.900803 ,  4.5243254, 18.52433  ,  4.521909 ,
        3.900494 ,  3.5338755, 19.681208 ,  1.4915371,  8.375433 ,
        4.7592716,  8.871006 ,  9.929342 , 12.808487 ,  3.9134858,
        5.2176523, 11.781528 ,  5.4759784, 10.235327 ,  4.515637 ,
        8.60412  , 15.099203 ,  9.714588 ,  6.3188353,  5.1161747,
        5.917504 ,  6.9771423,  9.004663 ,  9.75426  ,  2.050213 ], dtype="float32")
time = np.array(['2000-12-31T00:00:00.000000000', '2001-12-31T00:00:00.000000000',
       '2002-12-31T00:00:00.000000000', '2003-12-31T00:00:00.000000000',
       '2004-12-31T00:00:00.000000000', '2005-12-31T00:00:00.000000000',
       '2006-12-31T00:00:00.000000000', '2007-12-31T00:00:00.000000000',
       '2008-12-31T00:00:00.000000000', '2009-12-31T00:00:00.000000000',
       '2010-12-31T00:00:00.000000000', '2011-12-31T00:00:00.000000000',
       '2012-12-31T00:00:00.000000000', '2013-12-31T00:00:00.000000000',
       '2014-12-31T00:00:00.000000000', '2015-12-31T00:00:00.000000000',
       '2016-12-31T00:00:00.000000000', '2017-12-31T00:00:00.000000000',
       '2018-12-31T00:00:00.000000000', '2019-12-31T00:00:00.000000000',
       '2020-12-31T00:00:00.000000000', '2021-12-31T00:00:00.000000000',
       '2022-12-31T00:00:00.000000000', '2023-12-31T00:00:00.000000000',
       '2024-12-31T00:00:00.000000000', '2025-12-31T00:00:00.000000000',
       '2026-12-31T00:00:00.000000000', '2027-12-31T00:00:00.000000000',
       '2028-12-31T00:00:00.000000000', '2029-12-31T00:00:00.000000000'],dtype='datetime64[ns]')
ams = xr.DataArray(data,coords={"time":time})
ams.attrs["units"] = "inches"
rv = get_return_period(
    ams, return_value=32.13841, multiple_points=False, dropna_time=False
)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [ ] Advanced Testing passing (select Advanced Testing label)
- [x] Documentation
  - [x] Intent of all functions included
  - [x] Complex code commented
  - [x] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [x] Naming conventions followed
  - [x] Helper functions hidden with `_` before the name
- [ ] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
