### PR TITLE
Restore processor registry in TestEdgeCases teardown

### DIFF
--- a/tests/new_core/processors/test_abc_data_processor.py
+++ b/tests/new_core/processors/test_abc_data_processor.py
@@ -386,10 +386,21 @@ class TestProcessorIntegration:
 class TestEdgeCases:
     """Test edge cases and error conditions."""
 
+    def setup_method(self):
+        """Snapshot and clear the registry before each test."""
+        global _PROCESSOR_REGISTRY
+        self._original_registry = _PROCESSOR_REGISTRY.copy()
+        _PROCESSOR_REGISTRY.clear()
+
+    def teardown_method(self):
+        """Restore the original registry after each test."""
+        global _PROCESSOR_REGISTRY
+        _PROCESSOR_REGISTRY.clear()
+        _PROCESSOR_REGISTRY.update(self._original_registry)
+
     def test_register_processor_with_empty_string_key(self):
         """Test registering with empty string key."""
         global _PROCESSOR_REGISTRY
-        _PROCESSOR_REGISTRY.clear()
 
         @register_processor(key="", priority=1)
         class EmptyKeyProcessor(DataProcessor):
@@ -407,7 +418,6 @@ class TestEdgeCases:
     def test_register_processor_with_none_priority(self):
         """Test registering with None priority."""
         global _PROCESSOR_REGISTRY
-        _PROCESSOR_REGISTRY.clear()
 
         @register_processor(key="none_priority", priority=None)
         class NonePriorityProcessor(DataProcessor):


### PR DESCRIPTION
## Summary of changes and related issue
`TestEdgeCases` in `test_abc_data_processor.py` called `_PROCESSOR_REGISTRY.clear()` inline without restoring it, permanently wiping the registry for any tests that ran after it in the same session. This caused downstream integration tests (e.g. TMY `_fetch_raw_variable_time/_warming_level`) to see all processors as 'not found in registry', so `data_access.get_data` returned a raw dict of datasets that was never concatenated or clipped, producing `'dict' object has no attribute 'dims'` assertion failures in `ci-main`.

Mirror the `setup_method`/`teardown_method` pattern already used in `TestRegistrySystem` and `TestProcessorIntegration` so edge-case tests isolate registry mutations.

## Link to corresponding Jira ticket(s)
None, this just makes sure that our tests on main don't fail.

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Appropriate manual testing completed
- [x] Advanced Testing label added to PR if this PR makes major changes to the codebase 

## How to Test
Just make sure the tests run in the ci and that the code looks fine.

## Documentation
- [x] Complex code includes comments explaining logic
- [x] Function documentation created (docstrings)

## Code Quality
- [x] Follows PEP8 naming and style conventions
- [x] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [x] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [x] PR review instructions provided:
  - [x] Type of review requested (scientific/technical/debugging)
  - [x] Level of review detail needed
