### PR TITLE
Reapply "Remove wind rotation in get_data"

### DIFF
--- a/climakitae/core/data_load.py
+++ b/climakitae/core/data_load.py
@@ -828,116 +828,6 @@ def _check_valid_unit_selection(selections: "DataParameters") -> None:
     return None
 
 
-def _get_Uearth(selections: "DataParameters") -> xr.DataArray:
-    """Rotate winds from WRF grid --> spherical earth
-    We need to rotate U and V to Earth-relative coordinates in order to properly derive wind direction and generally make comparisons against observations.
-    Reference: https://www-k12.atmos.washington.edu/~ovens/wrfwinds.html
-    Ideally, this should NOT be done programmatically... we should update the zarrs and remove this code
-
-    Parameters
-    ----------
-    selections : DataParameters
-
-    Returns
-    -------
-    da : xr.DataArray
-
-    Notes
-    -----
-    This function will not return area average even if selections.area_average == "Yes". Area averaging
-    must be applied separately to the final wind data.
-    """
-    # Don't do any area averaging here
-    area_average = selections.area_average
-    selections.area_average = "No"
-
-    # Load v10 data
-    selections.variable_id = ["v10"]
-    v10_da = _get_data_one_var(selections)
-
-    # Load u10 data
-    selections.variable_id = ["u10"]
-    u10_da = _get_data_one_var(selections)
-
-    # Read in the appropriate file depending on the data resolution
-    # This file contains sinalpha and cosalpha for the WRF grid
-    gridlabel = resolution_to_gridlabel(selections.resolution)
-    wrf_angles_ds = xr.open_zarr(
-        "s3://cadcat/tmp/era/wrf/wrf_angles_{}.zarr/".format(gridlabel),
-        storage_options={"anon": True},
-    )
-    wrf_angles_ds = _spatial_subset(
-        wrf_angles_ds, selections
-    )  # Clip to spatial subset of data
-    sinalpha = wrf_angles_ds.SINALPHA
-    cosalpha = wrf_angles_ds.COSALPHA
-
-    # Compute Uearth
-    Uearth = u10_da * cosalpha - v10_da * sinalpha
-
-    # Add variable name
-    Uearth.name = selections.variable
-
-    # Reset selections to original value
-    selections.area_average = area_average
-    return Uearth
-
-
-def _get_Vearth(selections: "DataParameters") -> xr.DataArray:
-    """Rotate winds from WRF grid --> spherical earth
-    We need to rotate U and V to Earth-relative coordinates in order to properly derive wind direction and generally make comparisons against observations.
-    Reference: https://www-k12.atmos.washington.edu/~ovens/wrfwinds.html
-    Ideally, this should NOT be done programmatically... we should update the zarrs and remove this code
-
-    Parameters
-    ----------
-    selections : DataParameters
-
-    Returns
-    -------
-    da : xr.DataArray
-
-    Notes
-    -----
-    This function will not return area average even if selections.area_average == "Yes". Area averaging
-    must be applied separately to the final wind data.
-    """
-    # Don't area average here
-    area_average = selections.area_average
-    selections.area_average = "No"
-
-    # Load u10 data
-    selections.variable_id = ["u10"]
-    u10_da = _get_data_one_var(selections)
-
-    # Load v10 data
-    selections.variable_id = ["v10"]
-    v10_da = _get_data_one_var(selections)
-
-    # Read in the appropriate file depending on the data resolution
-    # This file contains sinalpha and cosalpha for the WRF grid
-    gridlabel = resolution_to_gridlabel(selections.resolution)
-    wrf_angles_ds = xr.open_zarr(
-        "s3://cadcat/tmp/era/wrf/wrf_angles_{}.zarr/".format(gridlabel),
-        storage_options={"anon": True},
-    )
-    wrf_angles_ds = _spatial_subset(
-        wrf_angles_ds, selections
-    )  # Clip to spatial subset of data
-    sinalpha = wrf_angles_ds.SINALPHA
-    cosalpha = wrf_angles_ds.COSALPHA
-
-    # Compute Uearth
-    Vearth = v10_da * cosalpha + u10_da * sinalpha
-
-    # Add variable name
-    Vearth.name = selections.variable
-
-    # Reset selections to original value
-    selections.area_average = area_average
-    return Vearth
-
-
 def _get_wind_speed_derived(selections: "DataParameters") -> xr.DataArray:
     """Get input data and derive wind speed for hourly data
 
@@ -955,12 +845,12 @@ def _get_wind_speed_derived(selections: "DataParameters") -> xr.DataArray:
     selections.units = (
         "m s-1"  # Need to set units to required units for compute_wind_mag
     )
-    u10_da = _get_Uearth(selections)
+    u10_da = _get_data_one_var(selections)
 
     # Load v10 data
     selections.variable_id = ["v10"]
     selections.units = "m s-1"
-    v10_da = _get_Vearth(selections)
+    v10_da = _get_data_one_var(selections)
 
     # Derive the variable
     da = compute_wind_mag(u10=u10_da, v10=v10_da)  # m/s
@@ -989,12 +879,12 @@ def _get_wind_dir_derived(selections: "DataParameters") -> xr.DataArray:
     selections.units = (
         "m s-1"  # Need to set units to required units for compute_wind_mag
     )
-    u10_da = _get_Uearth(selections)
+    u10_da = _get_data_one_var(selections)
 
     # Load v10 data
     selections.variable_id = ["v10"]
     selections.units = "m s-1"
-    v10_da = _get_Vearth(selections)
+    v10_da = _get_data_one_var(selections)
 
     # Derive the variable
     da = compute_wind_dir(u10=u10_da, v10=v10_da)
@@ -1412,20 +1302,6 @@ def read_catalog_from_select(selections: "DataParameters") -> xr.DataArray:
         # The dev team hasn't looked into this yet -- opportunity for future improvement
         data_attrs = data_attrs | {"institution": "Multiple"}
         da.attrs = data_attrs
-
-    # Rotate wind vectors
-    elif (
-        any(x in selections.variable_id for x in ["u10", "v10"])
-        and selections.downscaling_method == "Dynamical"
-    ):
-        if "u10" in selections.variable_id:
-            da = _get_Uearth(selections)
-        elif "v10" in selections.variable_id:
-            da = _get_Vearth(selections)
-        # Do area averaging here, if selected, as _get_Uearth and
-        # _get_Vearth return data without area averaging.
-        if selections.area_average == "Yes":
-            da = area_average(da)
 
     # Any other variable... i.e. not an index, derived var, or a WRF wind vector
     else:

--- a/climakitae/tools/derived_variables.py
+++ b/climakitae/tools/derived_variables.py
@@ -615,9 +615,6 @@ def _get_rotated_geostrophic_wind(
 ) -> tuple[xr.DataArray]:
     """Convert WRF-relative winds to Earth-relative winds.
 
