### PR TITLE
Fix x/y coordinate swap in single-point clip NaN-search fallback

### DIFF
--- a/climakitae/new_core/processors/clip.py
+++ b/climakitae/new_core/processors/clip.py
@@ -761,11 +761,13 @@ class Clip(DataProcessor):
                 coord2_target = lon
             else:
                 # For x/y dims transform lat/lon -> x/y coordinates
+                # dim1_name is "x", dim2_name is "y" here, so keep transform
+                # output (x, y) in that same order.
                 try:
                     fwd_transformer = pyproj.Transformer.from_crs(
                         "epsg:4326", dataset.rio.crs, always_xy=True
                     )
-                    coord2_target, coord1_target = fwd_transformer.transform(lon, lat)
+                    coord1_target, coord2_target = fwd_transformer.transform(lon, lat)
                 except Exception:
                     # Fall back to lat/lon if transform fails
                     coord1_target = lat

--- a/tests/new_core/processors/test_clip.py
+++ b/tests/new_core/processors/test_clip.py
@@ -2322,6 +2322,75 @@ class TestClipDataToPointNaNSearchExpansion:
         assert not np.isnan(result["temp"].isel(time=0).values)
 
 
+class TestClipDataToPointXYTransformOrder:
+    """Regression test for x/y transform ordering bug in the NaN-search fallback.
+
+    The nearest-cell fallback in `_clip_data_to_point` used to swap the
+    projected x/y values returned by `pyproj.Transformer.transform` before
+    matching them against the "x" and "y" dimension coordinates. On grids
+    where the x and y coordinate ranges don't overlap (e.g. real projected
+    WRF Lambert Conformal grids), this caused the search to look in the
+    wrong part of the domain, sometimes finding a "valid" cell hundreds of
+    kilometers from the requested point.
+    """
+
+    def setup_method(self):
+        """Build a small projected (non-lat/lon) grid with non-overlapping x/y ranges."""
+        self.crs = pyproj.CRS.from_proj4(
+            "+proj=lcc +lat_1=30 +lat_2=60 +lat_0=38 +lon_0=-120 "
+            "+x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs"
+        )
+        self.transformer = pyproj.Transformer.from_crs(
+            "epsg:4326", self.crs, always_xy=True
+        )
+
+        # Non-overlapping x/y ranges: a coordinate swap lands far outside
+        # the domain instead of coincidentally landing on a valid cell.
+        self.x_vals = np.linspace(0, 100_000, 11)
+        self.y_vals = np.linspace(200_000, 300_000, 11)
+
+        self.target_lat = 39.0
+        self.target_lon = -119.5
+        target_x, target_y = self.transformer.transform(
+            self.target_lon, self.target_lat
+        )
+        self.true_x_idx = int(np.abs(self.x_vals - target_x).argmin())
+        self.true_y_idx = int(np.abs(self.y_vals - target_y).argmin())
+
+        # All-NaN grid except the one cell nearest the true projected target.
+        data = np.full((1, 11, 11), np.nan)
+        data[0, self.true_y_idx, self.true_x_idx] = 25.0
+        self.dataset = xr.Dataset(
+            {"temp": (["time", "y", "x"], data)},
+            coords={
+                "time": pd.date_range("2020-01-01", periods=1),
+                "y": self.y_vals,
+                "x": self.x_vals,
+            },
+        )
+        self.dataset = self.dataset.rio.write_crs(self.crs)
+
+        # A NaN cell far from the true index to force the fallback path.
+        nan_x_idx = 0 if self.true_x_idx != 0 else 1
+        nan_y_idx = 0 if self.true_y_idx != 0 else 1
+        self.nan_cell = self.dataset.isel(x=nan_x_idx, y=nan_y_idx)
+
+    def test_neighbor_search_finds_cell_near_true_projected_target(self):
+        """Fallback search must use (x, y) in the correct order, not swapped."""
+        with patch(
+            "climakitae.new_core.processors.clip.get_closest_gridcell",
+            return_value=self.nan_cell,
+        ):
+            result = Clip._clip_data_to_point(
+                self.dataset, self.target_lat, self.target_lon
+            )
+
+        # With the coordinate swap bug, the 3x3 search centers on a location
+        # derived from mismatched x/y ranges, misses the only valid cell,
+        # and returns None. The fix must find it.
+        assert result is not None
+
+
 class TestGetMultiBoundaryGeometry:
     """Test class for _get_multi_boundary_geometry method.
 


### PR DESCRIPTION


## Summary of changes and related issue
Single-point `clip` (e.g. `.processes({"clip": (lat, lon)})`) could occasionally return a gridcell hundreds of kilometers from the requested point (e.g. clipping to KVNY near Los Angeles sometimes returned a cell in Arizona), logged as `Closest gridcell contains NaN values, searching nearby indices...`.

Root cause: in `Clip._clip_data_to_point`'s NaN-neighbor-search fallback (`climakitae/new_core/processors/clip.py`), the projected `(x, y)` coordinates returned by `pyproj.Transformer.transform` were assigned to the wrong variables:

```python
# dim1_name = "x", dim2_name = "y" at this point
coord2_target, coord1_target = fwd_transformer.transform(lon, lat)  # returns (x, y), but swapped on assignment
```

This swap silently searches the wrong axis whenever `x` and `y` span different, non-overlapping ranges (true of real projected WRF Lambert Conformal grids), landing on an arbitrary cell instead of erroring. It only manifested when the *primary* closest-gridcell lookup (in `climakitae/util/utils.py`, unaffected by this bug) found NaN and fell back to the 3x3 neighbor search — e.g. near a coastal/terrain edge, matching KVNY's location.

Fix: corrected the assignment to `coord1_target, coord2_target = fwd_transformer.transform(lon, lat)` so `x`/`y` line up with `dim1_name`/`dim2_name`.

## Link to corresponding Jira ticket(s)
issue-806

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed
- [ ] Advanced Testing label added to PR if this PR makes major changes to the codebase

Added `tests/new_core/processors/test_clip.py::TestClipDataToPointXYTransformOrder`, using a synthetic projected grid with non-overlapping x/y ranges so a coordinate swap can't coincidentally still succeed. Verified it fails on the pre-fix code (`result is None`) and passes with the fix. Full `tests/new_core/processors/test_clip.py` suite (148 tests) passes.

Also manually reproduced and verified the fix in a standalone notebook against a synthetic WRF-like Lambert Conformal grid, comparing the buggy vs. fixed index computation side by side and confirming the real `Clip._clip_data_to_point` now finds the correct cell.

## How to Test
```python
uv run python -m pytest tests/new_core/processors/test_clip.py -q
```
[clip_point_bug_investigation.ipynb](https://github.com/user-attachments/files/31531589/clip_point_bug_investigation.ipynb)

Or manually, build a projected dataset with non-overlapping `x`/`y` ranges, force the NaN-search fallback (mock `get_closest_gridcell` to return a NaN cell), and confirm `Clip._clip_data_to_point` finds the gridcell nearest the true projected target rather than one clamped to a domain edge.

## Documentation
- [x] Complex code includes comments explaining logic
- [ ] NumPy-style docstrings added/updated for all new or modified public functions, classes, and modules

**Which of the following need updating? Check all that apply and complete them:**
- [ ] **API reference** (`docs-mkdocs/api/`)
- [ ] **Concept / architecture docs** (`docs-mkdocs/climate-data-interface/`)
- [ ] **How-to guides** (`docs-mkdocs/climate-data-interface/howto/`)
- [ ] **Getting started / migration guides** (`docs-mkdocs/getting-started.md`, `docs-mkdocs/migration/`)
- [ ] **Notebook gallery** (`docs-mkdocs/notebook-gallery.md`)
- [ ] **`MAINTAINERS.md`**

No public API or docs changes — this is an internal bugfix to an existing private helper method.

## Code Quality
- [x] Follows PEP8 naming and style conventions
- [x] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [x] Code generalized for multiple uses (unless too complex/time-intensive)

## Review Process
- [ ] PR review instructions provided:
  - [ ] Type of review requested (scientific/technical/debugging)
  - [ ] Level of review detail needed

## Administrative Reminders
  - Jira ticket moved to "Review" when PR created
  - Jira ticket will be moved to "Done" when complete
  - PR branch will be deleted after merge
