### PR TITLE
Overriding units for 2 radiations variables

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -506,6 +506,10 @@ def _override_unit_defaults(da: xr.DataArray, var_id: str) -> xr.DataArray:
             # rsds units are "W m-2"
             # rename them to W/m2 to match the lookup catalog, and the units for WRF radiation variables
             da.attrs["units"] = "W/m2"
+        case "lwupb" | "lwupbc":
+            # lwupb and lwupbc units are "W m-2"
+            # rename them to W/m2 to match the lookup catalog, and the units for other WRF radiation variables
+            da.attrs["units"] = "W/m2"
     return da
 
 


### PR DESCRIPTION
## Summary of changes and related issue
Currently, `lwupb` and `lwupbc` are in units "W m-2", which is correct and fine, except that other variables with the same units are listed as "W/m2". This PR just creates consistency across different variables' units.

I was working with these different variables and this subtle difference caused a downstream bug that was very annoying to diagnose and fix.

## Link to corresponding Jira ticket(s)
https://eaglerockanalytics.atlassian.net/browse/AE-1421?atlOrigin=eyJpIjoiNmJjOWIyYzA3N2MwNDZiMmFiZmQzNDA5MjUyZDYwYTYiLCJwIjoiaiJ9

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed
- [x] Advanced Testing label added to PR if this PR makes major changes to the codebase 

## How to Test
```
import xarray as xr
from climakitae.core.data_load import _override_unit_defaults

for var_id in ["lwupb", "lwupbc"]:
    da = xr.DataArray()
    da.attrs = {"units": "W m-2"}  # native/raw WRF units
    result = _override_unit_defaults(da, var_id)
    print(var_id, "->", result.attrs["units"])
    assert result.attrs["units"] == "W/m2", f"{var_id} units not normalized!"

print("PASS: lwupb and lwupbc units normalized to W/m2")
```

and you can also run on both `main` and `bug/wrong-units`, and determine that the branches are printing out different variable descriptions

```
from climakitae.new_core.user_interface import ClimateData

cd = ClimateData()
for var_id in ["lwupb", "lwupbc"]:
    da = (
        cd.reset()
        .catalog("cadcat")
        .activity_id("WRF")
        .institution_id("UCLA")
        .source_id("EC-Earth3")
        .experiment_id("historical")
        .table_id("1hr")
        .grid_label("d01")
        .variable(var_id)
        .get()
    )
    var = list(da.data_vars)[0]
    print(var_id, da.data_vars[var].attrs.get("units"))
```


## Documentation
- [x] Complex code includes comments explaining logic
- [x] NumPy-style docstrings added/updated for all new or modified public functions, classes, and modules

## Code Quality
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [x] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [x] PR review instructions provided:
  - [ ] Type of review requested (scientific/technical/debugging)
  - [ ] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
