### PR TITLE
Fix attributes for warming level and model filter processors

### DIFF
--- a/climakitae/new_core/processors/filter_unadjusted_models.py
+++ b/climakitae/new_core/processors/filter_unadjusted_models.py
@@ -105,9 +105,12 @@ class FilterUnAdjustedModels(DataProcessor):
                         f"\nClimateData().processes('{self.name}': 'no')\n"
                     )
                     logger.warning(msg)
-                    return self._remove_unadjusted_models(result)
+                    new_result = self._remove_unadjusted_models(result)
+                    self.update_context(context)
+                    return new_result
 
                 # If no unadjusted models are found, return the result as is
+                self.update_context(context)
                 return result
             case "no":
                 # check if there are any biased models in the dataset
@@ -118,7 +121,7 @@ class FilterUnAdjustedModels(DataProcessor):
                         "\nProceed with caution as these models may not be suitable for your analysis.\n"
                     )
                     logger.warning(msg)
-
+                self.update_context(context)
                 return result
             case _:
                 raise ValueError(

--- a/climakitae/new_core/processors/update_attributes.py
+++ b/climakitae/new_core/processors/update_attributes.py
@@ -94,6 +94,8 @@ class UpdateAttributes(DataProcessor):
         if self.name not in context:
             self.update_context(context)
 
+        context = self._context_cleanup(context)
+
         match result:
             case dict():
                 for key, item in result.items():
@@ -119,6 +121,24 @@ class UpdateAttributes(DataProcessor):
             len(context.get(_NEW_ATTRS_KEY, {})),
         )
         return result
+
+    @staticmethod
+    def _context_cleanup(context: Dict[str, Any]):
+        """Do any final clean up of the context before saving to attributes.
+
+        Parameters
+        ----------
+        context : dict[str, Any]
+            Parameters for processing the data.
+
+        Returns
+        -------
+        dict[str, Any]
+        """
+        # The warming level processor uses the name "warming_level_simple", and
+        # we don't want to save the warming_level parameters under "warming_level".
+        context[_NEW_ATTRS_KEY].pop("warming_level")
+        return context
 
     def update_context(self, context: Dict[str, Any]) -> None:
         """Update the context with information about the clipping operation, to be stored

--- a/climakitae/new_core/processors/update_attributes.py
+++ b/climakitae/new_core/processors/update_attributes.py
@@ -137,7 +137,7 @@ class UpdateAttributes(DataProcessor):
         """
         # The warming level processor uses the name "warming_level_simple", and
         # we don't want to save the warming_level parameters under "warming_level".
-        context[_NEW_ATTRS_KEY].pop("warming_level")
+        context[_NEW_ATTRS_KEY].pop("warming_level", None)
         return context
 
     def update_context(self, context: Dict[str, Any]) -> None:

--- a/climakitae/new_core/processors/update_attributes.py
+++ b/climakitae/new_core/processors/update_attributes.py
@@ -135,8 +135,9 @@ class UpdateAttributes(DataProcessor):
         -------
         dict[str, Any]
         """
-        # The warming level processor uses the name "warming_level_simple", and
-        # we don't want to save the warming_level parameters under "warming_level".
+        # The warming level processor uses the name "warming_level_simple",
+        # and we don't want to save the warming_level parameters that are
+        # under the "warming_level" key.
         context[_NEW_ATTRS_KEY].pop("warming_level", None)
         return context
 

--- a/climakitae/new_core/processors/update_attributes.py
+++ b/climakitae/new_core/processors/update_attributes.py
@@ -100,17 +100,25 @@ class UpdateAttributes(DataProcessor):
             case dict():
                 for key, item in result.items():
                     result[key].attrs = item.attrs | context[_NEW_ATTRS_KEY]
+                    result[key] = self._attr_type_cleanup(result[key])
                     for dim in item.dims:
                         if dim not in item.attrs:
                             item[dim].attrs = common_attrs.get(dim, {})
             case xr.Dataset() | xr.DataArray():
                 result.attrs = result.attrs | context[_NEW_ATTRS_KEY]
+                result = self._attr_type_cleanup(result)
                 for dim in result.dims:
                     result[dim].attrs.update(common_attrs.get(dim, {}))
-
-            case list() | tuple():
+            case list():
                 for i, item in enumerate(result):
                     result[i].attrs = item.attrs | context[_NEW_ATTRS_KEY]
+                    result[i] = self._attr_type_cleanup(result[i])
+            case tuple():
+                result = list(result)
+                for i, item in enumerate(result):
+                    result[i].attrs = item.attrs | context[_NEW_ATTRS_KEY]
+                    result[i] = self._attr_type_cleanup(result[i])
+                result = tuple(result)
             case _:
                 raise TypeError(
                     "Result must be an xarray Dataset, DataArray, or iterable of them."
@@ -140,6 +148,34 @@ class UpdateAttributes(DataProcessor):
         # under the "warming_level" key.
         context[_NEW_ATTRS_KEY].pop("warming_level", None)
         return context
+
+    @staticmethod
+    def _attr_type_cleanup(
+        result: Union[xr.DataArray, xr.Dataset],
+    ) -> Union[xr.DataArray, xr.Dataset]:
+        """Go through all the dataset-level attributes and check for any types that will
+        break export to netcdf. This will also check attributes that aren't part of the processor
+        context variable.
+
+        Parameters
+        ----------
+        result : Union[xr.DataArray,xr.Dataset]
+            Data with attributes to check
+
+        Returns
+        -------
+        Union(xr.DataArray,xr.Dataset)
+        """
+        for item in result.attrs:
+            match result.attrs[item]:
+                case bool() | dict():
+                    # Can't write file to netcdf with these data types in the attributes,
+                    # so convert it to a string
+                    result.attrs[item] = str(result.attrs[item])
+                case _:
+                    # Safe type, do nothing
+                    continue
+        return result
 
     def update_context(self, context: Dict[str, Any]) -> None:
         """Update the context with information about the clipping operation, to be stored

