### PR TITLE
Changing `us_states` to `states` across new core

### DIFF
--- a/climakitae/new_core/data_access/boundaries.py
+++ b/climakitae/new_core/data_access/boundaries.py
@@ -695,9 +695,7 @@ class Boundaries:
 
     def get_states(self, name: Optional[str] = None) -> gpd.GeoDataFrame:
         """Return US western states boundary data."""
-        return self._lookup_boundary(
-            self._us_states, self._get_us_states, name, "State"
-        )
+        return self._lookup_boundary(self._states, self._get_states, name, "State")
 
     def get_counties(self, name: Optional[str] = None) -> gpd.GeoDataFrame:
         """Return California county boundary data."""

--- a/climakitae/new_core/data_access/boundaries.py
+++ b/climakitae/new_core/data_access/boundaries.py
@@ -83,7 +83,7 @@ class Boundaries:
 
     Properties
     ----------
-    _us_states : pd.DataFrame
+    _states : pd.DataFrame
         US western states with names, abbreviations, and geometries (lazy-loaded)
     _ca_counties : pd.DataFrame
         California counties with names and geometries, sorted alphabetically (lazy-loaded)
@@ -186,7 +186,7 @@ class Boundaries:
         self._cat = boundary_catalog
 
         # Private storage for lazy-loaded DataFrames
-        self.__us_states: Optional[pd.DataFrame] = None
+        self.__states: Optional[pd.DataFrame] = None
         self.__ca_counties: Optional[pd.DataFrame] = None
         self.__ca_watersheds: Optional[pd.DataFrame] = None
         self.__ca_utilities: Optional[pd.DataFrame] = None
@@ -229,18 +229,18 @@ class Boundaries:
             raise ValueError(f"Missing required catalog entries: {missing}")
 
     @property
-    def _us_states(self) -> pd.DataFrame:
+    def _states(self) -> pd.DataFrame:
         """Lazy-loaded US states data."""
-        if self.__us_states is None:
+        if self.__states is None:
             try:
-                self.__us_states = self._process_us_states(self._cat.states.read())
+                self.__states = self._process_states(self._cat.states.read())
             except Exception as e:
                 raise RuntimeError(f"Failed to load US states data: {e}") from e
-        return self.__us_states
+        return self.__states
 
-    @_us_states.setter
-    def _us_states(self, value: pd.DataFrame) -> None:
-        self.__us_states = value
+    @_states.setter
+    def _states(self, value: pd.DataFrame) -> None:
+        self.__states = value
 
     @property
     def _ca_counties(self) -> pd.DataFrame:
@@ -339,7 +339,7 @@ class Boundaries:
     def _ca_census_tracts(self, value: gpd.GeoDataFrame) -> None:
         self.__ca_census_tracts = value
 
