### PR TITLE
Fixing `show_boundary_options` functionality

### DIFF
--- a/climakitae/new_core/dataset_factory.py
+++ b/climakitae/new_core/dataset_factory.py
@@ -578,26 +578,32 @@ class DatasetFactory:
         """
         return DataCatalog()["stations"]["station"].unique().tolist()
 
-    def get_boundaries(self, boundary_type: str) -> List[str]:
+    def get_boundaries(self, boundary_type: str = UNSET) -> List[str]:
         """Get a list of available boundary datasets.
 
         Parameters
         ----------
-        boundary_type : str
-            The type of boundary datasets to retrieve. If the type is not found
-            in the cache, returns all available boundary types.
+        boundary_type : str, optional
+            The type of boundary datasets to retrieve. If not specified, or
+            if the type is not a recognized boundary category, returns all
+            available boundary category names.
 
         Returns
         -------
         List[str]
             List of available boundary datasets for the specified type, or
-            all available boundary types if the specified type is not found.
+            all available boundary category names if no type is specified or
+            the specified type is not found.
 
         """
-        if boundary_type not in DataCatalog().boundaries._lookup_cache:
-            return list(DataCatalog().boundaries._lookup_cache.keys())
-        else:
-            return list(DataCatalog().boundaries._lookup_cache[boundary_type].keys())
+        # `boundary_dict()` builds (and caches) the lookup for every boundary
+        # category, unlike `_lookup_cache`, which only contains categories
+        # that have already been accessed individually and is empty until
+        # then.
+        boundaries = DataCatalog().boundaries.boundary_dict()
+        if boundary_type in boundaries:
+            return list(boundaries[boundary_type].keys())
+        return list(boundaries.keys())
 
     def reset(self) -> None:
         """Reset the factory state, clearing all registered catalogs, validators, and processors.

--- a/climakitae/new_core/dataset_factory.py
+++ b/climakitae/new_core/dataset_factory.py
@@ -49,8 +49,8 @@ from climakitae.new_core.param_validation.param_validation_tools import (
     _get_closest_options,
 )
 from climakitae.new_core.processors.abc_data_processor import (
-    DataProcessor,
     _PROCESSOR_REGISTRY,
+    DataProcessor,
 )
 
 # Module logger
@@ -581,25 +581,25 @@ class DatasetFactory:
     def get_boundaries(self, boundary_type: str = UNSET) -> List[str]:
         """Get a list of available boundary datasets.
 
+        Call with no arguments to see all available boundary category names
+        (e.g. "states", "ca_counties"). Call again with one of those names as
+        `boundary_type` to see the individual boundaries within that category
+        (e.g. the list of county names).
+
         Parameters
         ----------
         boundary_type : str, optional
-            The type of boundary datasets to retrieve. If not specified, or
-            if the type is not a recognized boundary category, returns all
-            available boundary category names.
+            A boundary category name to look up, as returned by a previous
+            no-argument call. If omitted, or if it doesn't match a known
+            category, all available category names are returned instead.
 
         Returns
         -------
         List[str]
-            List of available boundary datasets for the specified type, or
-            all available boundary category names if no type is specified or
-            the specified type is not found.
+            The individual boundaries in `boundary_type`, or all available
+            boundary category names if no valid type was given.
 
         """
-        # `boundary_dict()` builds (and caches) the lookup for every boundary
-        # category, unlike `_lookup_cache`, which only contains categories
-        # that have already been accessed individually and is empty until
-        # then.
         boundaries = DataCatalog().boundaries.boundary_dict()
         if boundary_type in boundaries:
             return list(boundaries[boundary_type].keys())

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1366,7 +1366,7 @@ class ClimateData:
 
                 # Warn user of truncation if show_n was set
                 if limit < total_count:
