### PR TITLE
Enable new core clipping using a GeoDataFrame 

### DIFF
--- a/climakitae/new_core/param_validation/clip_param_validator.py
+++ b/climakitae/new_core/param_validation/clip_param_validator.py
@@ -9,6 +9,8 @@ import os
 import pprint
 from typing import Any, List, Tuple, Union
 
+import geopandas as gpd
+
 from climakitae.core.constants import UNSET
 from climakitae.new_core.data_access.data_access import DataCatalog
 from climakitae.new_core.param_validation.abc_param_validation import (
@@ -79,10 +81,12 @@ def validate_clip_param(
             return _validate_tuple_param(value)
         case dict():
             return _validate_dict_param(value)
+        case gpd.GeoDataFrame():
+            return True
         case _:
             logger.warning(
                 f"\n\nInvalid parameter type for Clip processor. "
-                f"\nExpected str, list, tuple, or dict, but got {type(value).__name__}. "
+                f"\nExpected str, list, tuple, dict, or GeoDataFrame, but got {type(value).__name__}. "
                 f"\nValid examples: 'CA', ['CA', 'OR'], ((32.0, 42.0), (-125.0, -114.0)), "
                 f"or {{'boundaries': ['CA', 'OR'], 'separated': True}}"
             )

--- a/climakitae/new_core/processors/clip.py
+++ b/climakitae/new_core/processors/clip.py
@@ -32,8 +32,9 @@ Clipping Modes
    - Single point: `Clip((lat, lon))` - returns closest gridcell
    - Multiple points: `Clip([(lat1, lon1), (lat2, lon2)])` - returns closest gridcells
 
-4. **Custom Geometry**: Clip using custom shapefiles
+4. **Custom Geometry**: Clip using custom shapefiles or GeoDataFrames
    - Shapefile path: `Clip("/path/to/shapefile.shp")`
+   - GeoDataFrame: `Clip(gdf)` where ``gdf`` is a ``geopandas.GeoDataFrame``
 
 Key Features
 ------------
@@ -146,12 +147,13 @@ class Clip(DataProcessor):
 
     Parameters
     ----------
-    value : str | list | tuple | dict
+    value : str | list | tuple | dict | gpd.GeoDataFrame
         The value(s) to clip the data by. Can be:
         - str: Single boundary key, file path, or coordinate specification
         - list: Multiple boundary keys of the same category OR list of (lat, lon) tuples
         - tuple: Coordinate bounds ((lat_min, lat_max), (lon_min, lon_max)) or single (lat, lon) point
         - dict: Configuration with ``boundaries`` or ``points`` key and optional flags
+        - gpd.GeoDataFrame: Clip directly using a GeoDataFrame geometry
 
     Examples
     --------
@@ -189,7 +191,7 @@ class Clip(DataProcessor):
 
         Parameters
         ----------
-        value : str | list | tuple | dict
+        value : str | list | tuple | dict | gpd.GeoDataFrame
             The value(s) to clip the data by. Can be:
             - str: Single boundary key, file path, station code/name, or coordinate specification
             - list: Multiple boundary keys, station codes/names, or (lat, lon) tuples for multiple points
@@ -201,6 +203,7 @@ class Clip(DataProcessor):
                 For points, extract along 'points' dimension instead of returning masked grid.
               - ``persist`` (bool): Compute data to memory after clipping (recommended for
                 multi-point clipping with downstream computations like 1-in-X analysis)
+            - gpd.GeoDataFrame: Clip directly using a GeoDataFrame geometry
         persist : bool, optional
             If True, compute the clipped data to memory after clipping. This collapses
             the Dask task graph, which is critical for efficient downstream operations

--- a/climakitae/new_core/processors/clip.py
+++ b/climakitae/new_core/processors/clip.py
@@ -364,9 +364,11 @@ class Clip(DataProcessor):
                         crs=pyproj.CRS.from_epsg(4326),
                         # 4326 is WGS84 i.e. lat/lon
                     )
+            case gpd.GeoDataFrame():
+                geom = self.value
             case _:
                 raise ValueError(
-                    f"Invalid value type for clipping. Expected str, list, or tuple but got {type(self.value)}."
+                    f"Invalid value type for clipping. Expected str, list, tuple, or GeoDataFrame but got {type(self.value)}."
                 )
 
         if (

--- a/climakitae/new_core/processors/clip.py
+++ b/climakitae/new_core/processors/clip.py
@@ -100,6 +100,12 @@ Examples
 >>> processor = Clip("/path/to/custom_boundary.shp")
 >>> clipped_data = processor.execute(dataset, context)
 
+>>> # GeoDataFrame
+>>> import geopandas as gpd
+>>> gdf = gpd.read_file("/path/to/custom_boundary.shp")
+>>> processor = Clip(gdf)
+>>> clipped_data = processor.execute(dataset, context)
+
 Notes
 -----
 - The processor requires a DataCatalog to access predefined boundary data
@@ -183,6 +189,11 @@ class Clip(DataProcessor):
     Multiple points extracted to dimension:
     >>> clip = Clip({"points": [(37.7749, -122.4194), (34.0522, -118.2437)], "separated": True})
     >>> # Returns data with 'points' dimension containing each location's values
+
+    GeoDataFrame:
+    >>> import geopandas as gpd
+    >>> gdf = gpd.read_file("/path/to/custom_boundary.shp")
+    >>> clip = Clip(gdf)
     """
 
     def __init__(self, value, persist: bool = False):

--- a/tests/new_core/processors/test_clip.py
+++ b/tests/new_core/processors/test_clip.py
@@ -910,6 +910,21 @@ class TestClipIntegrationCoordinateBounds:
         assert "x" in result.dims or "lon" in result.dims
         assert "y" in result.dims or "lat" in result.dims
 
+    def test_clip_with_geodataframe_input(self):
+        """Test that a GeoDataFrame can be passed directly as the clip value."""
+        gdf = gpd.GeoDataFrame(
+            geometry=[box(-122, 35, -118, 40)], crs=pyproj.CRS.from_epsg(4326)
+        )
+        clip = Clip(gdf)
+        context = {}
+
+        result = clip.execute(self.dataset, context)
+
+        assert result is not None
+        assert isinstance(result, xr.Dataset)
+        assert result.sizes["y"] < self.dataset.sizes["y"]
+        assert result.sizes["x"] < self.dataset.sizes["x"]
+
 
 class TestClipBoundaryValidation:
     """Integration tests for boundary validation methods."""


### PR DESCRIPTION
## Summary of changes and related issue
Added support for clipping using a GeoDataFrame in the clip processor. This was needed for the notebook refactor in `cae-notebooks` [#247](https://github.com/cal-adapt/cae-notebooks/pull/247), where clipping to a single row of a shapefile required passing a GeoDataFrame rather than the full shapefile path.

## Link to corresponding Jira ticket(s)
Kind of this one: https://eaglerockanalytics.atlassian.net/browse/AE-1242

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed
- [x] Advanced Testing label added to PR if this PR makes major changes to the codebase 

## How to Test
If you’re reviewing the PR in `cae-notebooks`, some code is there that uses the clipping function: https://github.com/cal-adapt/cae-notebooks/pull/247

Or, here’s an isolated code chunk you can use to test: 
```python 
import geopandas as gpd 

# Read in shapefile and filter for specific ROI
shapefile_all = gpd.read_file("https://geo.sandag.org/server/rest/directories/downloads/Hydrological_Basins_shapefile.zip")
roi = shapefile_all[shapefile_all["haname"] == "Brawley"] # GeoDataFrame object 

# Read in data and clip to gpd 
cd.reset()
climate_data = (cd
    .catalog("cadcat")       # Catalog name
    .activity_id("WRF")      # Downscaling method
    .experiment_id("ssp370") # SSP scenario
    .institution_id("UCLA")  # Institution name
    .table_id("mon")         # Data frequency
    .grid_label("d02")       # Grid resolution
    .variable("t2")          # Variable name
    .processes({"clip": roi})
).get()
climate_data
```

## Documentation
- [x] Complex code includes comments explaining logic
- [x] Function documentation created (docstrings)

## Code Quality
- [x] Follows PEP8 naming and style conventions
- [x] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [x] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [x] PR review instructions provided:
  - [x] Type of review requested (scientific/technical/debugging)
  - [x] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