-    def _process_us_states(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _process_states(self, df: pd.DataFrame) -> pd.DataFrame:
         """Process raw US states data.
 
         Parameters
@@ -443,7 +443,7 @@ class Boundaries:
         ].index
         return df.drop(tiny_caliso)
 
-    def _get_us_states(self) -> Dict[str, int]:
+    def _get_states(self) -> Dict[str, int]:
         """Get cached lookup dictionary for western US states.
 
         Returns
@@ -452,11 +452,11 @@ class Boundaries:
             Dictionary mapping state abbreviations to DataFrame indices
 
         """
-        if "us_states" not in self._lookup_cache:
-            self._lookup_cache["us_states"] = self._build_us_states_lookup()
-        return self._lookup_cache["us_states"]
+        if "states" not in self._lookup_cache:
+            self._lookup_cache["states"] = self._build_states_lookup()
+        return self._lookup_cache["states"]
 
-    def _build_us_states_lookup(self) -> Dict[str, int]:
+    def _build_states_lookup(self) -> Dict[str, int]:
         """Build lookup dictionary for western US states with custom ordering.
 
         Returns
@@ -465,14 +465,14 @@ class Boundaries:
             Dictionary mapping state abbreviations to DataFrame indices
 
         """
-        us_states_subset = self._us_states.query("abbrevs in @WESTERN_STATES_LIST")[
+        states_subset = self._states.query("abbrevs in @WESTERN_STATES_LIST")[
             ["abbrevs"]
         ]
-        us_states_subset["abbrevs"] = pd.Categorical(
-            us_states_subset["abbrevs"], categories=WESTERN_STATES_LIST
+        states_subset["abbrevs"] = pd.Categorical(
+            states_subset["abbrevs"], categories=WESTERN_STATES_LIST
         )
-        us_states_subset.sort_values(by="abbrevs", inplace=True)
-        return dict(zip(us_states_subset.abbrevs, us_states_subset.index))
+        states_subset.sort_values(by="abbrevs", inplace=True)
+        return dict(zip(states_subset.abbrevs, states_subset.index))
 
     def _get_ca_counties(self) -> Dict[str, int]:
         """Get cached lookup dictionary for California counties.
@@ -647,7 +647,7 @@ class Boundaries:
         return {
             "none": {"entire domain": 0},
             "lat/lon": {"coordinate selection": 0},
-            "states": self._get_us_states(),
+            "states": self._get_states(),
             "CA counties": self._get_ca_counties(),
             "CA watersheds": self._get_ca_watersheds(),
             "CA Electric Load Serving Entities (IOU & POU)": self._get_ious_pous(),
@@ -715,7 +715,7 @@ class Boundaries:
         """
         # Force loading of all properties
         _ = (
-            self._us_states,
+            self._states,
             self._ca_counties,
             self._ca_watersheds,
             self._ca_utilities,
@@ -726,7 +726,7 @@ class Boundaries:
 
         # Build all lookup caches
         _ = (
-            self._get_us_states(),
+            self._get_states(),
             self._get_ca_counties(),
             self._get_ca_watersheds(),
             self._get_forecast_zones(),
@@ -770,7 +770,7 @@ class Boundaries:
 
         """
         # Clear raw DataFrames
-        self.__us_states = None
+        self.__states = None
         self.__ca_counties = None
         self.__ca_watersheds = None
         self.__ca_utilities = None
@@ -794,7 +794,7 @@ class Boundaries:
             Comprehensive memory usage information:
 
             Per-dataset usage (bytes):
-            - 'us_states': Memory used by US states DataFrame (0 if not loaded)
+            - 'states': Memory used by US states DataFrame (0 if not loaded)
             - 'ca_counties': Memory used by CA counties DataFrame (0 if not loaded)
             - 'ca_watersheds': Memory used by CA watersheds DataFrame (0 if not loaded)
             - 'ca_utilities': Memory used by CA utilities DataFrame (0 if not loaded)
@@ -815,7 +815,7 @@ class Boundaries:
         >>>
         >>> print(f"Total memory: {usage['total_human']}")
         >>> print(f"Loaded datasets: {usage['loaded_datasets']}/6")
-        >>> print(f"Largest dataset: {max(usage['us_states'], usage['ca_counties'])}")
+        >>> print(f"Largest dataset: {max(usage['states'], usage['ca_counties'])}")
         >>>
         >>> # Check if specific dataset is loaded
         >>> if usage['ca_counties'] > 0:
@@ -840,7 +840,7 @@ class Boundaries:
         total_bytes = 0
 
         datasets = {
-            "us_states": self.__us_states,
+            "states": self.__states,
             "ca_counties": self.__ca_counties,
             "ca_watersheds": self.__ca_watersheds,
             "ca_utilities": self.__ca_utilities,

--- a/climakitae/new_core/processors/clip.py
+++ b/climakitae/new_core/processors/clip.py
@@ -1540,7 +1540,7 @@ class Clip(DataProcessor):
 
         # Map category names to the appropriate DataFrame properties
         category_map = {
-            "states": boundaries._us_states,
+            "states": boundaries._states,
             "CA counties": boundaries._ca_counties,
             "CA watersheds": boundaries._ca_watersheds,
             "CA Electric Load Serving Entities (IOU & POU)": boundaries._ca_utilities,

--- a/docs-mkdocs/climate-data-interface/concepts.md
+++ b/docs-mkdocs/climate-data-interface/concepts.md
@@ -95,7 +95,7 @@ ClimateData provides multiple boundary types for spatial subsetting:
 - `ca_census_tracts`: Census block groups and tracts  
 
 **Regional/National:**  
-- `us_states`: Western US states (11 states)
+- `states`: Western US states (11 states)
 
 **Infrastructure:**  
 - `ious_pous`: California investor-owned (IOU) and publicly-owned (POU) utilities  

--- a/docs-mkdocs/climate-data-interface/howto/clip.md
+++ b/docs-mkdocs/climate-data-interface/howto/clip.md
@@ -41,7 +41,7 @@ cd.show_boundary_options("ca_counties")  # All California counties
 | `ca_counties` | California counties (58 total) |
 | `ca_watersheds` | Hydrologic units (HUC8) |
 | `ca_census_tracts` | Census geography |
-| `us_states` | Western US states (11 states) |
+| `states` | Western US states (11 states) |
 | `ious_pous` | California investor-owned and public utilities |
 | `forecast_zones` | NOAA forecast zones |
 | `electric_balancing_areas` | Electric grid authorities |

--- a/tests/new_core/data_access/test_boundaries.py
+++ b/tests/new_core/data_access/test_boundaries.py
@@ -158,22 +158,22 @@ class TestBoundariesProperties:
                 }
             )
 
-    def test_us_states_lazy_loading(self, mock_boundaries):
+    def test_states_lazy_loading(self, mock_boundaries):
         """Test lazy loading of US states data."""
         # Initially not loaded - check private attribute
-        assert getattr(mock_boundaries, "_Boundaries__us_states", None) is None
+        assert getattr(mock_boundaries, "_Boundaries__states", None) is None
 
         # Access triggers loading
-        states = mock_boundaries._us_states
+        states = mock_boundaries._states
         assert states is not None
         assert isinstance(states, pd.DataFrame)
-        assert getattr(mock_boundaries, "_Boundaries__us_states", None) is not None
+        assert getattr(mock_boundaries, "_Boundaries__states", None) is not None
 
         # Subsequent access uses cached data
-        states2 = mock_boundaries._us_states
+        states2 = mock_boundaries._states
         assert states is states2
 
-    def test_us_states_loading_error(self):
+    def test_states_loading_error(self):
         """Test error handling during US states loading."""
         mock_catalog = Mock()
         catalog_entry = Mock()
@@ -187,7 +187,7 @@ class TestBoundariesProperties:
         boundaries = Boundaries(mock_catalog)
 
         with pytest.raises(RuntimeError) as excinfo:
-            _ = boundaries._us_states
+            _ = boundaries._states
 
         assert "Failed to load US states data" in str(excinfo.value)
 
@@ -252,8 +252,8 @@ class TestBoundariesProperties:
         """Test property setters work correctly."""
         test_df = pd.DataFrame({"test": [1, 2, 3]})
 
-        mock_boundaries._us_states = test_df
-        assert getattr(mock_boundaries, "_Boundaries__us_states", None) is test_df
+        mock_boundaries._states = test_df
+        assert getattr(mock_boundaries, "_Boundaries__states", None) is test_df
 
         mock_boundaries._ca_counties = test_df
         assert getattr(mock_boundaries, "_Boundaries__ca_counties", None) is test_df
@@ -262,14 +262,14 @@ class TestBoundariesProperties:
 class TestBoundariesDataProcessing:
     """Test data processing methods."""
 
-    def test_process_us_states(self):
+    def test_process_states(self):
         """Test US states data processing."""
         boundaries = Boundaries.__new__(Boundaries)
         test_df = pd.DataFrame(
             {"abbrevs": ["CA", "OR"], "name": ["California", "Oregon"]}
         )
 
-        result = boundaries._process_us_states(test_df)
+        result = boundaries._process_states(test_df)
 
         # Currently no processing, should return same DataFrame
         pd.testing.assert_frame_equal(result, test_df)
@@ -355,7 +355,7 @@ class TestBoundariesLookupMethods:
         # Mock data for different boundary types using setattr
         setattr(
             boundaries,
-            "_Boundaries__us_states",
+            "_Boundaries__states",
             pd.DataFrame(
                 {
                     "abbrevs": ["CA", "OR", "WA", "NV"],  # Some western states
@@ -411,27 +411,27 @@ class TestBoundariesLookupMethods:
 
         return boundaries
 
-    def test_get_us_states_caching(self, mock_boundaries_with_data):
+    def test_get_states_caching(self, mock_boundaries_with_data):
         """Test US states lookup dictionary caching."""
         boundaries = mock_boundaries_with_data
 
         # First call builds cache
-        result1 = boundaries._get_us_states()
-        assert "us_states" in boundaries._lookup_cache
+        result1 = boundaries._get_states()
+        assert "states" in boundaries._lookup_cache
         assert isinstance(result1, dict)
 
         # Second call uses cache
-        result2 = boundaries._get_us_states()
+        result2 = boundaries._get_states()
         assert result1 is result2
 
-    def test_build_us_states_lookup(self, mock_boundaries_with_data):
+    def test_build_states_lookup(self, mock_boundaries_with_data):
         """Test building US states lookup with western states ordering."""
         boundaries = mock_boundaries_with_data
 
         with patch("pandas.Categorical") as mock_categorical:
-            us_states_df = getattr(boundaries, "_Boundaries__us_states")
-            mock_categorical.return_value = us_states_df["abbrevs"]
-            result = boundaries._build_us_states_lookup()
+            states_df = getattr(boundaries, "_Boundaries__states")
+            mock_categorical.return_value = states_df["abbrevs"]
+            result = boundaries._build_states_lookup()
 
         assert isinstance(result, dict)
         # Should only include western states
@@ -517,7 +517,7 @@ class TestBoundariesPublicMethods:
         boundaries = Boundaries(mock_catalog)
 
         # Mock all getter methods to avoid complex setup
-        boundaries._get_us_states = Mock(return_value={"CA": 0, "OR": 1})
+        boundaries._get_states = Mock(return_value={"CA": 0, "OR": 1})
         boundaries._get_ca_counties = Mock(
             return_value={"Alameda": 0, "Los Angeles": 1}
         )
@@ -550,7 +550,7 @@ class TestBoundariesPublicMethods:
             assert isinstance(result[key], dict)
 
         # Check that getter methods were called
-        mock_boundaries_public._get_us_states.assert_called_once()
+        mock_boundaries_public._get_states.assert_called_once()
         mock_boundaries_public._get_ca_counties.assert_called_once()
         mock_boundaries_public._get_ca_watersheds.assert_called_once()
         mock_boundaries_public._get_ious_pous.assert_called_once()
@@ -573,7 +573,7 @@ class TestBoundariesPublicMethods:
     def test_preload_all(self, mock_boundaries_public):
         """Test preload_all forces loading of all data."""
         # Mock the actual property accesses to avoid complex nested patches
-        mock_boundaries_public._us_states = Mock()
+        mock_boundaries_public._states = Mock()
         mock_boundaries_public._ca_counties = Mock()
         mock_boundaries_public._ca_watersheds = Mock()
         mock_boundaries_public._ca_utilities = Mock()
@@ -584,14 +584,14 @@ class TestBoundariesPublicMethods:
         mock_boundaries_public.preload_all()
 
         # Verify all getter methods were called for cache building
-        mock_boundaries_public._get_us_states.assert_called()
+        mock_boundaries_public._get_states.assert_called()
         mock_boundaries_public._get_ca_counties.assert_called()
 
     def test_clear_cache(self, mock_boundaries_public):
         """Test clear_cache resets all cached data."""
         # Set some data first
         mock_boundaries_public._lookup_cache["test"] = {"key": "value"}
-        setattr(mock_boundaries_public, "_Boundaries__us_states", Mock())
+        setattr(mock_boundaries_public, "_Boundaries__states", Mock())
         setattr(mock_boundaries_public, "_Boundaries__ca_counties", Mock())
 
         mock_boundaries_public.clear_cache()
@@ -600,7 +600,7 @@ class TestBoundariesPublicMethods:
         assert mock_boundaries_public._lookup_cache == {}
         # Check key attributes are None after clearing
         private_attrs = [
-            "_Boundaries__us_states",
+            "_Boundaries__states",
             "_Boundaries__ca_counties",
             "_Boundaries__ca_watersheds",
             "_Boundaries__ca_utilities",
@@ -620,7 +620,7 @@ class TestBoundariesMemoryManagement:
         boundaries._lookup_cache = {}
 
         # Set all private DataFrames to None (not loaded) using setattr
-        setattr(boundaries, "_Boundaries__us_states", None)
+        setattr(boundaries, "_Boundaries__states", None)
         setattr(boundaries, "_Boundaries__ca_counties", None)
         setattr(boundaries, "_Boundaries__ca_watersheds", None)
         setattr(boundaries, "_Boundaries__ca_utilities", None)
@@ -631,7 +631,7 @@ class TestBoundariesMemoryManagement:
         result = boundaries.get_memory_usage()
 
         # All dataset usage should be 0
-        assert result["us_states"] == 0
+        assert result["states"] == 0
         assert result["ca_counties"] == 0
         assert result["ca_watersheds"] == 0
         assert result["ca_utilities"] == 0
@@ -659,7 +659,7 @@ class TestBoundariesMemoryManagement:
         mock_df2.memory_usage.return_value = mock_memory_usage2
 
         # Set some DataFrames as loaded, others as None using setattr
-        setattr(boundaries, "_Boundaries__us_states", mock_df1)
+        setattr(boundaries, "_Boundaries__states", mock_df1)
         setattr(boundaries, "_Boundaries__ca_counties", mock_df2)
         setattr(boundaries, "_Boundaries__ca_watersheds", None)
         setattr(boundaries, "_Boundaries__ca_utilities", None)
@@ -669,7 +669,7 @@ class TestBoundariesMemoryManagement:
 
         result = boundaries.get_memory_usage()
 
-        assert result["us_states"] == 1024
+        assert result["states"] == 1024
         assert result["ca_counties"] == 2048
         assert result["ca_watersheds"] == 0
         assert result["ca_census_tracts"] == 0
@@ -712,7 +712,7 @@ class TestBoundariesEdgeCases:
         boundaries = Boundaries.__new__(Boundaries)
         setattr(
             boundaries,
-            "_Boundaries__us_states",
+            "_Boundaries__states",
             pd.DataFrame(
                 {
                     "abbrevs": ["NY", "FL"],  # No western states
@@ -722,7 +722,7 @@ class TestBoundariesEdgeCases:
         )
         boundaries._lookup_cache = {}
 
-        result = boundaries._build_us_states_lookup()
+        result = boundaries._build_states_lookup()
         # Should return empty dict or handle gracefully
         assert isinstance(result, dict)
 

--- a/tests/new_core/data_access/test_boundaries.py
+++ b/tests/new_core/data_access/test_boundaries.py
@@ -819,7 +819,7 @@ class TestBoundariesAccessorFunctions:
             index=[70, 71],
         )
 
-        setattr(boundaries, "_Boundaries__us_states", states_df)
+        setattr(boundaries, "_Boundaries__states", states_df)
         setattr(boundaries, "_Boundaries__ca_counties", counties_df)
         setattr(boundaries, "_Boundaries__ca_watersheds", watersheds_df)
         setattr(boundaries, "_Boundaries__ca_utilities", utilities_df)
@@ -842,7 +842,7 @@ class TestBoundariesAccessorFunctions:
         ):
             with patch.object(
                 boundaries_with_data,
-                "_get_us_states",
+                "_get_states",
                 return_value={"CA": 10, "OR": 11, "NV": 12},
             ):
                 result = boundaries_with_data.get_states("CA")
@@ -852,7 +852,7 @@ class TestBoundariesAccessorFunctions:
     def test_get_states_invalid_name_raises(self, boundaries_with_data):
         with patch.object(
             boundaries_with_data,
-            "_get_us_states",
+            "_get_states",
             return_value={"CA": 10, "OR": 11},
         ):
             with pytest.raises(ValueError, match="State 'TX' not found"):

--- a/tests/new_core/processors/test_clip.py
+++ b/tests/new_core/processors/test_clip.py
@@ -1954,8 +1954,8 @@ class TestGetBoundaryGeometry:
             mock_df, geometry=[box(-124, 32, -114, 42)], crs="EPSG:4326"
         )
 
-        # Mock the boundaries._us_states attribute
-        self.mock_boundaries._us_states = mock_gdf
+        # Mock the boundaries._states attribute
+        self.mock_boundaries._states = mock_gdf
 
         # Call _extract_geometry_from_category
         result = self.clip._extract_geometry_from_category("states", 5)
@@ -1980,8 +1980,8 @@ class TestGetBoundaryGeometry:
             mock_df, geometry=[box(-124, 32, -114, 42)], crs="EPSG:4326"
         )
 
-        # Mock the boundaries._us_states attribute
-        self.mock_boundaries._us_states = mock_gdf
+        # Mock the boundaries._states attribute
+        self.mock_boundaries._states = mock_gdf
 
         # Try to extract with invalid index
         with pytest.raises(ValueError, match="Index 999 not found in states data"):

--- a/tests/new_core/test_user_interface.py
+++ b/tests/new_core/test_user_interface.py
@@ -1019,9 +1019,9 @@ class TestClimateDataShowOptionsExceptionHandling:
         self.climate_data._factory.get_boundaries.return_value = ["CA", "NV"]
 
         with patch("builtins.print"):
-            self.climate_data.show_boundary_options(boundary_type="us_states")
+            self.climate_data.show_boundary_options(boundary_type="states")
 
-        self.climate_data._factory.get_boundaries.assert_called_with("us_states")
+        self.climate_data._factory.get_boundaries.assert_called_with("states")
 
     def test_show_boundary_options_exception(self):
         """Test show_boundary_options handles exception gracefully."""


### PR DESCRIPTION
## Summary of changes and related issue
There were some discrepancies between `us_states` and `states` usage in Boundaries and clip in new_core. This PR updates all us_states to states.

## Link to corresponding Jira ticket(s)
https://eaglerockanalytics.atlassian.net/browse/AE-1546?atlOrigin=eyJpIjoiY2RlZjY4MDc0MDhlNDM0MWIyYzVhZDQ1OGYyMTI0ZWMiLCJwIjoiaiJ9

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed

## How to Test
Make sure all tests run and run the following snippet and make sure it works and that the last line doesn't work:

```python
import intake
from climakitae.core.paths import BOUNDARY_CATALOG_URL
from climakitae.new_core.data_access.boundaries import Boundaries

cat = intake.open_catalog(BOUNDARY_CATALOG_URL)
b = Boundaries(cat)

df = b._states                        # was _us_states
b._get_states()
assert "states" in b._lookup_cache
assert "states" in b.get_memory_usage()

b._get_us_states()               # this shouldn't work
```


## Documentation
- [x] Complex code includes comments explaining logic
- [x] NumPy-style docstrings added/updated for all new or modified public functions, classes, and modules

**Which of the following need updating? Check all that apply and complete them:**
- [x] **API reference** (`docs-mkdocs/api/`) — add or update the `.md` file for the affected module (e.g. `processors.md`, `tools.md`, `util.md`)
- [x] **Concept / architecture docs** (`docs-mkdocs/climate-data-interface/`) — update if you changed how a processor, validator, or data access component works
- [x] **How-to guides** (`docs-mkdocs/climate-data-interface/howto/`) — add a new guide if you introduced a non-obvious workflow

## Code Quality
- [x] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved

## Review Process
- [ ] PR review instructions provided:
  - [ ] Type of review requested (scientific/technical/debugging)
  - [ ] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
