### PR TITLE
Changing file exports from `cava_data` to include `multi_pts` for `batch_mode=True` or `separate_files=False`

### DIFF
--- a/climakitae/explore/vulnerability.py
+++ b/climakitae/explore/vulnerability.py
@@ -92,14 +92,14 @@ def _check_filenames(
     else:
         if export_method in ("raw", "both"):
             if file_name is None:
-                filenames.append("combined_raw_data")
+                filenames.append(f"{clean_params['raw_name']}_multi_pts")
             else:
                 filenames.append(
                     f"{file_name}_raw" if export_method == "both" else file_name
                 )
         if export_method in ("calculate", "both"):
             if file_name is None:
-                filenames.append("metric_data")
+                filenames.append(f"{clean_params['calc_name']}_multi_pts")
             else:
                 filenames.append(
                     f"{file_name}_calculated" if export_method == "both" else file_name
@@ -1297,7 +1297,7 @@ def cava_data(
                 )
         else:
             if file_name is None:
-                raw_filename = "combined_raw_data"
+                raw_filename = f"{clean_params['raw_name']}_multi_pts"
             else:
                 # Add _raw suffix when export_method="both" to avoid name collision
                 raw_filename = (
@@ -1382,7 +1382,7 @@ def cava_data(
                     )
             else:
                 if file_name is None:
-                    calc_filename = "metric_data"
+                    calc_filename = f"{clean_params['calc_name']}_multi_pts"
                 else:
                     # Add _calculated suffix when export_method="both" to avoid name collision
                     calc_filename = (


### PR DESCRIPTION
## Summary of changes and related issue
Changing file exports from `cava_data` to include `multi_pts` and not export files just as `metric_data` or `combined_raw_data`, since separate `cava_data` calls may create the same files if they both have `batch_mode=True` or `separate_files=False`

## Link to corresponding Jira ticket(s)
Addressing comment in https://github.com/cal-adapt/cae-notebooks/pull/229

## How to Test
Run `vulnerability_assessment.ipynb` and make sure it all runs.

## Code Quality
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase

## Review Process
- [x] PR review instructions provided:
  - [ ] Type of review requested (scientific/technical/debugging)
  - [ ] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