-    This is the code from data_load._get_Uearth and
-    data_load._get_Vearth but adapted to take u and v as parameters.
-
     Parameters
     ----------
     u : xr.DataArray

--- a/tests/data_load/test_data_load.py
+++ b/tests/data_load/test_data_load.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 import shapely
 import xarray as xr
-from pytest import approx
 
 from climakitae.core.data_interface import DataParameters
 from climakitae.core.data_load import (
@@ -18,8 +17,6 @@ from climakitae.core.data_load import (
     _get_hourly_specific_humidity,
     _get_monthly_daily_dewpoint,
     _get_noaa_heat_index,
-    _get_Uearth,
-    _get_Vearth,
     _get_wind_dir_derived,
     _get_wind_speed_derived,
     _override_unit_defaults,
@@ -36,44 +33,6 @@ def mock_data() -> xr.DataArray:
     da.attrs = {"units": ""}
     da.name = "data"
     return da
-
-
-def mock_wind_var() -> xr.DataArray:
-    # Simplify testing wind speed functions
-    # with single gridpoint dataset
-    lon = -123.521255
-    lat = 9.475632
-    da = xr.DataArray(
-        data=np.array([[10]]),
-        dims=["y", "x"],
-        coords={
-            "lon": (("y", "x"), np.array([[lon]])),
-            "lat": (("y", "x"), np.array([[lat]])),
-        },
-    )
-    da.name = "wind speed"
-    da.attrs = {"units": "m/s"}
-    return da
-
-
-def mock_wrf_angles_ds() -> xr.DataArray:
-    # Simplify testing wind speed functions with
-    # single gridpoint dataset
-    lon = -123.521255
-    lat = 9.475632
-    sinalpha = 0.6197577
-    cosalpha = 0.78479314
-    ds = xr.Dataset(
-        data_vars={
-            "COSALPHA": ((lat, lon), np.array([[cosalpha]])),
-            "SINALPHA": ((lat, lon), np.array([[sinalpha]])),
-        },
-        coords={
-            "lon": (("y", "x"), np.array([[lon]])),
-            "lat": (("y", "x"), np.array([[lat]])),
-        },
-    )
-    return ds
 
 
 @pytest.fixture
@@ -278,59 +237,19 @@ class TestDataLoadDerived:
         assert isinstance(result, xr.core.dataarray.DataArray)
         assert result.name == "Fosberg Fire Weather Index"
 
-    @patch("xarray.backends.zarr.open_zarr", return_value=mock_wrf_angles_ds())
-    @patch("climakitae.core.data_load._get_data_one_var", return_value=mock_wind_var())
-    @patch(
-        "climakitae.core.data_load._spatial_subset", return_value=mock_wrf_angles_ds()
-    )
-    def test__get_Uearth(
-        self, mock_open_zarr, mock_get_data_one_var, mock_spatial_subset, selections
-    ):
-        # Function is heavily patched so we aren't downloading any data
-        # Just stepping through the function with small canned datasets
-        result = _get_Uearth(selections)
-        assert isinstance(result, xr.core.dataarray.DataArray)
-        assert result.name == selections.variable
-        assert approx(result.data.item(), rel=1e-7) == 1.6503544
-
-    @patch("xarray.backends.zarr.open_zarr", return_value=mock_wrf_angles_ds())
-    @patch("climakitae.core.data_load._get_data_one_var", return_value=mock_wind_var())
-    @patch(
-        "climakitae.core.data_load._spatial_subset", return_value=mock_wrf_angles_ds()
-    )
-    def test__get_Vearth(
-        self, mock_open_zarr, mock_get_data_one_var, mock_spatial_subset, selections
-    ):
-        # Function is heavily patched so we aren't downloading any data
-        # Just stepping through the function with small canned datasets
-        result = _get_Vearth(selections)
-        assert isinstance(result, xr.core.dataarray.DataArray)
-        assert result.name == selections.variable
-        assert approx(result.data.item(), rel=1e-7) == 14.0455084
-
-    @patch("climakitae.core.data_load._get_Uearth", return_value=mock_wind_var())
-    @patch("climakitae.core.data_load._get_Vearth", return_value=mock_wind_var())
-    def test__get_wind_speed_derived(
-        self, mock_get_Uearth, mock_get_Vearth, selections
-    ):
-        # Function is heavily patched so we aren't downloading any data
-        # Just stepping through the function with small canned datasets
+    @patch("climakitae.core.data_load._get_data_one_var", return_value=mock_data())
+    def test__get_wind_speed_derived(self, mock_get_data_one_var, selections):
+        # Check that wind speed variable is returned with data.
         result = _get_wind_speed_derived(selections)
-        expected = np.sqrt(np.square(1.6503544) + np.square(14.0455084))
         assert isinstance(result, xr.core.dataarray.DataArray)
-        assert approx(result.data.item(), rel=1e-7) == expected
         assert result.name == "wind_speed_derived"
         assert result.attrs["units"] == "m s-1"
 
-    @patch("climakitae.core.data_load._get_Uearth", return_value=mock_wind_var())
-    @patch("climakitae.core.data_load._get_Vearth", return_value=mock_wind_var())
-    def test__get_wind_dir_derived(self, mock_get_Uearth, mock_get_Vearth, selections):
-        # Function is heavily patched so we aren't downloading any data
-        # Just stepping through the function with small canned datasets
+    @patch("climakitae.core.data_load._get_data_one_var", return_value=mock_data())
+    def test__get_wind_dir_derived(self, mock_get_data_one_var, selections):
+        # Check that wind direction variable is returned with data.
         result = _get_wind_dir_derived(selections)
-        expected = 225
         assert isinstance(result, xr.core.dataarray.DataArray)
-        assert approx(result.data.item(), rel=1e-7) == expected
         assert result.name == "wind_direction_derived"
         assert result.attrs["units"] == "degrees"
 


### PR DESCRIPTION
This reverts commit 3cf4275bce3fa02714035cf4db8dbee25d4c4e26.

## Summary of changes and related issue
Replicate changes in https://github.com/cal-adapt/climakitae/pull/767

## Link to corresponding Jira ticket(s)
[AE-1450](https://eaglerockanalytics.atlassian.net/browse/AE-1450)

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Appropriate manual testing completed
- [x] Advanced Testing label added to PR if this PR makes major changes to the codebase 

## How to Test
The linked PR has a link to a comparison doc that shows more results for this code. You can also manually run:
```
from climakitae.core.data_interface import DataParameters, get_data

data = get_data(
    downscaling_method = "Dynamical",         
    resolution = "3 km",
    timescale = "hourly",
    # Affected variables are:
    # "Wind direction at 10m"
    # "Wind speed at 10m"
    # "West-East component of Wind at 10m"
    # "North-South component of Wind at 10m"
    variable = "Wind direction at 10m", 
    scenario_historical = ["Historical Climate"],
    area_subset = "CA counties",
    cached_area = ["Los Angeles County"]    
)
```

## Documentation
- [x] Complex code includes comments explaining logic
- [x] NumPy-style docstrings added/updated for all new or modified public functions, classes, and modules

**Which of the following need updating? Check all that apply and complete them:**
- [ ] **API reference** (`docs-mkdocs/api/`) — add or update the `.md` file for the affected module (e.g. `processors.md`, `tools.md`, `util.md`)
- [ ] **Concept / architecture docs** (`docs-mkdocs/climate-data-interface/`) — update if you changed how a processor, validator, or data access component works
- [ ] **How-to guides** (`docs-mkdocs/climate-data-interface/howto/`) — add a new guide if you introduced a non-obvious workflow
- [ ] **Getting started / migration guides** (`docs-mkdocs/getting-started.md`, `docs-mkdocs/migration/`) — update if you changed the public API or added a new entry point
- [ ] **Notebook gallery** (`docs-mkdocs/notebook-gallery.md`) — add a link if this PR introduces a new example notebook
- [ ] **`MAINTAINERS.md`** — update release notes, secrets inventory, or CI table if you changed workflows or infrastructure

## Code Quality
- [x] Follows PEP8 naming and style conventions
- [x] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [x] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [ ] PR review instructions provided:
  - [ ] Type of review requested (scientific/technical/debugging)
  - [ ] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