-                    truncation_msg = f"Showing {limit} of {total_count} total boundaries, pass in `show_n`=None to see all boundaries"
+                    truncation_msg = f"Showing {limit} of {total_count} total boundaries, pass in `show_n`=None to see all boundaries."
                     logger.info("%s", truncation_msg)
 
                 for boundary in display_boundaries:

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1334,17 +1334,23 @@ class ClimateData:
             Maximum number of boundaries to display. If None (default), shows all boundaries.
 
         """
-        if boundary_type is UNSET:
-            msg = "Boundary Types (call again with boundary_type='...' to see options):"
-        else:
-            msg = "Available {} Boundaries:".format(
-                " ".join([x.capitalize() for x in boundary_type.split("_")])
-            )
-        logger.info(msg)
-        logger.info("%s", "-" * len(msg))
-
         try:
-            boundaries = self._factory.get_boundaries(boundary_type)
+            all_boundary_types = self._factory.get_boundaries()
+            is_valid_type = (
+                boundary_type is not UNSET and boundary_type in all_boundary_types
+            )
+
+            if is_valid_type:
+                msg = "Available {} Boundaries:".format(
+                    " ".join([x.capitalize() for x in boundary_type.split("_")])
+                )
+                boundaries = self._factory.get_boundaries(boundary_type)
+            else:
+                msg = "Boundary Types (call again with boundary_type='...' to see all options for a specific boundary):"
+                boundaries = all_boundary_types
+            logger.info(msg)
+            logger.info("%s", "-" * len(msg))
+
             if not boundaries:
                 logger.info("No boundaries available with current parameters")
 

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1348,10 +1348,7 @@ class ClimateData:
                 boundaries = self._factory.get_boundaries(boundary_type)
             else:
                 if boundary_type is not UNSET:
-                    msg = (
-                        f"Invalid boundary type: {boundary_type}, call again with "
-                        "boundary_type='' to see available boundary options"
-                    )
+                    msg = f"Invalid boundary type: {boundary_type}, see below for available `boundary_type` options."
                 else:
                     msg = "Boundary Types (call again with boundary_type='...' to see all options for a specific boundary):"
                 boundaries = all_boundary_types

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1321,7 +1321,7 @@ class ClimateData:
 
     @_with_info_verbosity
     def show_boundary_options(
-        self, boundary_type=UNSET, show_n: Optional[int] = None
+        self, boundary_type=UNSET, show_n: Optional[int] = 10
     ) -> None:
         """Display available boundaries for spatial queries.
 
@@ -1331,7 +1331,8 @@ class ClimateData:
             The type of boundary to display (e.g., "ca_counties", "ca_watersheds").
             If not specified, displays available boundary types.
         show_n : int, optional
