### PR TITLE
Fix/issue 720 - Resolve error with Dask datasets passed into `get_block_maxima` functions with `groupby_duration`

### DIFF
--- a/climakitae/explore/threshold_tools.py
+++ b/climakitae/explore/threshold_tools.py
@@ -140,6 +140,12 @@ def get_block_maxima(
                 "`grouped_duration` specification must be in days. example: `grouped_duration = (3, 'day')`."
             )
 
+        # Rechunk time dimension if dask-backed to ensure chunks are large enough
+        # for the rolling window. After groupby resampling, chunks may be smaller
+        # than the rolling window size, causing a ValueError.
+        if hasattr(da_series.data, "chunks"):
+            da_series = da_series.chunk(time=-1)
+
         # Now select the min (max) from the duration period
         match extremes_type:
             case "max":

--- a/climakitae/new_core/processors/processor_utils.py
+++ b/climakitae/new_core/processors/processor_utils.py
@@ -467,6 +467,12 @@ def _apply_grouped_duration_filter_vectorized(
             "`grouped_duration` specification must be in days. example: `grouped_duration = (3, 'day')`."
         )
 
+    # Rechunk time dimension if dask-backed to ensure chunks are large enough
+    # for the rolling window. After groupby resampling, chunks may be smaller
+    # than the rolling window size, causing a ValueError.
+    if hasattr(da.data, "chunks"):
+        da = da.chunk(time=-1)
+
     # Use vectorized rolling operations
     if extremes_type == "max":
         return da.rolling(time=dur2_len, center=False).min()


### PR DESCRIPTION
## Summary of changes and related issue
This PR rechunks the time dimension in `get_block_maxima` and `_get_block_maxima_optimized` code if a Dask dataset is passed along with a `groupby_duration` parameter.

## Link to corresponding Jira ticket(s)
https://eaglerockanalytics.atlassian.net/jira/software/c/projects/AE/boards/12?assignee=712020%3A90be8adb-f03d-497a-b14b-752f14cb89b2&selectedIssue=AE-1253

## Testing
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed

## How to Test
Reviewers should run this notebook and ensure that it works, and test around with different parameters across `groupby`, `groupby_duration`, and `duration` (more documentation into how to use those 3 parameters here: 
https://github.com/cal-adapt/cae-notebooks/blob/main/analysis/threshold_event_types.ipynb

Notebook to run:
[rechunk_testing.ipynb](https://github.com/user-attachments/files/25195377/rechunk_testing.ipynb)

You can also run the above notebook on main and ensure that it's breaking there ^



## Documentation
- [x] Complex code includes comments explaining logic

## Code Quality
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase

## Review Process
- [x] PR review instructions provided:
  - [ ] Type of review requested (scientific/technical/debugging)
  - [ ] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
