### PR TITLE
adding documentation for missing functions

### DIFF
--- a/docs-mkdocs/api/explore.md
+++ b/docs-mkdocs/api/explore.md
@@ -41,6 +41,20 @@ The `climakitae.explore` module provides user-friendly classes and functions for
       docstring_style: numpy
       show_source: true
 
+## Extreme Meteorological Year
+
+::: climakitae.explore.extreme_meteorological_year
+    options:
+      docstring_style: numpy
+      show_source: true
+
+## Standard Year Profile
+
+::: climakitae.explore.standard_year_profile
+    options:
+      docstring_style: numpy
+      show_source: true
+
 ## Climate Vulnerability Assessment
 
 ::: climakitae.explore.vulnerability.CavaParams

--- a/docs-mkdocs/api/param-validation-detailed.md
+++ b/docs-mkdocs/api/param-validation-detailed.md
@@ -84,6 +84,16 @@ All validators inherit from the abstract base class:
       docstring_style: numpy
       show_source: true
 
+::: climakitae.new_core.param_validation.derived_variable_param_validator
+    options:
+      docstring_style: numpy
+      show_source: true
+
+::: climakitae.new_core.param_validation.update_attributes_param_validator
+    options:
+      docstring_style: numpy
+      show_source: true
+
 ## Alternative Catalog Validators
 
 ::: climakitae.new_core.param_validation.renewables_param_validator

--- a/docs-mkdocs/notebook-gallery.md
+++ b/docs-mkdocs/notebook-gallery.md
@@ -196,8 +196,8 @@ source .venv/bin/activate
 uv pip install -r requirements.txt
 
 # Or install with conda
-conda create -n cae -f conda-linux-64.lock
-conda activate cae
+conda env create -f environment.yml
+conda activate notebook
 
 # Start Jupyter
 jupyter lab


### PR DESCRIPTION
## Summary of changes and related issue
Adding documentation coverage for 
- `climakitae.explore.extreme_meteorological_year`
- `climakitae.explore.standard_year_profile`
- `climakitae.new_core.param_validation.derived_variable_param_validator`
- `climakitae.new_core.param_validation.update_attributes_param_validator`


**Which of the following need updating? Check all that apply and complete them:**
- [x] **API reference** (`docs-mkdocs/api/`) — add or update the `.md` file for the affected module (e.g. `processors.md`, `tools.md`, `util.md`)
- [ ] **Concept / architecture docs** (`docs-mkdocs/climate-data-interface/`) — update if you changed how a processor, validator, or data access component works
- [ ] **How-to guides** (`docs-mkdocs/climate-data-interface/howto/`) — add a new guide if you introduced a non-obvious workflow
- [ ] **Getting started / migration guides** (`docs-mkdocs/getting-started.md`, `docs-mkdocs/migration/`) — update if you changed the public API or added a new entry point
- [x] **Notebook gallery** (`docs-mkdocs/notebook-gallery.md`) — add a link if this PR introduces a new example notebook
- [ ] **`MAINTAINERS.md`** — update release notes, secrets inventory, or CI table if you changed workflows or infrastructure

## Code Quality
- [x] Follows PEP8 naming and style conventions
- [x] Helper functions prefixed with underscore `_`
- [x] Linting completed and all issues resolved
- [x] Does not replicate existing functionality
- [x] Aligns with general coding standards of existing codebase
- [x] Code generalized for multiple uses (unless too complex/time-intensive)