-            Maximum number of boundaries to display. If None (default), shows all boundaries.
+            Maximum number of boundaries to display. Defaults to 10. Pass a
+            larger value, or None, to show all boundaries.
 
         """
         try:
@@ -1346,6 +1347,8 @@ class ClimateData:
                 )
                 boundaries = self._factory.get_boundaries(boundary_type)
             else:
+                if boundary_type is not UNSET:
+                    logger.info("Invalid boundary type: %s", boundary_type)
                 msg = "Boundary Types (call again with boundary_type='...' to see all options for a specific boundary):"
                 boundaries = all_boundary_types
             logger.info(msg)

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1366,9 +1366,7 @@ class ClimateData:
 
                 # Warn user of truncation if show_n was set
                 if limit < total_count:
-                    truncation_msg = (
-                        f"Showing {limit} of {total_count} total boundaries"
-                    )
+                    truncation_msg = f"Showing {limit} of {total_count} total boundaries, pass in `show_n`=None to see all boundaries"
                     logger.info("%s", truncation_msg)
 
                 for boundary in display_boundaries:

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1342,9 +1342,7 @@ class ClimateData:
             )
 
             if is_valid_type:
-                msg = "Available {} Boundaries:".format(
-                    " ".join([x.capitalize() for x in boundary_type.split("_")])
-                )
+                msg = f"Available {boundary_type} Boundaries:"
                 boundaries = self._factory.get_boundaries(boundary_type)
             else:
                 if boundary_type is not UNSET:

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1348,7 +1348,7 @@ class ClimateData:
                 boundaries = self._factory.get_boundaries(boundary_type)
             else:
                 if boundary_type is not UNSET:
-                    msg = f"Invalid boundary type: {boundary_type}, see below for available `boundary_type` options."
+                    msg = f"Invalid boundary type, see below for available `boundary_type` options."
                 else:
                     msg = "Boundary Types (call again with boundary_type=<boundary-type-below> to see all options for a specific boundary):"
                 boundaries = all_boundary_types

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1350,7 +1350,7 @@ class ClimateData:
                 if boundary_type is not UNSET:
                     msg = f"Invalid boundary type: {boundary_type}, see below for available `boundary_type` options."
                 else:
-                    msg = "Boundary Types (call again with boundary_type='...' to see all options for a specific boundary):"
+                    msg = "Boundary Types (call again with boundary_type=<boundary-type-below> to see all options for a specific boundary):"
                 boundaries = all_boundary_types
             logger.info(msg)
             logger.info("%s", "-" * len(msg))

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1350,7 +1350,7 @@ class ClimateData:
                 if boundary_type is not UNSET:
                     msg = f"Invalid boundary type, see below for available `boundary_type` options."
                 else:
-                    msg = "Boundary Types (call again with boundary_type=<boundary-type-below> to see all options for a specific boundary):"
+                    msg = "Boundary Types (call again with boundary_type=<insert-boundary-type-below> to see all options for a specific boundary):"
                 boundaries = all_boundary_types
             logger.info(msg)
             logger.info("%s", "-" * len(msg))

--- a/climakitae/new_core/user_interface.py
+++ b/climakitae/new_core/user_interface.py
@@ -1348,8 +1348,12 @@ class ClimateData:
                 boundaries = self._factory.get_boundaries(boundary_type)
             else:
                 if boundary_type is not UNSET:
-                    logger.info("Invalid boundary type: %s", boundary_type)
-                msg = "Boundary Types (call again with boundary_type='...' to see all options for a specific boundary):"
+                    msg = (
+                        f"Invalid boundary type: {boundary_type}, call again with "
+                        "boundary_type='' to see available boundary options"
+                    )
+                else:
+                    msg = "Boundary Types (call again with boundary_type='...' to see all options for a specific boundary):"
                 boundaries = all_boundary_types
             logger.info(msg)
             logger.info("%s", "-" * len(msg))

--- a/tests/new_core/test_dataset_factory.py
+++ b/tests/new_core/test_dataset_factory.py
@@ -608,7 +608,7 @@ class TestDatasetFactoryGetMethods:
         """Test get_boundaries method with specific boundary type."""
         mock_catalog_instance = MagicMock()
         mock_boundaries = MagicMock()
-        mock_boundaries._lookup_cache = {
+        mock_boundaries.boundary_dict.return_value = {
             "counties": {"LA": MagicMock(), "SF": MagicMock()},
             "states": {"CA": MagicMock()},
         }
@@ -624,7 +624,7 @@ class TestDatasetFactoryGetMethods:
         """Test get_boundaries method with unknown boundary type."""
         mock_catalog_instance = MagicMock()
         mock_boundaries = MagicMock()
-        mock_boundaries._lookup_cache = {
+        mock_boundaries.boundary_dict.return_value = {
             "counties": {"LA": MagicMock()},
             "states": {"CA": MagicMock()},
         }
@@ -634,6 +634,24 @@ class TestDatasetFactoryGetMethods:
         result = self.factory.get_boundaries("unknown_type")
 
         # Should return all available boundary types
+        assert result == ["counties", "states"]
+
+    @patch("climakitae.new_core.dataset_factory.DataCatalog")
+    def test_get_boundaries_no_type_returns_all(self, mock_catalog_class):
+        """Test get_boundaries with no arguments returns all boundary types,
+        even when no boundary category has been accessed yet (i.e. the
+        lazy-loaded lookup cache is still empty)."""
+        mock_catalog_instance = MagicMock()
+        mock_boundaries = MagicMock()
+        mock_boundaries.boundary_dict.return_value = {
+            "counties": {"LA": MagicMock()},
+            "states": {"CA": MagicMock()},
+        }
+        mock_catalog_instance.boundaries = mock_boundaries
+        mock_catalog_class.return_value = mock_catalog_instance
+
+        result = self.factory.get_boundaries()
+
         assert result == ["counties", "states"]
 
 

--- a/tests/new_core/test_user_interface.py
+++ b/tests/new_core/test_user_interface.py
@@ -1016,7 +1016,15 @@ class TestClimateDataShowOptionsExceptionHandling:
 
     def test_show_boundary_options_with_type(self):
         """Test show_boundary_options with specific boundary_type parameter."""
-        self.climate_data._factory.get_boundaries.return_value = ["CA", "NV"]
+
+        def get_boundaries_side_effect(boundary_type=UNSET):
+            if boundary_type == "states":
+                return ["CA", "NV"]
+            return ["states", "counties"]
+
+        self.climate_data._factory.get_boundaries.side_effect = (
+            get_boundaries_side_effect
+        )
 
         with patch("builtins.print"):
             self.climate_data.show_boundary_options(boundary_type="states")


### PR DESCRIPTION
## Summary of changes and related issue
Updating the `show_boundary_options` call to allow available boundary types to be listed when no boundary type is passed in, and provide more useful logging to help the user debug their `show_boundary_options` calls.

## Link to corresponding Jira ticket(s)
https://eaglerockanalytics.atlassian.net/browse/AE-1513?atlOrigin=eyJpIjoiYTZlMGEwNzgwYTRlNDRmYTgxZWI3ZDk1NzhhZWQyODMiLCJwIjoiaiJ9

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed
- [ ] Advanced Testing label added to PR if this PR makes major changes to the codebase 

## How to Test

Run this block to check that no boundary options works:
```
from climakitae.new_core.user_interface import ClimateData

cd = ClimateData(verbosity=-1)
cd.show_boundary_options()
```

and run this block to check that a chained set of queries before boundary options also works:

```
from climakitae.new_core.user_interface import ClimateData

cd = ClimateData(verbosity=-1)
cd.catalog("cadcat").activity_id("WRF").institution_id("UCLA").table_id("day").grid_label("d02").show_boundary_options(
    boundary_type="CA Electricity Demand Forecast Zones", show_n=10
)
```

## Documentation
- [x] Complex code includes comments explaining logic
- [x] NumPy-style docstrings added/updated for all new or modified public functions, classes, and modules

## Code Quality
- [x] Follows PEP8 naming and style conventions
- [x] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [x] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [x] PR review instructions provided:
  - [ ] Type of review requested (scientific/technical/debugging)
  - [ ] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
