### PR TITLE
docs: update methods page link to appropriate links on new website 

### DIFF
--- a/docs-mkdocs/climate-data-interface/index.md
+++ b/docs-mkdocs/climate-data-interface/index.md
@@ -43,6 +43,6 @@ The ClimateData interface has reached feature parity with the legacy `climakitae
 
 ## See also
 
-- [Cal-Adapt Analytics Engine — Methods](https://analytics.cal-adapt.org/analytics/methods)
+- [Cal-Adapt Analytics Engine — Methods](https://analytics.cal-adapt.org/data-tools/access-methods.html)
 - [Cal-Adapt Analytics Engine — Glossary](https://analytics.cal-adapt.org/guidance/glossary)
 - [Notebook Gallery](../notebook-gallery.md)

--- a/docs-mkdocs/climate-data-interface/index.md
+++ b/docs-mkdocs/climate-data-interface/index.md
@@ -43,6 +43,6 @@ The ClimateData interface has reached feature parity with the legacy `climakitae
 
 ## See also
 
-- [Cal-Adapt Analytics Engine — Methods](https://analytics.cal-adapt.org/data-tools/access-methods.html)
+- [Cal-Adapt Analytics Engine — Python Tools](https://analytics.cal-adapt.org/data-tools/python-tools.html)
 - [Cal-Adapt Analytics Engine — Glossary](https://analytics.cal-adapt.org/guidance/glossary)
 - [Notebook Gallery](../notebook-gallery.md)

--- a/docs-mkdocs/index.md
+++ b/docs-mkdocs/index.md
@@ -110,7 +110,7 @@ reference:
 - [About climate projections and models](https://analytics.cal-adapt.org/guidance/about_climate_projections_and_models) — GCMs, downscaling, SSPs, global warming levels
 - [Glossary](https://analytics.cal-adapt.org/guidance/glossary) — bias correction, GWL, localization, dynamical vs. statistical downscaling
 - [Datasets summary](https://analytics.cal-adapt.org/data/about) — WRF + LOCA2 model lists, resolution and time coverage
-- [Methods](https://analytics.cal-adapt.org/analytics/methods) — algorithmic details (e.g. the warming-level fetching procedure)
+- [Methods](https://analytics.cal-adapt.org/data-tools/access-methods.html) — algorithmic details (e.g. the warming-level fetching procedure)
 - [Example applications](https://cal-adapt.github.io/climakitae/dev/notebook-gallery/) — featured notebooks
 
 ---

--- a/docs-mkdocs/index.md
+++ b/docs-mkdocs/index.md
@@ -107,10 +107,10 @@ ClimakitAE is the Python toolkit underneath the
 website hosts the broader scientific context that complements this API
 reference:
 
-- [About climate projections and models](https://analytics.cal-adapt.org/guidance/about_climate_projections_and_models) — GCMs, downscaling, SSPs, global warming levels
-- [Glossary](https://analytics.cal-adapt.org/guidance/glossary) — bias correction, GWL, localization, dynamical vs. statistical downscaling
-- [Datasets summary](https://analytics.cal-adapt.org/data/about) — WRF + LOCA2 model lists, resolution and time coverage
-- [Methods](https://analytics.cal-adapt.org/data-tools/access-methods.html) — algorithmic details (e.g. the warming-level fetching procedure)
+- [About climate projections and models](https://analytics.cal-adapt.org/scientific-guidance/general-climate-guidance/about-climate-projections.html) — GCMs, downscaling, SSPs, global warming levels
+- [Glossary](https://analytics.cal-adapt.org/glossary/) — bias correction, GWL, localization, dynamical vs. statistical downscaling
+- [Datasets summary](https://analytics.cal-adapt.org/data-tools/data-documentation/climate-model-sims.html) — WRF + LOCA2 model lists, resolution and time coverage
+- [Warming Levels Methods](https://analytics.cal-adapt.org/scientific-guidance/global-warming-levels.html) — algorithmic details on the warming levels methods
 - [Example applications](https://cal-adapt.github.io/climakitae/dev/notebook-gallery/) — featured notebooks
 
 ---

--- a/docs-mkdocs/migration/legacy-to-climate-data.md
+++ b/docs-mkdocs/migration/legacy-to-climate-data.md
@@ -232,7 +232,7 @@ params.variable = "Minimum air temperature at 2m"
 data = get_data(params)
 ```
 
-The Cal-Adapt [Methods page](https://analytics.cal-adapt.org/data-tools/access-methods.html)
+The Cal-Adapt [Warming Levels Methods page](https://analytics.cal-adapt.org/scientific-guidance/global-warming-levels.html)
 describes the warming-level fetching algorithm in more detail (and is itself
 still written against the legacy API).
 

--- a/docs-mkdocs/migration/legacy-to-climate-data.md
+++ b/docs-mkdocs/migration/legacy-to-climate-data.md
@@ -232,7 +232,7 @@ params.variable = "Minimum air temperature at 2m"
 data = get_data(params)
 ```
 
-The Cal-Adapt [Methods page](https://analytics.cal-adapt.org/analytics/methods)
+The Cal-Adapt [Methods page](https://analytics.cal-adapt.org/data-tools/access-methods.html)
 describes the warming-level fetching algorithm in more detail (and is itself
 still written against the legacy API).
 

--- a/docs-mkdocs/notebook-gallery.md
+++ b/docs-mkdocs/notebook-gallery.md
@@ -226,7 +226,7 @@ Access pre-installed notebooks on the [Cal-Adapt Analytics Engine JupyterHub](ht
 - **cae-notebooks Repository**: [https://github.com/cal-adapt/cae-notebooks](https://github.com/cal-adapt/cae-notebooks)  
 - **Cal-Adapt Analytics Engine**: [https://analytics.cal-adapt.org/](https://analytics.cal-adapt.org/)  
   - [Example Notebooks](https://cal-adapt.github.io/climakitae/dev/notebook-gallery/)  
-  - [Methods](https://analytics.cal-adapt.org/analytics/methods)  
+  - [Methods](https://analytics.cal-adapt.org/data-tools/access-methods.html)  
   - [Glossary](https://analytics.cal-adapt.org/guidance/glossary)  
 - **Cal-Adapt Overview**: [https://cal-adapt.org/](https://cal-adapt.org/)  
 

--- a/docs-mkdocs/notebook-gallery.md
+++ b/docs-mkdocs/notebook-gallery.md
@@ -226,7 +226,7 @@ Access pre-installed notebooks on the [Cal-Adapt Analytics Engine JupyterHub](ht
 - **cae-notebooks Repository**: [https://github.com/cal-adapt/cae-notebooks](https://github.com/cal-adapt/cae-notebooks)  
 - **Cal-Adapt Analytics Engine**: [https://analytics.cal-adapt.org/](https://analytics.cal-adapt.org/)  
   - [Example Notebooks](https://cal-adapt.github.io/climakitae/dev/notebook-gallery/)  
-  - [Methods](https://analytics.cal-adapt.org/data-tools/access-methods.html)  
+  - [Analytics Engine Python Tools page](https://analytics.cal-adapt.org/data-tools/python-tools.html)  
   - [Glossary](https://analytics.cal-adapt.org/guidance/glossary)  
 - **Cal-Adapt Overview**: [https://cal-adapt.org/](https://cal-adapt.org/)  
 


### PR DESCRIPTION
## Summary of changes and related issue
The URL for the top-level section “Methods” at https://analytics.cal-adapt.org/analytics/methods/  no longer exists. I pointed this URL to the most appropriate pages on the new website instead. 

## Link to corresponding Jira ticket(s)
https://eaglerockanalytics.atlassian.net/browse/AE-1681

## How to Test
Ensure the link checker is passing! Type of review: debugging

## Review Process
- [x] PR review instructions provided:
  - [x] Type of review requested (scientific/technical/debugging)
  - [x] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
