### PR TITLE
Fix for custom longitude display in TMY

### DIFF
--- a/climakitae/explore/typical_meteorological_year.py
+++ b/climakitae/explore/typical_meteorological_year.py
@@ -404,15 +404,17 @@ class TMY:
                         "Do not set `latitude` and `longitude` when using a HadISD station for `station_name`. Change `station_name` value if using custom location."
                     )
                 else:
+                    # assumed longitude will always be western hemisphere
                     print(
-                        f"Initializing TMY object for custom location: {latitude} N, {longitude} W with name '{station_name}'."
+                        f"Initializing TMY object for custom location: {latitude} N, {abs(longitude)} W with name '{station_name}'."
                     )
                     self._set_loc_from_lat_lon(latitude, longitude)
                     self.stn_name = station_name
             # Case 2: lat/lon provided, no station_name string
             case float() | int(), float() | int(), object():
+                # assumed longitude will always be western hemisphere
                 print(
-                    f"Initializing TMY object for custom location: {latitude} N, {longitude} W."
+                    f"Initializing TMY object for custom location: {latitude} N, {abs(longitude)} W."
                 )
                 self._set_loc_from_lat_lon(latitude, longitude)
             # Case 3: station name provided, lat/lon not numeric


### PR DESCRIPTION
## Summary of changes and related issue
Change longitude display to always assume western hemisphere

## Relevant motivation and context
Easier to understand for California

## How to test 
Run tests locally: `python -m pytest tests/typical_meteorological_year/test_tmy.py --cov=climakitae/explore --cov-report=term-missing`

Create TMY object with lat/lon with or without custom station_name:
```
from climakitae.explore.typical_meteorological_year import  TMY

stn_name = "custom"
lat = 38.8
lon = -121.2
warming_level = 2.0
# Initialize TMY object
tmy = TMY(warming_level=warming_level,latitude=lat,longitude=lon,station_name=stn_name)

# Prints: Initializing TMY object for custom location: 38.8 N, 121.2 W with name 'custom'.
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New tests (increased test coverage on existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] None of the above  

## To-Do
- [x] Unit tests
  - [x] Existing unit tests are passing
  - [ ] If relevant, new unit tests are written (required 80% unit test coverage)
  - [x] Advanced Testing passing (select Advanced Testing label)
- [ ] Documentation
  - [ ] Intent of all functions included
  - [ ] Complex code commented
  - [ ] Functions include [NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) 
- [ ] Naming conventions followed
  - [ ] Helper functions hidden with `_` before the name
- [x] Any notebooks known to utilize the affected functions are still working
- [x] Black formatting has been utilized
- [x] Tagged/notified 2 reviewers for this PR