--- a/tests/new_core/processors/test_update_attributes.py
+++ b/tests/new_core/processors/test_update_attributes.py
@@ -119,6 +119,22 @@ class TestUpdateAttributesExecuteDataset:
         assert result["time"].attrs["standard_name"] == "time"
         assert result["time"].attrs["axis"] == "T"
 
+    def test_update_context_removes_warming_level_key(self):
+        """Test that execute removes unwanted warming_level attribute."""
+        context = {
+            _NEW_ATTRS_KEY: {
+                "test_attr": "test_value",
+                "warming_level": "warming_level_value",
+                "warming_level_simple": "simple_value",
+            }
+        }
+
+        result = self.processor.execute(self.sample_dataset, context)
+
+        # Make sure warming level key is dropped, warming_level_simple is saved
+        assert "warming_level" not in result.attrs
+        assert "warming_level_simple" in result.attrs
+
     def test_execute_dataset_calls_update_context_if_needed(self):
         """Test that execute calls update_context when processor name not in context."""
         # Context without the processor name, but with _NEW_ATTRS_KEY

--- a/tests/new_core/processors/test_update_attributes.py
+++ b/tests/new_core/processors/test_update_attributes.py
@@ -103,6 +103,19 @@ class TestUpdateAttributesExecuteDataset:
         assert result.attrs["original_attr"] == "original_value"
         assert "new_attr" in result.attrs
 
+    def test_execute_dataset_converts_bad_types(self):
+        """Test that execute converts bad types to strings."""
+        self.sample_dataset.attrs["dictionary"] = {"key": "value"}
+        self.sample_dataset.attrs["bool"] = True
+        context = {_NEW_ATTRS_KEY: {"new_attr": "new_value"}}
+
+        result = self.processor.execute(self.sample_dataset, context)
+
+        assert "dictionary" in result.attrs
+        assert result.attrs["dictionary"] == "{'key': 'value'}"
+        assert "bool" in result.attrs
+        assert result.attrs["bool"] == "True"
+
     def test_execute_dataset_updates_dim_attrs(self):
         """Test that execute updates dimension attributes with common_attrs."""
         context = {_NEW_ATTRS_KEY: {"test_attr": "test_value"}}


### PR DESCRIPTION
## Summary of changes and related issue

- Add a context cleanup function to the `update_attributes` processor. Currently only used to drop the `warming_level` key from the context. The issue with this key is that in contains a dictionary object that prevents the data from being written to file. It also duplicates information in the "warming_level_simple" key.
- Add an attribute type clean up to the `update_attributes` processor. This checks all of the attributes in the file and converts any bad types to strings. A bad type is a bool or dictionary, as those types of attributes cannot be written to netcdf.
- Make sure the `filter_unadjusted_models` processor updates the context

## Link to corresponding Jira ticket(s)
[AE-1607](https://eaglerockanalytics.atlassian.net/browse/AE-1607)

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed
- [x] Advanced Testing label added to PR if this PR makes major changes to the codebase 

## How to Test
Use new core to load warming level data. Check that the "warming_level" attribute is not attached. Check that the "filter_unadjusted_models" attribute contains the processor text, not just "yes" or "no".
```
import climakitae as ck
cd = ck.ClimateData(verbosity=-1)

t2 = (
    cd.catalog("cadcat")
    .activity_id("WRF")
    .institution_id("UCLA")
    .table_id("day")
    .grid_label("d03")
    .variable("t2")
    .processes(
        {
            "warming_level": {"warming_levels":[2.0]},
            "convert_units": "degC",
        }
    )
    .get()
)
t2.attrs # check warming_level, warming_level_simple, and filter_unadjusted_models
```

## Documentation
- [x] Complex code includes comments explaining logic
- [x] NumPy-style docstrings added/updated for all new or modified public functions, classes, and modules

## Code Quality
- [x] Follows PEP8 naming and style conventions
- [x] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [x] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [x] PR review instructions provided:
  - [x] Type of review requested (scientific/technical/debugging)
  - [x] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
