### PR TITLE
Add skip last to function call in shock xmy

### DIFF
--- a/climakitae/explore/extreme_meteorological_year.py
+++ b/climakitae/explore/extreme_meteorological_year.py
@@ -994,7 +994,7 @@ class shock_XMY:
             "Finding top months (greatest deviation from climatological CDF median)."
         )
         self.top_months = generate_candidate_months(
-            self.cdf_monthly, self.cdf_climatology, self.extreme
+            self.cdf_monthly, self.cdf_climatology, self.extreme, self._skip_last
         )
 
     def show_xmy_data_to_export(self, simulation: str):

--- a/tests/extreme_meteorological_year/test_shock_xmy.py
+++ b/tests/extreme_meteorological_year/test_shock_xmy.py
@@ -835,7 +835,7 @@ class TestXMYClass:
             xmy.set_top_months()
             mock_clim.assert_called_once()
             mock_monthly.assert_called_once()
-            mock_generate.assert_called_once()
+            mock_generate.assert_called_with(UNSET, UNSET, "hot", False)
 
     def test_run_xmy_analysis_adds_scenario_column(self):
         """Check that run_xmy_analysis adds 'scenario' column in time mode."""


### PR DESCRIPTION
## Summary of changes and related issue
The skip_last variable needs to be passed to generate_candidate_months() in the shock XMY code. Otherwise export fails when the 2029 year is selected as the December match.

## Link to corresponding Jira ticket(s)


## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed
- [ ] Advanced Testing label added to PR if this PR makes major changes to the codebase 

## How to Test
Check that hot shock XMY generates for Bakersfield Meadows Field (KBFL) at GWL 1.2
Check that XMYs generate for known failing cases.

## Documentation
- [ ] Complex code includes comments explaining logic
- [ ] NumPy-style docstrings added/updated for all new or modified public functions, classes, and modules

**Which of the following need updating? Check all that apply and complete them:**
- [ ] **API reference** (`docs-mkdocs/api/`) — add or update the `.md` file for the affected module (e.g. `processors.md`, `tools.md`, `util.md`)
- [ ] **Concept / architecture docs** (`docs-mkdocs/climate-data-interface/`) — update if you changed how a processor, validator, or data access component works
- [ ] **How-to guides** (`docs-mkdocs/climate-data-interface/howto/`) — add a new guide if you introduced a non-obvious workflow
- [ ] **Getting started / migration guides** (`docs-mkdocs/getting-started.md`, `docs-mkdocs/migration/`) — update if you changed the public API or added a new entry point
- [ ] **Notebook gallery** (`docs-mkdocs/notebook-gallery.md`) — add a link if this PR introduces a new example notebook
- [ ] **`MAINTAINERS.md`** — update release notes, secrets inventory, or CI table if you changed workflows or infrastructure

## Code Quality
- [ ] Follows PEP8 naming and style conventions
- [ ] Helper functions prefixed with underscore `_`
- [ ] Linting completed and all issues resolved
- [ ] Does not replicate existing functionality
- [ ] Aligns with general coding standards of existing codebase
- [ ] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [ ] PR review instructions provided:
  - [ ] Type of review requested (scientific/technical/debugging)
  - [ ] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
