### PR TITLE
Updates TMY header for .csv and .tmy format

### DIFF
--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1633,6 +1633,7 @@ def write_tmy_file(
             with open(path_to_file, "w") as f:
                 f.writelines(
                     _tmy_header(
+                        filename,
                         location_name,
                         station_code,
                         stn_lat,

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1457,6 +1457,7 @@ def write_tmy_file(
         state: str,
         timezone: str,
         elevation: float,
+        years: Tuple[int, int],
         df: pd.DataFrame,
     ) -> list[str]:
         """Constructs the header for the TMY output file in .tmy format
@@ -1470,18 +1471,19 @@ def write_tmy_file(
         state : str
         timezone : str
         elevation : float
+        years : Tuple[int, int]
         df : pd.DataFrame
 
         Returns
         -------
         headers : list[str]
 
-        Source: https://www.nrel.gov/docs/fy08osti/43156.pdf (pg. 3)
+        Source: https://www.docs.nlr.gov/docs/fy08osti/43156.pdf (pg. 3)
 
         """
         # line 1 - site information
         # line 1: USAF, station name quote delimited, state, time zone, lat, lon, elev (m)
-        line_1 = "{0},'{1}',{2},{3},{4},{5},{6},{7}\n".format(
+        line_1 = "{0},'{1}',{2},{3},{4},{5},{6},Simulation: {7},TMY data produced using {8}-{9} climatological period, \n".format(
             station_code,
             location_name,
             state,
@@ -1489,7 +1491,10 @@ def write_tmy_file(
             stn_lat,
             stn_lon,
             elevation,
+            "Generated on: Cal-Adapt: Analytics Engine",
             df["sim"].values[0],
+            years[0],
+            years[1],
         )
 
         # line 2 - data field name and units, manually setting to ensure matches TMY3 labeling
@@ -1610,6 +1615,7 @@ def write_tmy_file(
                         state,
                         timezone,
                         elevation,
+                        years,
                         df,
                     )
                 )  # writes required header lines

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1483,7 +1483,7 @@ def write_tmy_file(
         """
         # line 1 - site information
         # line 1: USAF, station name quote delimited, state, time zone, lat, lon, elev (m)
-        line_1 = "{0},'{1}',{2},{3},{4},{5},{6},Simulation: {7},TMY data produced using {8}-{9} climatological period, \n".format(
+        line_1 = "{0},'{1}',{2},{3},{4},{5},{6},Generated on Cal-Adapt Analytics Engine, Simulation: {7},TMY data produced using {8}-{9} climatological period, ,\n".format(
             station_code,
             location_name,
             state,
@@ -1491,7 +1491,6 @@ def write_tmy_file(
             stn_lat,
             stn_lon,
             elevation,
-            "Generated on: Cal-Adapt: Analytics Engine",
             df["sim"].values[0],
             years[0],
             years[1],

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1633,7 +1633,7 @@ def write_tmy_file(
             with open(path_to_file, "w") as f:
                 f.writelines(
                     _tmy_header(
-                        filename,
+                        filename_to_export,
                         location_name,
                         station_code,
                         stn_lat,

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1449,7 +1449,28 @@ def write_tmy_file(
         case _:
             raise ValueError("station_code needs to be either str or int")
 
+    def _gwl_or_time_str(filename: str) -> str:
+        """Based on filename construction pass the appropriate approach to _tmy_header
+
+        Parameters
+        ----------
+        filename : str
+            name of TMY file to be exported
+
+        Returns
+        -------
+        str
+        """
+
+        # string matching for GWL or Time-based approach
+        gwl_str = {"warming", "present", "future", "century"}
+
+        if any(word in filename for word in gwl_str):
+            return "GWL"
+        return "Time-based"
+
     def _tmy_header(
+        filename: str,
         location_name: str,
         station_code: int,
         stn_lat: float,
@@ -1464,6 +1485,7 @@ def write_tmy_file(
 
         Parameters
         ----------
+        filename : str
         location_name : str
         station_code : int
         stn_lat : float
@@ -1481,9 +1503,12 @@ def write_tmy_file(
         Source: https://www.docs.nlr.gov/docs/fy08osti/43156.pdf (pg. 3)
 
         """
+        # custom filename approach handling
+        gwl_or_time = _gwl_or_time_str(filename)
+
         # line 1 - site information
         # line 1: USAF, station name quote delimited, state, time zone, lat, lon, elev (m)
-        line_1 = "{0},'{1}',{2},{3},{4},{5},{6},Generated on Cal-Adapt Analytics Engine, Simulation: {7},TMY data produced using {8}-{9} climatological period, ,\n".format(
+        line_1 = "{0},'{1}',{2},{3},{4},{5},{6},Generated on Cal-Adapt Analytics Engine, Simulation: {7},TMY data produced using {8}-{9} climatological period,Approach:{10},\n".format(
             station_code,
             location_name,
             state,
@@ -1494,6 +1519,7 @@ def write_tmy_file(
             df["sim"].values[0],
             years[0],
             years[1],
+            gwl_or_time,
         )
 
         # line 2 - data field name and units, manually setting to ensure matches TMY3 labeling

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1344,9 +1344,9 @@ def write_tmy_file(
     stn_lon: float,
     stn_state: str,
     stn_elev: float = 0.0,
-    file_ext: str = "tmy",
+    file_ext: str = "epw",
 ):
-    """Exports TMY data either as .epw or .tmy file
+    """Exports TMY data either as .epw, .csv, or .tmy file
 
     Parameters
     ----------
@@ -1369,7 +1369,7 @@ def write_tmy_file(
     stn_elev : float, optional
         Elevation of station, default is 0.0
     file_ext : str, optional
-        File extension for export, default is .tmy, options are "tmy" and "epw"
+        File extension for export, default is .epw, options are "epw", "csv", and "tmy"
 
     Returns
     -------
@@ -1496,6 +1496,7 @@ def write_tmy_file(
         line_2 = (
             ",".join(
                 [
+                    "time",
                     "Air temperature at 2m (degC)",
                     "Dew point temperature at 2m (degC)",
                     "Relative humidity (0-100)",

--- a/climakitae/core/data_export.py
+++ b/climakitae/core/data_export.py
@@ -1508,7 +1508,7 @@ def write_tmy_file(
 
         # line 1 - site information
         # line 1: USAF, station name quote delimited, state, time zone, lat, lon, elev (m)
-        line_1 = "{0},'{1}',{2},{3},{4},{5},{6},Generated on Cal-Adapt Analytics Engine, Simulation: {7},TMY data produced using {8}-{9} climatological period,Approach:{10},\n".format(
+        line_1 = "{0},'{1}',{2},{3},{4},{5},{6},Generated on Cal-Adapt Analytics Engine, Simulation: {7},TMY data produced using {8}-{9} climatological period,Approach: {10},\n".format(
             station_code,
             location_name,
             state,


### PR DESCRIPTION
## Summary of changes and related issue
Update to the tmy export function, specifically for `.csv` and `.tmy` format. 
- Previously a minor bug in the tmy header builder function did not include `time` as a variable so the header was shifted one column to the left.
- Updated the TMY data format reference to the new NLR link
- Updated the header to include references to Cal-Adapt in the metadata
- Sets the default file format option to be `.epw` not `.tmy`


## Link to corresponding Jira ticket(s)
https://eaglerockanalytics.atlassian.net/jira/software/c/projects/AE/boards/12?issueParent=17587&selectedIssue=AE-1528

## Testing
- [ ] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed

## How to Test
Technical / Debugging review only: Using the `custom_climate_profiles` notebook, please generate a TMY and export as `.csv` and/or `.tmy`. Please test GWL option and time-based option. 

## Documentation
- [x] Complex code includes comments explaining logic
- [x] NumPy-style docstrings added/updated for all new or modified public functions, classes, and modules

**Which of the following need updating? Check all that apply and complete them:**
- [ ] **API reference** (`docs-mkdocs/api/`) — add or update the `.md` file for the affected module (e.g. `processors.md`, `tools.md`, `util.md`)
- [ ] **Concept / architecture docs** (`docs-mkdocs/climate-data-interface/`) — update if you changed how a processor, validator, or data access component works
- [ ] **How-to guides** (`docs-mkdocs/climate-data-interface/howto/`) — add a new guide if you introduced a non-obvious workflow
- [ ] **Getting started / migration guides** (`docs-mkdocs/getting-started.md`, `docs-mkdocs/migration/`) — update if you changed the public API or added a new entry point
- [ ] **Notebook gallery** (`docs-mkdocs/notebook-gallery.md`) — add a link if this PR introduces a new example notebook
- [ ] **`MAINTAINERS.md`** — update release notes, secrets inventory, or CI table if you changed workflows or infrastructure

## Code Quality
- [ ] Follows PEP8 naming and style conventions
- [ ] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved
- [ ] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [ ] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [x] PR review instructions provided:
  - [x] Type of review requested (scientific/technical/debugging)
  - [x] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
