### PR TITLE
Resolving FutureWarning with `xr.to_datetimeindex`

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -1814,7 +1814,7 @@ def _station_apply(
             # Bias correct the data
             da_adj = QDM.adjust(data_sliced)
             da_adj.name = gridded_da.name  # Rename it to get back to original name
-            da_adj["time"] = da_adj.indexes["time"].to_datetimeindex()
+            da_adj["time"] = da_adj.indexes["time"].to_datetimeindex(time_unit="ns")
 
             # Ensure bias_adjustment attribute is present. xsdba's adjust
             # implementation usually sets this, but in some execution paths

--- a/climakitae/explore/uncertainty.py
+++ b/climakitae/explore/uncertainty.py
@@ -91,7 +91,7 @@ def _cf_to_dt(ds: xr.Dataset) -> xr.Dataset:
 
     """
     if type(ds.indexes["time"]) not in [pd.core.indexes.datetimes.DatetimeIndex]:
-        datetimeindex = ds.indexes["time"].to_datetimeindex()
+        datetimeindex = ds.indexes["time"].to_datetimeindex(time_unit="ns")
         ds["time"] = datetimeindex
     return ds
 

--- a/climakitae/new_core/processors/bias_adjust_model_to_station.py
+++ b/climakitae/new_core/processors/bias_adjust_model_to_station.py
@@ -492,7 +492,7 @@ class BiasAdjustModelToStation(DataProcessor):
         try:
             time_index = da_adj.indexes["time"]
             if hasattr(time_index, "to_datetimeindex"):
-                da_adj["time"] = time_index.to_datetimeindex()
+                da_adj["time"] = time_index.to_datetimeindex(time_unit="ns")
             else:
                 # Fallback if to_datetimeindex not available
                 da_adj = da_adj.convert_calendar("standard", use_cftime=False)


### PR DESCRIPTION
## Summary of changes and related issue
Resolving FutureWarning:

```
FutureWarning: In a future version of xarray to_datetimeindex will default to returning a 'us'-resolution DatetimeIndex instead of a 'ns'-resolution DatetimeIndex. This warning can be silenced by explicitly passing the `time_unit` keyword argument.
```

## Jira Ticket
https://eaglerockanalytics.atlassian.net/browse/AE-1365?atlOrigin=eyJpIjoiY2MyOThlMzViMmQ4NDI5ZjhhY2UwZmY5MTkzOTU4MjIiLCJwIjoiaiJ9

## How to Test
Make sure this doesn't show any `xr.to_datetimeindex` warning anymore:
```
import climakitae as ck
## set station name
station_name = "KSAC"

# select historical data
cd = ck.ClimateData(verbosity=0)
data_at_station = (
    cd.catalog("cadcat")
    .activity_id("WRF")
    .experiment_id(["historical", "ssp370"])
    .institution_id("UCLA")
    .table_id("1hr")
    .grid_label("d02")
    .variable("t2")
    .processes(
        {
            "convert_to_local_time": {"convert": "yes"},
            "convert_units": "degF",
            "time_slice": (2005, 2025),
            "bias_adjust_model_to_station": {
                "stations": [station_name],
                "historical_slice": (
                    1980,
                    2014,
                ),  # You can specify what historical period to bias correct for.
            },
        }
    )
).get()
```