### PR TITLE
fixing warming level file for non-standard warming levels

### DIFF
--- a/climakitae/new_core/processors/warming_level.py
+++ b/climakitae/new_core/processors/warming_level.py
@@ -14,7 +14,7 @@ import pandas as pd
 import xarray as xr
 
 from climakitae.core.constants import _NEW_ATTRS_KEY, UNSET
-from climakitae.core.paths import GWL_1850_1900_FILE, GWL_1981_2010_TIMEIDX_FILE
+from climakitae.core.paths import GWL_1850_1900_FILE, GWL_1850_1900_TIMEIDX_FILE
 from climakitae.new_core.data_access.data_access import DataCatalog
 from climakitae.new_core.processors.abc_data_processor import (
     DataProcessor,
@@ -95,7 +95,7 @@ class WarmingLevel(DataProcessor):
             GWL_1850_1900_FILE, index_col=[0, 1, 2], parse_dates=True
         )
         self.warming_level_times_idx = read_csv_file(
-            GWL_1981_2010_TIMEIDX_FILE, index_col="time", parse_dates=True
+            GWL_1850_1900_TIMEIDX_FILE, index_col="time", parse_dates=True
         )
         self.catalog = None
         self.value = {
@@ -147,7 +147,7 @@ class WarmingLevel(DataProcessor):
         if self.warming_level_times is None:
             try:
                 self.warming_level_times = read_csv_file(
-                    GWL_1981_2010_TIMEIDX_FILE, index_col="time", parse_dates=True
+                    GWL_1850_1900_TIMEIDX_FILE, index_col="time", parse_dates=True
                 )
             except (FileNotFoundError, pd.errors.ParserError) as e:
                 logger.error(

--- a/docs-mkdocs/climate-data-interface/processors/warming_level.md
+++ b/docs-mkdocs/climate-data-interface/processors/warming_level.md
@@ -8,7 +8,7 @@ Subset climate data by global warming level thresholds instead of calendar dates
 
 ### Execution Flow
 
-1. **Initialization** (lines 73–111): Validate dict, store `warming_levels`, `warming_level_window` (default 15), `warming_level_months` (default `UNSET`), `add_dummy_time` (default `False`). **Eagerly loads two CSV lookup tables** (`gwl_1850-1900ref.csv` at L91 and `gwl_1981-2010ref.csv` at L94). Sets `self.name = "warming_level_simple"` (note: this is the metadata key written to context).
+1. **Initialization** (lines 73–111): Validate dict, store `warming_levels`, `warming_level_window` (default 15), `warming_level_months` (default `UNSET`), `add_dummy_time` (default `False`). **Eagerly loads two CSV lookup tables** (`gwl_1850-1900ref.csv` at L91 and `gwl_1850-1900ref_timeidx.csv` at L94). Sets `self.name = "warming_level_simple"` (note: this is the metadata key written to context).
 2. **Defensive Reload** (lines 120–129): If `warming_level_times` is somehow `None`, attempt to reload from CSV; raise `RuntimeError` on failure.
 3. **Member ID Reformatting** (line 132 → method at line 343): `reformat_member_ids` splits any `member_id` dimension into separate dict keys with `key.member_id` suffix.
 4. **Time Domain Extension** (line 135): `extend_time_domain` (helper) splices historical onto SSP scenarios so the data range covers 1980/1850 – 2100.
@@ -165,7 +165,7 @@ data = (ClimateData()
 GWL timing is pre-computed from climate model simulations and stored in CSV files shipped with `climakitae`:
 
 - **`gwl_1850-1900ref.csv`**: Year/timestamp when each `(activity_id, member_id, source_id)` triple reaches each integer warming level (1850–1900 reference period). Used when the requested WL exists as a column in the table.
-- **`gwl_1981-2010ref.csv`** (loaded as `warming_level_times_idx`): Time-indexed table of running warming-level estimates per simulation column. Used as a fallback when the requested WL is not a column in `gwl_1850-1900ref.csv` — the processor finds the **first** time the simulation column crosses the requested level.
+- **`gwl_1850-1900ref_timeidx.csv`** (loaded as `warming_level_times_idx`): Time-indexed table of running warming-level estimates per simulation column, also referenced to the 1850–1900 baseline. Used as a fallback when the requested WL is not a column in `gwl_1850-1900ref.csv` — the processor finds the **first** time the simulation column crosses the requested level.
 
 Lookup keys parse the dict key as `key.split(".")` and use `(key_list[2], member_id, key_list[3])`, which corresponds to `(activity_id, member_id, source_id)` in catalog terms. Missing entries log a warning and append `np.nan` for that warming level (the slice is then skipped).
 


### PR DESCRIPTION
## Summary of changes and related issue

- `ClimateData` warming level processor uses the wrong file
- `get_data()` does not use the wrong file
- In March of 2026, the processor was briefly updated to use the correct file, but in May of 2026 that change was reverted probably due to a malformed merge/rebase

### What does this affect:
ONLY affects non-standard gwl values
NON-AFFECTED warming levels include:
0.8, 1.0, 1.2, 1.5, 2.0, 2.5, 3.0, 4.0 °C

### GWL Status:
TMY, shock_XMY, and persistence_XMY all use the "buggy" warming level code 
HOWEVER, climate profiles were only produced for 1.2, 1.5, 2.0, and 2.5 so the hosted profiles ARE NOT affected by this bug. 
That said if a user entered a non-standard profile they would have problems. 
Standard Year profiles still use get_data as the data fetch tool so it's not affected at all. 

## Link to corresponding Jira ticket(s)
https://cal-adaptdp.slack.com/archives/C021EAYF0MC/p1788355626531949

## Testing
- [x] Unit tests written for new/modified code (goal: 80% coverage)
  - All public functions have unit tests
  - Functions that must produce specific values have unit tests
- [x] Verified that notebooks utilizing affected functions still work
- [x] Appropriate manual testing completed
- [x] Advanced Testing label added to PR if this PR makes major changes to the codebase 

## How to Test
Confirm that 2.5 and 2.52 produce almost identical results. Confirm 2.5 and 2.6 produce very similar results.

## Documentation
**Which of the following need updating? Check all that apply and complete them:**
- [x] **API reference** (`docs-mkdocs/api/`) — add or update the `.md` file for the affected module (e.g. `processors.md`, `tools.md`, `util.md`)

## Review Process
- [x] PR review instructions provided:
  - [x] Type of review requested (scientific/technical/debugging)
  - [x] Level of review detail needed